### PR TITLE
fix(navigation): Update coursebuilder view on hash change

### DIFF
--- a/src/pages/shared/institutions.html
+++ b/src/pages/shared/institutions.html
@@ -1,206 +1,291 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>For Institutions - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/shared/teachers.html" class="link link--nav">For Teachers</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/students.html" class="link link--nav">For Students</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/institutions.html" class="link link--nav link--active">For Institutions</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/pricing.html" class="link link--nav">Pricing</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <a href="/src/pages/shared/signin.html" class="button button--primary">Sign In</a>
-            </div>
-        </nav>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a href="/src/pages/shared/teachers.html" class="link link--nav"
+                >For Teachers</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/shared/students.html" class="link link--nav"
+                >For Students</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/shared/institutions.html"
+                class="link link--nav link--active"
+                >For Institutions</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/shared/pricing.html" class="link link--nav"
+                >Pricing</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <a href="/src/pages/shared/signin.html" class="button button--primary"
+            >Sign In</a
+          >
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <section class="hero">
-            <div class="hero__content">
-                <h1 class="heading heading--primary">Scale Education Excellence with Neptino</h1>
-                <p class="text text--lead">Empower your institution with comprehensive learning management tools, advanced analytics, and seamless administration capabilities.</p>
-                <div class="hero__actions">
-                    <a href="/src/pages/shared/signup.html" class="button button--primary">Request Demo</a>
-                    <a href="/src/pages/shared/pricing.html" class="button button--secondary">View Enterprise Plans</a>
-                </div>
-            </div>
-        </section>
+      <section class="hero">
+        <div class="hero__content">
+          <h1 class="heading heading--primary">
+            Scale Education Excellence with Neptino
+          </h1>
+          <p class="text text--lead">
+            Empower your institution with comprehensive learning management
+            tools, advanced analytics, and seamless administration capabilities.
+          </p>
+          <div class="hero__actions">
+            <a
+              href="/src/pages/shared/signup.html"
+              class="button button--primary"
+              >Request Demo</a
+            >
+            <a
+              href="/src/pages/shared/pricing.html"
+              class="button button--secondary"
+              >View Enterprise Plans</a
+            >
+          </div>
+        </div>
+      </section>
 
-        <section class="features">
-            <h2 class="heading heading--secondary">Enterprise-Grade Educational Solutions</h2>
-            <div class="features-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Centralized Administration</h3>
-                        <p class="text">Manage users, courses, and resources from a single dashboard. Streamline enrollment, permissions, and institutional workflows.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Advanced Analytics</h3>
-                        <p class="text">Gain insights into institutional performance with comprehensive reporting, learning analytics, and outcome tracking across all programs.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Integration Capabilities</h3>
-                        <p class="text">Seamlessly integrate with existing SIS, LTI tools, and third-party applications. Support for SAML, OAuth, and custom APIs.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Compliance & Security</h3>
-                        <p class="text">Meet FERPA, GDPR, and accessibility standards with enterprise-grade security, data protection, and audit trails.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Scalable Infrastructure</h3>
-                        <p class="text">Support thousands of concurrent users with 99.9% uptime guarantee, global CDN, and auto-scaling architecture.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">24/7 Support</h3>
-                        <p class="text">Dedicated account management, priority support, training resources, and implementation assistance for smooth adoption.</p>
-                    </div>
-                </div>
+      <section class="features">
+        <h2 class="heading heading--secondary">
+          Enterprise-Grade Educational Solutions
+        </h2>
+        <div class="features-grid">
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">
+                Centralized Administration
+              </h3>
+              <p class="text">
+                Manage users, courses, and resources from a single dashboard.
+                Streamline enrollment, permissions, and institutional workflows.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="testimonial">
-            <div class="card">
-                <div class="card__content">
-                    <blockquote class="text text--quote">
-                        "Neptino has revolutionized how we deliver education across our campuses. The analytics give us unprecedented insight into student success, and the platform scales beautifully with our growing enrollment."
-                    </blockquote>
-                    <cite class="text text--cite">— Dr. Maria Rodriguez, VP of Academic Technology, State University System</cite>
-                </div>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Advanced Analytics</h3>
+              <p class="text">
+                Gain insights into institutional performance with comprehensive
+                reporting, learning analytics, and outcome tracking across all
+                programs.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="institution-stats">
-            <h2 class="heading heading--secondary">Trusted by Leading Institutions</h2>
-            <div class="stats-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">500+</div>
-                        <div class="stat-label">Educational Institutions</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">2M+</div>
-                        <div class="stat-label">Students Served</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">99.9%</div>
-                        <div class="stat-label">Uptime Guarantee</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">40%</div>
-                        <div class="stat-label">Cost Reduction</div>
-                    </div>
-                </div>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">
+                Integration Capabilities
+              </h3>
+              <p class="text">
+                Seamlessly integrate with existing SIS, LTI tools, and
+                third-party applications. Support for SAML, OAuth, and custom
+                APIs.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="enterprise-features">
-            <h2 class="heading heading--secondary">Enterprise Features</h2>
-            <div class="features-list">
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">White-Label Solutions</h3>
-                        <p class="text">Customize the platform with your institution's branding, colors, and domain for a seamless branded experience.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Multi-Tenant Architecture</h3>
-                        <p class="text">Manage multiple campuses, departments, or programs with isolated environments and centralized oversight.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Custom Development</h3>
-                        <p class="text">Work with our team to develop custom features, integrations, and workflows tailored to your specific needs.</p>
-                    </div>
-                </div>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Compliance & Security</h3>
+              <p class="text">
+                Meet FERPA, GDPR, and accessibility standards with
+                enterprise-grade security, data protection, and audit trails.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="cta">
-            <h2 class="heading heading--secondary">Ready to Transform Your Institution?</h2>
-            <p class="text text--lead">Join hundreds of institutions already delivering exceptional educational experiences with Neptino.</p>
-            <div class="cta__actions">
-                <a href="/src/pages/shared/signup.html" class="button button--primary">Schedule Demo</a>
-                <a href="#" class="button button--secondary">Download Brochure</a>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Scalable Infrastructure</h3>
+              <p class="text">
+                Support thousands of concurrent users with 99.9% uptime
+                guarantee, global CDN, and auto-scaling architecture.
+              </p>
             </div>
-        </section>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">24/7 Support</h3>
+              <p class="text">
+                Dedicated account management, priority support, training
+                resources, and implementation assistance for smooth adoption.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="testimonial">
+        <div class="card">
+          <div class="card__content">
+            <blockquote class="text text--quote">
+              "Neptino has revolutionized how we deliver education across our
+              campuses. The analytics give us unprecedented insight into student
+              success, and the platform scales beautifully with our growing
+              enrollment."
+            </blockquote>
+            <cite class="text text--cite"
+              >— Dr. Maria Rodriguez, VP of Academic Technology, State
+              University System</cite
+            >
+          </div>
+        </div>
+      </section>
+
+      <section class="institution-stats">
+        <h2 class="heading heading--secondary">
+          Trusted by Leading Institutions
+        </h2>
+        <div class="stats-grid">
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">500+</div>
+              <div class="stat-label">Educational Institutions</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">2M+</div>
+              <div class="stat-label">Students Served</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">99.9%</div>
+              <div class="stat-label">Uptime Guarantee</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">40%</div>
+              <div class="stat-label">Cost Reduction</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="enterprise-features">
+        <h2 class="heading heading--secondary">Enterprise Features</h2>
+        <div class="features-list">
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">White-Label Solutions</h3>
+              <p class="text">
+                Customize the platform with your institution's branding, colors,
+                and domain for a seamless branded experience.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">
+                Multi-Tenant Architecture
+              </h3>
+              <p class="text">
+                Manage multiple campuses, departments, or programs with isolated
+                environments and centralized oversight.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Custom Development</h3>
+              <p class="text">
+                Work with our team to develop custom features, integrations, and
+                workflows tailored to your specific needs.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta">
+        <h2 class="heading heading--secondary">
+          Ready to Transform Your Institution?
+        </h2>
+        <p class="text text--lead">
+          Join hundreds of institutions already delivering exceptional
+          educational experiences with Neptino.
+        </p>
+        <div class="cta__actions">
+          <a href="/src/pages/shared/signup.html" class="button button--primary"
+            >Schedule Demo</a
+          >
+          <a href="#" class="button button--secondary">Download Brochure</a>
+        </div>
+      </section>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/shared/pricing.html
+++ b/src/pages/shared/pricing.html
@@ -1,254 +1,325 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pricing - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/shared/teachers.html" class="link link--nav">For Teachers</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/students.html" class="link link--nav">For Students</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/institutions.html" class="link link--nav">For Institutions</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/pricing.html" class="link link--nav link--active">Pricing</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <a href="/src/pages/shared/signin.html" class="button button--primary">Sign In</a>
-            </div>
-        </nav>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a href="/src/pages/shared/teachers.html" class="link link--nav"
+                >For Teachers</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/shared/students.html" class="link link--nav"
+                >For Students</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/shared/institutions.html"
+                class="link link--nav"
+                >For Institutions</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/shared/pricing.html"
+                class="link link--nav link--active"
+                >Pricing</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <a href="/src/pages/shared/signin.html" class="button button--primary"
+            >Sign In</a
+          >
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <section class="pricing-hero">
-            <h1 class="heading heading--primary">Choose Your Perfect Plan</h1>
-            <p class="text text--lead">From individual educators to large institutions, we have a plan that fits your needs and budget.</p>
-        </section>
+      <section class="pricing-hero">
+        <h1 class="heading heading--primary">Choose Your Perfect Plan</h1>
+        <p class="text text--lead">
+          From individual educators to large institutions, we have a plan that
+          fits your needs and budget.
+        </p>
+      </section>
 
-        <section class="pricing-tiers">
-            <div class="pricing-grid">
-                <!-- Free Plan -->
-                <div class="card pricing-card">
-                    <div class="card__header">
-                        <h3 class="heading heading--tertiary">Free</h3>
-                        <div class="price">
-                            <span class="price__amount">$0</span>
-                            <span class="price__period">forever</span>
-                        </div>
-                        <p class="text">Perfect for getting started</p>
-                    </div>
-                    <div class="card__content">
-                        <ul class="features-list">
-                            <li class="feature">✓ 3 courses maximum</li>
-                            <li class="feature">✓ Up to 50 students per course</li>
-                            <li class="feature">✓ Basic course builder</li>
-                            <li class="feature">✓ Community support</li>
-                            <li class="feature">✓ Mobile access</li>
-                            <li class="feature">× Advanced analytics</li>
-                            <li class="feature">× Integration tools</li>
-                        </ul>
-                    </div>
-                    <div class="card__footer">
-                        <a href="/src/pages/shared/signup.html" class="button button--secondary button--full">Get Started Free</a>
-                    </div>
-                </div>
-
-                <!-- Teacher Plan -->
-                <div class="card pricing-card">
-                    <div class="card__header">
-                        <h3 class="heading heading--tertiary">Teacher</h3>
-                        <div class="price">
-                            <span class="price__amount">$9</span>
-                            <span class="price__period">/month</span>
-                        </div>
-                        <p class="text">For individual educators</p>
-                    </div>
-                    <div class="card__content">
-                        <ul class="features-list">
-                            <li class="feature">✓ Unlimited courses</li>
-                            <li class="feature">✓ Up to 200 students per course</li>
-                            <li class="feature">✓ Advanced course builder</li>
-                            <li class="feature">✓ Progress tracking</li>
-                            <li class="feature">✓ Assignment grading</li>
-                            <li class="feature">✓ Email support</li>
-                            <li class="feature">✓ Mobile app access</li>
-                        </ul>
-                    </div>
-                    <div class="card__footer">
-                        <a href="/src/pages/shared/signup.html" class="button button--primary button--full">Start Free Trial</a>
-                    </div>
-                </div>
-
-                <!-- Professional Plan -->
-                <div class="card pricing-card pricing-card--featured">
-                    <div class="card__header">
-                        <div class="badge">Most Popular</div>
-                        <h3 class="heading heading--tertiary">Professional</h3>
-                        <div class="price">
-                            <span class="price__amount">$29</span>
-                            <span class="price__period">/month</span>
-                        </div>
-                        <p class="text">For serious educators</p>
-                    </div>
-                    <div class="card__content">
-                        <ul class="features-list">
-                            <li class="feature">✓ Everything in Teacher</li>
-                            <li class="feature">✓ Unlimited students</li>
-                            <li class="feature">✓ Advanced analytics</li>
-                            <li class="feature">✓ Custom branding</li>
-                            <li class="feature">✓ Integration tools</li>
-                            <li class="feature">✓ Priority support</li>
-                            <li class="feature">✓ White-label options</li>
-                        </ul>
-                    </div>
-                    <div class="card__footer">
-                        <a href="/src/pages/shared/signup.html" class="button button--primary button--full">Start Free Trial</a>
-                    </div>
-                </div>
-
-                <!-- School Plan -->
-                <div class="card pricing-card">
-                    <div class="card__header">
-                        <h3 class="heading heading--tertiary">School</h3>
-                        <div class="price">
-                            <span class="price__amount">$99</span>
-                            <span class="price__period">/month</span>
-                        </div>
-                        <p class="text">For schools and departments</p>
-                    </div>
-                    <div class="card__content">
-                        <ul class="features-list">
-                            <li class="feature">✓ Everything in Professional</li>
-                            <li class="feature">✓ Up to 50 teachers</li>
-                            <li class="feature">✓ Admin dashboard</li>
-                            <li class="feature">✓ Bulk user management</li>
-                            <li class="feature">✓ Advanced reporting</li>
-                            <li class="feature">✓ SSO integration</li>
-                            <li class="feature">✓ Dedicated support</li>
-                        </ul>
-                    </div>
-                    <div class="card__footer">
-                        <a href="/src/pages/shared/signup.html" class="button button--primary button--full">Request Demo</a>
-                    </div>
-                </div>
-
-                <!-- Enterprise Plan -->
-                <div class="card pricing-card">
-                    <div class="card__header">
-                        <h3 class="heading heading--tertiary">Enterprise</h3>
-                        <div class="price">
-                            <span class="price__amount">Custom</span>
-                            <span class="price__period">pricing</span>
-                        </div>
-                        <p class="text">For large institutions</p>
-                    </div>
-                    <div class="card__content">
-                        <ul class="features-list">
-                            <li class="feature">✓ Everything in School</li>
-                            <li class="feature">✓ Unlimited teachers</li>
-                            <li class="feature">✓ Multi-tenant setup</li>
-                            <li class="feature">✓ Custom integrations</li>
-                            <li class="feature">✓ On-premise deployment</li>
-                            <li class="feature">✓ 24/7 phone support</li>
-                            <li class="feature">✓ Training & onboarding</li>
-                        </ul>
-                    </div>
-                    <div class="card__footer">
-                        <a href="/src/pages/shared/signup.html" class="button button--secondary button--full">Contact Sales</a>
-                    </div>
-                </div>
+      <section class="pricing-tiers">
+        <div class="pricing-grid">
+          <!-- Free Plan -->
+          <div class="card pricing-card">
+            <div class="card__header">
+              <h3 class="heading heading--tertiary">Free</h3>
+              <div class="price">
+                <span class="price__amount">$0</span>
+                <span class="price__period">forever</span>
+              </div>
+              <p class="text">Perfect for getting started</p>
             </div>
-        </section>
-
-        <section class="pricing-faq">
-            <h2 class="heading heading--secondary">Frequently Asked Questions</h2>
-            <div class="faq-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Can I upgrade or downgrade anytime?</h3>
-                        <p class="text">Yes! You can change your plan at any time. Upgrades take effect immediately, and downgrades take effect at the next billing cycle.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Is there a free trial?</h3>
-                        <p class="text">Yes, all paid plans come with a 14-day free trial. No credit card required to start your trial.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">What payment methods do you accept?</h3>
-                        <p class="text">We accept all major credit cards, PayPal, and for Enterprise customers, we can accommodate wire transfers and purchase orders.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Do you offer discounts for nonprofits?</h3>
-                        <p class="text">Yes! We offer special pricing for qualified educational institutions and nonprofits. Contact our sales team for more information.</p>
-                    </div>
-                </div>
+            <div class="card__content">
+              <ul class="features-list">
+                <li class="feature">✓ 3 courses maximum</li>
+                <li class="feature">✓ Up to 50 students per course</li>
+                <li class="feature">✓ Basic course builder</li>
+                <li class="feature">✓ Community support</li>
+                <li class="feature">✓ Mobile access</li>
+                <li class="feature">× Advanced analytics</li>
+                <li class="feature">× Integration tools</li>
+              </ul>
             </div>
-        </section>
-
-        <section class="pricing-cta">
-            <h2 class="heading heading--secondary">Ready to Get Started?</h2>
-            <p class="text text--lead">Join thousands of educators already using Neptino to enhance their teaching.</p>
-            <div class="cta__actions">
-                <a href="/src/pages/shared/signup.html" class="button button--primary">Start Your Free Trial</a>
-                <a href="#" class="button button--secondary">Schedule a Demo</a>
+            <div class="card__footer">
+              <a
+                href="/src/pages/shared/signup.html"
+                class="button button--secondary button--full"
+                >Get Started Free</a
+              >
             </div>
-        </section>
+          </div>
+
+          <!-- Teacher Plan -->
+          <div class="card pricing-card">
+            <div class="card__header">
+              <h3 class="heading heading--tertiary">Teacher</h3>
+              <div class="price">
+                <span class="price__amount">$9</span>
+                <span class="price__period">/month</span>
+              </div>
+              <p class="text">For individual educators</p>
+            </div>
+            <div class="card__content">
+              <ul class="features-list">
+                <li class="feature">✓ Unlimited courses</li>
+                <li class="feature">✓ Up to 200 students per course</li>
+                <li class="feature">✓ Advanced course builder</li>
+                <li class="feature">✓ Progress tracking</li>
+                <li class="feature">✓ Assignment grading</li>
+                <li class="feature">✓ Email support</li>
+                <li class="feature">✓ Mobile app access</li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <a
+                href="/src/pages/shared/signup.html"
+                class="button button--primary button--full"
+                >Start Free Trial</a
+              >
+            </div>
+          </div>
+
+          <!-- Professional Plan -->
+          <div class="card pricing-card pricing-card--featured">
+            <div class="card__header">
+              <div class="badge">Most Popular</div>
+              <h3 class="heading heading--tertiary">Professional</h3>
+              <div class="price">
+                <span class="price__amount">$29</span>
+                <span class="price__period">/month</span>
+              </div>
+              <p class="text">For serious educators</p>
+            </div>
+            <div class="card__content">
+              <ul class="features-list">
+                <li class="feature">✓ Everything in Teacher</li>
+                <li class="feature">✓ Unlimited students</li>
+                <li class="feature">✓ Advanced analytics</li>
+                <li class="feature">✓ Custom branding</li>
+                <li class="feature">✓ Integration tools</li>
+                <li class="feature">✓ Priority support</li>
+                <li class="feature">✓ White-label options</li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <a
+                href="/src/pages/shared/signup.html"
+                class="button button--primary button--full"
+                >Start Free Trial</a
+              >
+            </div>
+          </div>
+
+          <!-- School Plan -->
+          <div class="card pricing-card">
+            <div class="card__header">
+              <h3 class="heading heading--tertiary">School</h3>
+              <div class="price">
+                <span class="price__amount">$99</span>
+                <span class="price__period">/month</span>
+              </div>
+              <p class="text">For schools and departments</p>
+            </div>
+            <div class="card__content">
+              <ul class="features-list">
+                <li class="feature">✓ Everything in Professional</li>
+                <li class="feature">✓ Up to 50 teachers</li>
+                <li class="feature">✓ Admin dashboard</li>
+                <li class="feature">✓ Bulk user management</li>
+                <li class="feature">✓ Advanced reporting</li>
+                <li class="feature">✓ SSO integration</li>
+                <li class="feature">✓ Dedicated support</li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <a
+                href="/src/pages/shared/signup.html"
+                class="button button--primary button--full"
+                >Request Demo</a
+              >
+            </div>
+          </div>
+
+          <!-- Enterprise Plan -->
+          <div class="card pricing-card">
+            <div class="card__header">
+              <h3 class="heading heading--tertiary">Enterprise</h3>
+              <div class="price">
+                <span class="price__amount">Custom</span>
+                <span class="price__period">pricing</span>
+              </div>
+              <p class="text">For large institutions</p>
+            </div>
+            <div class="card__content">
+              <ul class="features-list">
+                <li class="feature">✓ Everything in School</li>
+                <li class="feature">✓ Unlimited teachers</li>
+                <li class="feature">✓ Multi-tenant setup</li>
+                <li class="feature">✓ Custom integrations</li>
+                <li class="feature">✓ On-premise deployment</li>
+                <li class="feature">✓ 24/7 phone support</li>
+                <li class="feature">✓ Training & onboarding</li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <a
+                href="/src/pages/shared/signup.html"
+                class="button button--secondary button--full"
+                >Contact Sales</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="pricing-faq">
+        <h2 class="heading heading--secondary">Frequently Asked Questions</h2>
+        <div class="faq-grid">
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">
+                Can I upgrade or downgrade anytime?
+              </h3>
+              <p class="text">
+                Yes! You can change your plan at any time. Upgrades take effect
+                immediately, and downgrades take effect at the next billing
+                cycle.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Is there a free trial?</h3>
+              <p class="text">
+                Yes, all paid plans come with a 14-day free trial. No credit
+                card required to start your trial.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">
+                What payment methods do you accept?
+              </h3>
+              <p class="text">
+                We accept all major credit cards, PayPal, and for Enterprise
+                customers, we can accommodate wire transfers and purchase
+                orders.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">
+                Do you offer discounts for nonprofits?
+              </h3>
+              <p class="text">
+                Yes! We offer special pricing for qualified educational
+                institutions and nonprofits. Contact our sales team for more
+                information.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="pricing-cta">
+        <h2 class="heading heading--secondary">Ready to Get Started?</h2>
+        <p class="text text--lead">
+          Join thousands of educators already using Neptino to enhance their
+          teaching.
+        </p>
+        <div class="cta__actions">
+          <a href="/src/pages/shared/signup.html" class="button button--primary"
+            >Start Your Free Trial</a
+          >
+          <a href="#" class="button button--secondary">Schedule a Demo</a>
+        </div>
+      </section>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/shared/signin.html
+++ b/src/pages/shared/signin.html
@@ -1,109 +1,121 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sign In - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <!-- No navigation links on auth pages -->
-            </div>
-            
-            <div class="nav__actions-section">
-                <a href="/src/pages/shared/signup.html" class="button button--secondary">Sign Up</a>
-            </div>
-        </nav>
-    </header>
- 
-    <main class="main grid__main">
-        <div class="auth-form">
-            <header class="auth-form__header">
-                <h1 class="heading heading--primary">Welcome back</h1>
-                <p class="text text--lead">Sign in to your Neptino account</p>
-            </header>
-            
-            <form class="form" id="signin-form" method="post" action="#">
-                <div class="form__group">
-                    <label for="email" class="form__label">Email address</label>
-                    <input 
-                        type="email" 
-                        id="email" 
-                        name="email" 
-                        class="form__input" 
-                        placeholder="Enter your email"
-                        autocomplete="email"
-                        required
-                    >
-                </div>
-                
-                <div class="form__group">
-                    <label for="password" class="form__label">Password</label>
-                    <input 
-                        type="password" 
-                        id="password" 
-                        name="password" 
-                        class="form__input" 
-                        placeholder="Enter your password"
-                        autocomplete="current-password"
-                        required
-                    >
-                </div>
-                
-                <button type="submit" class="button button--primary">
-                    Sign In
-                </button>
-            </form>
-            
-            <footer class="auth-form__footer">
-                <p class="text text--small">
-                    Don't have an account yet? 
-                    <a href="/src/pages/shared/signup.html" class="link link--primary">Sign up</a>
-                </p>
-            </footer>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
         </div>
+
+        <div class="nav__links-section">
+          <!-- No navigation links on auth pages -->
+        </div>
+
+        <div class="nav__actions-section">
+          <a
+            href="/src/pages/shared/signup.html"
+            class="button button--secondary"
+            >Sign Up</a
+          >
+        </div>
+      </nav>
+    </header>
+
+    <main class="main grid__main">
+      <div class="auth-form">
+        <header class="auth-form__header">
+          <h1 class="heading heading--primary">Welcome back</h1>
+          <p class="text text--lead">Sign in to your Neptino account</p>
+        </header>
+
+        <form class="form" id="signin-form" method="post" action="#">
+          <div class="form__group">
+            <label for="email" class="form__label">Email address</label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              class="form__input"
+              placeholder="Enter your email"
+              autocomplete="email"
+              required
+            />
+          </div>
+
+          <div class="form__group">
+            <label for="password" class="form__label">Password</label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              class="form__input"
+              placeholder="Enter your password"
+              autocomplete="current-password"
+              required
+            />
+          </div>
+
+          <button type="submit" class="button button--primary">Sign In</button>
+        </form>
+
+        <footer class="auth-form__footer">
+          <p class="text text--small">
+            Don't have an account yet?
+            <a href="/src/pages/shared/signup.html" class="link link--primary"
+              >Sign up</a
+            >
+          </p>
+        </footer>
+      </div>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <!-- Footer doesn't need action buttons, but keeping structure consistent -->
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <!-- Footer doesn't need action buttons, but keeping structure consistent -->
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/shared/signup.html
+++ b/src/pages/shared/signup.html
@@ -1,144 +1,158 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sign Up - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <!-- No navigation links on auth pages -->
-            </div>
-            
-            <div class="nav__actions-section">
-                <a href="/src/pages/shared/signin.html" class="button button--secondary">Sign In</a>
-            </div>
-        </nav>
-    </header>
- 
-    <main class="main grid__main">
-        <div class="auth-form">
-            <header class="auth-form__header">
-                <h1 class="heading heading--primary">Join Neptino</h1>
-                <p class="text text--lead">Create your account to get started</p>
-            </header>
-            
-            <form class="form" id="signup-form" method="post" action="#">
-                <div class="form__group">
-                    <label for="first-name" class="form__label">First name</label>
-                    <input 
-                        type="text" 
-                        id="first-name" 
-                        name="firstName" 
-                        class="form__input" 
-                        placeholder="Enter your first name"
-                        autocomplete="given-name"
-                        required
-                    >
-                </div>
-                
-                <div class="form__group">
-                    <label for="last-name" class="form__label">Last name</label>
-                    <input 
-                        type="text" 
-                        id="last-name" 
-                        name="lastName" 
-                        class="form__input" 
-                        placeholder="Enter your last name"
-                        autocomplete="family-name"
-                    >
-                </div>
-                
-                <div class="form__group">
-                    <label for="email" class="form__label">Email address</label>
-                    <input 
-                        type="email" 
-                        id="email" 
-                        name="email" 
-                        class="form__input" 
-                        placeholder="Enter your email"
-                        autocomplete="email"
-                        required
-                    >
-                </div>
-                
-                <div class="form__group">
-                    <label for="role" class="form__label">I am a</label>
-                    <select id="role" name="role" class="form__select" required>
-                        <option value="">Select your role</option>
-                        <option value="student">Student</option>
-                        <option value="teacher">Teacher</option>
-                        <option value="administrator">Administrator</option>
-                    </select>
-                </div>
-                
-                <div class="form__group">
-                    <label for="password" class="form__label">Password</label>
-                    <input 
-                        type="password" 
-                        id="password" 
-                        name="password" 
-                        class="form__input" 
-                        placeholder="Create a password"
-                        autocomplete="new-password"
-                        required
-                    >
-                </div>
-                
-                <button type="submit" class="button button--primary">
-                    Create Account
-                </button>
-            </form>
-            
-            <footer class="auth-form__footer">
-                <p class="text text--small">
-                    Already have an account? 
-                    <a href="/src/pages/shared/signin.html" class="link link--primary">Sign in</a>
-                </p>
-            </footer>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
         </div>
+
+        <div class="nav__links-section">
+          <!-- No navigation links on auth pages -->
+        </div>
+
+        <div class="nav__actions-section">
+          <a
+            href="/src/pages/shared/signin.html"
+            class="button button--secondary"
+            >Sign In</a
+          >
+        </div>
+      </nav>
+    </header>
+
+    <main class="main grid__main">
+      <div class="auth-form">
+        <header class="auth-form__header">
+          <h1 class="heading heading--primary">Join Neptino</h1>
+          <p class="text text--lead">Create your account to get started</p>
+        </header>
+
+        <form class="form" id="signup-form" method="post" action="#">
+          <div class="form__group">
+            <label for="first-name" class="form__label">First name</label>
+            <input
+              type="text"
+              id="first-name"
+              name="firstName"
+              class="form__input"
+              placeholder="Enter your first name"
+              autocomplete="given-name"
+              required
+            />
+          </div>
+
+          <div class="form__group">
+            <label for="last-name" class="form__label">Last name</label>
+            <input
+              type="text"
+              id="last-name"
+              name="lastName"
+              class="form__input"
+              placeholder="Enter your last name"
+              autocomplete="family-name"
+            />
+          </div>
+
+          <div class="form__group">
+            <label for="email" class="form__label">Email address</label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              class="form__input"
+              placeholder="Enter your email"
+              autocomplete="email"
+              required
+            />
+          </div>
+
+          <div class="form__group">
+            <label for="role" class="form__label">I am a</label>
+            <select id="role" name="role" class="form__select" required>
+              <option value="">Select your role</option>
+              <option value="student">Student</option>
+              <option value="teacher">Teacher</option>
+              <option value="administrator">Administrator</option>
+            </select>
+          </div>
+
+          <div class="form__group">
+            <label for="password" class="form__label">Password</label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              class="form__input"
+              placeholder="Create a password"
+              autocomplete="new-password"
+              required
+            />
+          </div>
+
+          <button type="submit" class="button button--primary">
+            Create Account
+          </button>
+        </form>
+
+        <footer class="auth-form__footer">
+          <p class="text text--small">
+            Already have an account?
+            <a href="/src/pages/shared/signin.html" class="link link--primary"
+              >Sign in</a
+            >
+          </p>
+        </footer>
+      </div>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <!-- Footer doesn't need action buttons, but keeping structure consistent -->
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <!-- Footer doesn't need action buttons, but keeping structure consistent -->
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/shared/students.html
+++ b/src/pages/shared/students.html
@@ -1,179 +1,246 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>For Students - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/shared/teachers.html" class="link link--nav">For Teachers</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/students.html" class="link link--nav link--active">For Students</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/institutions.html" class="link link--nav">For Institutions</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/pricing.html" class="link link--nav">Pricing</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <a href="/src/pages/shared/signin.html" class="button button--primary">Sign In</a>
-            </div>
-        </nav>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a href="/src/pages/shared/teachers.html" class="link link--nav"
+                >For Teachers</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/shared/students.html"
+                class="link link--nav link--active"
+                >For Students</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/shared/institutions.html"
+                class="link link--nav"
+                >For Institutions</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/shared/pricing.html" class="link link--nav"
+                >Pricing</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <a href="/src/pages/shared/signin.html" class="button button--primary"
+            >Sign In</a
+          >
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <section class="hero">
-            <div class="hero__content">
-                <h1 class="heading heading--primary">Learn Without Limits with Neptino</h1>
-                <p class="text text--lead">Access engaging courses, track your progress, and achieve your learning goals with our student-centered platform designed for success.</p>
-                <div class="hero__actions">
-                    <a href="/src/pages/shared/signup.html" class="button button--primary">Start Learning Today</a>
-                    <a href="/src/pages/shared/pricing.html" class="button button--secondary">View Student Plans</a>
-                </div>
-            </div>
-        </section>
+      <section class="hero">
+        <div class="hero__content">
+          <h1 class="heading heading--primary">
+            Learn Without Limits with Neptino
+          </h1>
+          <p class="text text--lead">
+            Access engaging courses, track your progress, and achieve your
+            learning goals with our student-centered platform designed for
+            success.
+          </p>
+          <div class="hero__actions">
+            <a
+              href="/src/pages/shared/signup.html"
+              class="button button--primary"
+              >Start Learning Today</a
+            >
+            <a
+              href="/src/pages/shared/pricing.html"
+              class="button button--secondary"
+              >View Student Plans</a
+            >
+          </div>
+        </div>
+      </section>
 
-        <section class="features">
-            <h2 class="heading heading--secondary">Your Learning Journey, Simplified</h2>
-            <div class="features-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Interactive Learning</h3>
-                        <p class="text">Engage with multimedia content, interactive quizzes, and hands-on activities that make learning fun and memorable.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Progress Tracking</h3>
-                        <p class="text">Monitor your learning journey with visual progress indicators, achievement badges, and personalized learning analytics.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Collaborative Learning</h3>
-                        <p class="text">Connect with classmates, participate in group discussions, and learn together in a supportive community environment.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Flexible Scheduling</h3>
-                        <p class="text">Learn at your own pace with 24/7 access to course materials, offline content, and mobile-friendly design.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Instant Feedback</h3>
-                        <p class="text">Get immediate feedback on assignments and quizzes to understand concepts better and improve continuously.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Study Tools</h3>
-                        <p class="text">Access note-taking tools, flashcards, study guides, and other resources to enhance your learning experience.</p>
-                    </div>
-                </div>
+      <section class="features">
+        <h2 class="heading heading--secondary">
+          Your Learning Journey, Simplified
+        </h2>
+        <div class="features-grid">
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Interactive Learning</h3>
+              <p class="text">
+                Engage with multimedia content, interactive quizzes, and
+                hands-on activities that make learning fun and memorable.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="testimonial">
-            <div class="card">
-                <div class="card__content">
-                    <blockquote class="text text--quote">
-                        "Neptino made online learning actually enjoyable! The interactive content kept me engaged, and I could see my progress every step of the way. It's like having a personal tutor available 24/7."
-                    </blockquote>
-                    <cite class="text text--cite">— Alex Chen, University Student</cite>
-                </div>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Progress Tracking</h3>
+              <p class="text">
+                Monitor your learning journey with visual progress indicators,
+                achievement badges, and personalized learning analytics.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="learning-stats">
-            <h2 class="heading heading--secondary">Join a Thriving Learning Community</h2>
-            <div class="stats-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">50,000+</div>
-                        <div class="stat-label">Active Students</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">1,200+</div>
-                        <div class="stat-label">Available Courses</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">95%</div>
-                        <div class="stat-label">Completion Rate</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">4.8/5</div>
-                        <div class="stat-label">Student Satisfaction</div>
-                    </div>
-                </div>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Collaborative Learning</h3>
+              <p class="text">
+                Connect with classmates, participate in group discussions, and
+                learn together in a supportive community environment.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="cta">
-            <h2 class="heading heading--secondary">Ready to Start Your Learning Adventure?</h2>
-            <p class="text text--lead">Join thousands of students who are already achieving their goals with Neptino.</p>
-            <div class="cta__actions">
-                <a href="/src/pages/shared/signup.html" class="button button--primary">Start Learning Free</a>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Flexible Scheduling</h3>
+              <p class="text">
+                Learn at your own pace with 24/7 access to course materials,
+                offline content, and mobile-friendly design.
+              </p>
             </div>
-        </section>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Instant Feedback</h3>
+              <p class="text">
+                Get immediate feedback on assignments and quizzes to understand
+                concepts better and improve continuously.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Study Tools</h3>
+              <p class="text">
+                Access note-taking tools, flashcards, study guides, and other
+                resources to enhance your learning experience.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="testimonial">
+        <div class="card">
+          <div class="card__content">
+            <blockquote class="text text--quote">
+              "Neptino made online learning actually enjoyable! The interactive
+              content kept me engaged, and I could see my progress every step of
+              the way. It's like having a personal tutor available 24/7."
+            </blockquote>
+            <cite class="text text--cite">— Alex Chen, University Student</cite>
+          </div>
+        </div>
+      </section>
+
+      <section class="learning-stats">
+        <h2 class="heading heading--secondary">
+          Join a Thriving Learning Community
+        </h2>
+        <div class="stats-grid">
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">50,000+</div>
+              <div class="stat-label">Active Students</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">1,200+</div>
+              <div class="stat-label">Available Courses</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">95%</div>
+              <div class="stat-label">Completion Rate</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">4.8/5</div>
+              <div class="stat-label">Student Satisfaction</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta">
+        <h2 class="heading heading--secondary">
+          Ready to Start Your Learning Adventure?
+        </h2>
+        <p class="text text--lead">
+          Join thousands of students who are already achieving their goals with
+          Neptino.
+        </p>
+        <div class="cta__actions">
+          <a href="/src/pages/shared/signup.html" class="button button--primary"
+            >Start Learning Free</a
+          >
+        </div>
+      </section>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/shared/teachers.html
+++ b/src/pages/shared/teachers.html
@@ -1,149 +1,217 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>For Teachers - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/shared/teachers.html" class="link link--nav link--active">For Teachers</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/students.html" class="link link--nav">For Students</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/institutions.html" class="link link--nav">For Institutions</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/shared/pricing.html" class="link link--nav">Pricing</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <a href="/src/pages/shared/signin.html" class="button button--primary">Sign In</a>
-            </div>
-        </nav>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a
+                href="/src/pages/shared/teachers.html"
+                class="link link--nav link--active"
+                >For Teachers</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/shared/students.html" class="link link--nav"
+                >For Students</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/shared/institutions.html"
+                class="link link--nav"
+                >For Institutions</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/shared/pricing.html" class="link link--nav"
+                >Pricing</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <a href="/src/pages/shared/signin.html" class="button button--primary"
+            >Sign In</a
+          >
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <section class="hero">
-            <div class="hero__content">
-                <h1 class="heading heading--primary">Empower Your Teaching with Neptino</h1>
-                <p class="text text--lead">Create engaging courses, track student progress, and streamline your educational workflow with our comprehensive teaching platform.</p>
-                <div class="hero__actions">
-                    <a href="/src/pages/shared/signup.html" class="button button--primary">Start Teaching Today</a>
-                    <a href="/src/pages/shared/pricing.html" class="button button--secondary">View Plans</a>
-                </div>
-            </div>
-        </section>
+      <section class="hero">
+        <div class="hero__content">
+          <h1 class="heading heading--primary">
+            Empower Your Teaching with Neptino
+          </h1>
+          <p class="text text--lead">
+            Create engaging courses, track student progress, and streamline your
+            educational workflow with our comprehensive teaching platform.
+          </p>
+          <div class="hero__actions">
+            <a
+              href="/src/pages/shared/signup.html"
+              class="button button--primary"
+              >Start Teaching Today</a
+            >
+            <a
+              href="/src/pages/shared/pricing.html"
+              class="button button--secondary"
+              >View Plans</a
+            >
+          </div>
+        </div>
+      </section>
 
-        <section class="features">
-            <h2 class="heading heading--secondary">Why Teachers Choose Neptino</h2>
-            <div class="features-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Course Builder</h3>
-                        <p class="text">Create comprehensive courses with our intuitive drag-and-drop interface. Add multimedia content, quizzes, and interactive elements effortlessly.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Student Analytics</h3>
-                        <p class="text">Track student progress with detailed analytics. Identify learning gaps and provide personalized feedback to improve outcomes.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Assessment Tools</h3>
-                        <p class="text">Create and grade assignments automatically. Support for multiple question types, rubrics, and instant feedback systems.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Collaboration Hub</h3>
-                        <p class="text">Foster classroom discussions, group projects, and peer-to-peer learning with integrated communication tools.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Resource Library</h3>
-                        <p class="text">Access thousands of educational resources, templates, and content created by fellow educators worldwide.</p>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Mobile Ready</h3>
-                        <p class="text">Teach from anywhere with our responsive design. Full functionality on tablets and mobile devices for ultimate flexibility.</p>
-                    </div>
-                </div>
+      <section class="features">
+        <h2 class="heading heading--secondary">Why Teachers Choose Neptino</h2>
+        <div class="features-grid">
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Course Builder</h3>
+              <p class="text">
+                Create comprehensive courses with our intuitive drag-and-drop
+                interface. Add multimedia content, quizzes, and interactive
+                elements effortlessly.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="testimonial">
-            <div class="card">
-                <div class="card__content">
-                    <blockquote class="text text--quote">
-                        "Neptino has transformed how I teach. The course builder is incredibly intuitive, and my students are more engaged than ever. The analytics help me understand exactly where each student needs support."
-                    </blockquote>
-                    <cite class="text text--cite">— Sarah Mitchell, High School Biology Teacher</cite>
-                </div>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Student Analytics</h3>
+              <p class="text">
+                Track student progress with detailed analytics. Identify
+                learning gaps and provide personalized feedback to improve
+                outcomes.
+              </p>
             </div>
-        </section>
+          </div>
 
-        <section class="cta">
-            <h2 class="heading heading--secondary">Ready to Transform Your Teaching?</h2>
-            <p class="text text--lead">Join thousands of educators who have already enhanced their teaching with Neptino.</p>
-            <div class="cta__actions">
-                <a href="/src/pages/shared/signup.html" class="button button--primary">Get Started Free</a>
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Assessment Tools</h3>
+              <p class="text">
+                Create and grade assignments automatically. Support for multiple
+                question types, rubrics, and instant feedback systems.
+              </p>
             </div>
-        </section>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Collaboration Hub</h3>
+              <p class="text">
+                Foster classroom discussions, group projects, and peer-to-peer
+                learning with integrated communication tools.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Resource Library</h3>
+              <p class="text">
+                Access thousands of educational resources, templates, and
+                content created by fellow educators worldwide.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Mobile Ready</h3>
+              <p class="text">
+                Teach from anywhere with our responsive design. Full
+                functionality on tablets and mobile devices for ultimate
+                flexibility.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="testimonial">
+        <div class="card">
+          <div class="card__content">
+            <blockquote class="text text--quote">
+              "Neptino has transformed how I teach. The course builder is
+              incredibly intuitive, and my students are more engaged than ever.
+              The analytics help me understand exactly where each student needs
+              support."
+            </blockquote>
+            <cite class="text text--cite"
+              >— Sarah Mitchell, High School Biology Teacher</cite
+            >
+          </div>
+        </div>
+      </section>
+
+      <section class="cta">
+        <h2 class="heading heading--secondary">
+          Ready to Transform Your Teaching?
+        </h2>
+        <p class="text text--lead">
+          Join thousands of educators who have already enhanced their teaching
+          with Neptino.
+        </p>
+        <div class="cta__actions">
+          <a href="/src/pages/shared/signup.html" class="button button--primary"
+            >Get Started Free</a
+          >
+        </div>
+      </section>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/student/courses.html
+++ b/src/pages/student/courses.html
@@ -1,81 +1,104 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Courses - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/src/pages/student/home.html" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/student/home.html" class="link link--nav">Dashboard</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/student/courses.html" class="link link--nav link--active">My Courses</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/student/progress.html" class="link link--nav">Progress</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <button id="logout-btn" class="button button--secondary">Logout</button>
-            </div>
-        </nav>
-    </header>
- 
-    <main class="main grid__main">
-        <section class="courses-header">
-            <h1 class="heading heading--primary">My Courses</h1>
-            <p class="text text--lead">Manage your enrolled courses and continue learning.</p>
-        </section>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/src/pages/student/home.html" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
 
-        <section class="courses-container">
-            <div class="card">
-                <div class="card__content">
-                    <h3 class="heading heading--tertiary">No Courses Yet</h3>
-                    <p class="text">You haven't enrolled in any courses yet. Start exploring our course catalog to begin your learning journey!</p>
-                    <a href="#" class="button button--primary">Browse Course Catalog</a>
-                </div>
-            </div>
-        </section>
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a href="/src/pages/student/home.html" class="link link--nav"
+                >Dashboard</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/student/courses.html"
+                class="link link--nav link--active"
+                >My Courses</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/student/progress.html" class="link link--nav"
+                >Progress</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <button id="logout-btn" class="button button--secondary">
+            Logout
+          </button>
+        </div>
+      </nav>
+    </header>
+
+    <main class="main grid__main">
+      <section class="courses-header">
+        <h1 class="heading heading--primary">My Courses</h1>
+        <p class="text text--lead">
+          Manage your enrolled courses and continue learning.
+        </p>
+      </section>
+
+      <section class="courses-container">
+        <div class="card">
+          <div class="card__content">
+            <h3 class="heading heading--tertiary">No Courses Yet</h3>
+            <p class="text">
+              You haven't enrolled in any courses yet. Start exploring our
+              course catalog to begin your learning journey!
+            </p>
+            <a href="#" class="button button--primary">Browse Course Catalog</a>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/src/pages/student/home.html" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Help Center</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/src/pages/student/home.html" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Help Center</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/student/home.html
+++ b/src/pages/student/home.html
@@ -1,139 +1,179 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Student Dashboard - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/src/pages/student/home.html" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/student/home.html" class="link link--nav link--active">Dashboard</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/student/courses.html" class="link link--nav">My Courses</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/student/progress.html" class="link link--nav">Progress</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <button id="logout-btn" class="button button--secondary">Logout</button>
-            </div>
-        </nav>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/src/pages/student/home.html" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a
+                href="/src/pages/student/home.html"
+                class="link link--nav link--active"
+                >Dashboard</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/student/courses.html" class="link link--nav"
+                >My Courses</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/student/progress.html" class="link link--nav"
+                >Progress</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <button id="logout-btn" class="button button--secondary">
+            Logout
+          </button>
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <section class="dashboard-welcome">
-            <h1 class="heading heading--primary">Welcome to Your Dashboard</h1>
-            <p class="text text--lead">Continue your learning journey with Neptino.</p>
-        </section>
+      <section class="dashboard-welcome">
+        <h1 class="heading heading--primary">Welcome to Your Dashboard</h1>
+        <p class="text text--lead">
+          Continue your learning journey with Neptino.
+        </p>
+      </section>
 
-        <section class="dashboard-stats">
-            <div class="stats-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0</div>
-                        <div class="stat-label">Enrolled Courses</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0%</div>
-                        <div class="stat-label">Overall Progress</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0</div>
-                        <div class="stat-label">Assignments Due</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0</div>
-                        <div class="stat-label">Certificates Earned</div>
-                    </div>
-                </div>
+      <section class="dashboard-stats">
+        <div class="stats-grid">
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0</div>
+              <div class="stat-label">Enrolled Courses</div>
             </div>
-        </section>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0%</div>
+              <div class="stat-label">Overall Progress</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0</div>
+              <div class="stat-label">Assignments Due</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0</div>
+              <div class="stat-label">Certificates Earned</div>
+            </div>
+          </div>
+        </div>
+      </section>
 
-        <section class="recent-activity">
-            <h2 class="heading heading--secondary">Recent Activity</h2>
-            <div class="card">
-                <div class="card__content">
-                    <p class="text">No recent activity. Start by enrolling in your first course!</p>
-                    <a href="/src/pages/student/courses.html" class="button button--primary">Browse Courses</a>
-                </div>
-            </div>
-        </section>
+      <section class="recent-activity">
+        <h2 class="heading heading--secondary">Recent Activity</h2>
+        <div class="card">
+          <div class="card__content">
+            <p class="text">
+              No recent activity. Start by enrolling in your first course!
+            </p>
+            <a
+              href="/src/pages/student/courses.html"
+              class="button button--primary"
+              >Browse Courses</a
+            >
+          </div>
+        </div>
+      </section>
 
-        <section class="quick-actions">
-            <h2 class="heading heading--secondary">Quick Actions</h2>
-            <div class="features-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Browse Courses</h3>
-                        <p class="text">Discover new courses and expand your knowledge.</p>
-                        <a href="/src/pages/student/courses.html" class="button button--secondary">Browse</a>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">View Progress</h3>
-                        <p class="text">Track your learning progress and achievements.</p>
-                        <a href="/src/pages/student/progress.html" class="button button--secondary">View Progress</a>
-                    </div>
-                </div>
-                
-                <div class="card">
-                    <div class="card__content">
-                        <h3 class="heading heading--tertiary">Update Profile</h3>
-                        <p class="text">Manage your account settings and preferences.</p>
-                        <a href="/src/pages/student/profile.html" class="button button--secondary">Edit Profile</a>
-                    </div>
-                </div>
+      <section class="quick-actions">
+        <h2 class="heading heading--secondary">Quick Actions</h2>
+        <div class="features-grid">
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Browse Courses</h3>
+              <p class="text">
+                Discover new courses and expand your knowledge.
+              </p>
+              <a
+                href="/src/pages/student/courses.html"
+                class="button button--secondary"
+                >Browse</a
+              >
             </div>
-        </section>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">View Progress</h3>
+              <p class="text">Track your learning progress and achievements.</p>
+              <a
+                href="/src/pages/student/progress.html"
+                class="button button--secondary"
+                >View Progress</a
+              >
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card__content">
+              <h3 class="heading heading--tertiary">Update Profile</h3>
+              <p class="text">Manage your account settings and preferences.</p>
+              <a
+                href="/src/pages/student/profile.html"
+                class="button button--secondary"
+                >Edit Profile</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/src/pages/student/home.html" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Help Center</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/src/pages/student/home.html" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Help Center</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/student/progress.html
+++ b/src/pages/student/progress.html
@@ -1,110 +1,137 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Progress - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/src/pages/student/home.html" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/student/home.html" class="link link--nav">Dashboard</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/student/courses.html" class="link link--nav">My Courses</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="/src/pages/student/progress.html" class="link link--nav link--active">Progress</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <button id="logout-btn" class="button button--secondary">Logout</button>
-            </div>
-        </nav>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/src/pages/student/home.html" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a href="/src/pages/student/home.html" class="link link--nav"
+                >Dashboard</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="/src/pages/student/courses.html" class="link link--nav"
+                >My Courses</a
+              >
+            </li>
+            <li class="list__item">
+              <a
+                href="/src/pages/student/progress.html"
+                class="link link--nav link--active"
+                >Progress</a
+              >
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <button id="logout-btn" class="button button--secondary">
+            Logout
+          </button>
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <section class="progress-header">
-            <h1 class="heading heading--primary">Learning Progress</h1>
-            <p class="text text--lead">Track your achievements and learning milestones.</p>
-        </section>
+      <section class="progress-header">
+        <h1 class="heading heading--primary">Learning Progress</h1>
+        <p class="text text--lead">
+          Track your achievements and learning milestones.
+        </p>
+      </section>
 
-        <section class="progress-overview">
-            <div class="stats-grid">
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0</div>
-                        <div class="stat-label">Courses Completed</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0</div>
-                        <div class="stat-label">Hours Learned</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0</div>
-                        <div class="stat-label">Certificates Earned</div>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card__content">
-                        <div class="stat-number">0</div>
-                        <div class="stat-label">Skills Acquired</div>
-                    </div>
-                </div>
+      <section class="progress-overview">
+        <div class="stats-grid">
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0</div>
+              <div class="stat-label">Courses Completed</div>
             </div>
-        </section>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0</div>
+              <div class="stat-label">Hours Learned</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0</div>
+              <div class="stat-label">Certificates Earned</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card__content">
+              <div class="stat-number">0</div>
+              <div class="stat-label">Skills Acquired</div>
+            </div>
+          </div>
+        </div>
+      </section>
 
-        <section class="progress-details">
-            <h2 class="heading heading--secondary">Course Progress</h2>
-            <div class="card">
-                <div class="card__content">
-                    <p class="text">No course progress to display yet. Enroll in courses to start tracking your learning journey!</p>
-                    <a href="/src/pages/student/courses.html" class="button button--primary">View My Courses</a>
-                </div>
-            </div>
-        </section>
+      <section class="progress-details">
+        <h2 class="heading heading--secondary">Course Progress</h2>
+        <div class="card">
+          <div class="card__content">
+            <p class="text">
+              No course progress to display yet. Enroll in courses to start
+              tracking your learning journey!
+            </p>
+            <a
+              href="/src/pages/student/courses.html"
+              class="button button--primary"
+              >View My Courses</a
+            >
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/src/pages/student/home.html" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Help Center</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/src/pages/student/home.html" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Help Center</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/pages/teacher/coursebuilder.html
+++ b/src/pages/teacher/coursebuilder.html
@@ -1,1015 +1,1859 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="pixi-devtools" content="enabled">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="pixi-devtools" content="enabled" />
     <title>Course Builder - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <!-- Special Course Builder Header -->
     <header class="header grid__header">
-        <nav class="nav nav--coursebuilder">
-            <div class="nav__left-section">
-                <button id="previous-btn" class="button button--previous">Courses</button>
-            </div>
-            
-            <div class="nav__center-section">
-                <a href="/src/pages/teacher/home.html" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__right-section">
-                <button id="next-btn" class="button button--succeeding">Next</button>
-            </div>
-        </nav>
+      <nav class="nav nav--coursebuilder">
+        <div class="nav__left-section">
+          <button id="previous-btn" class="button button--previous">
+            Courses
+          </button>
+        </div>
+
+        <div class="nav__center-section">
+          <a href="/src/pages/teacher/home.html" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__right-section">
+          <button id="next-btn" class="button button--succeeding">Next</button>
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <!-- Setup Section (with aside navigation) -->
-        <section id="setup" class="section section--active">
-            <aside class="aside">
-                <nav class="aside__nav">
-                    <div class="aside__group aside__group--required">
-                        <h3 class="aside__group-title">Required</h3>
-                        <ul class="aside__menu">
-                            <li class="aside__item">
-                                <a href="#essentials" class="aside__link aside__link--active" data-section="essentials">Essentials</a>
-                            </li>
-                            <li class="aside__item">
-                                <a href="#classification" class="aside__link" data-section="classification">Classification</a>
-                            </li>
-                            <li class="aside__item">
-                                <a href="#templates" class="aside__link" data-section="templates">Templates</a>
-                            </li>
-                            <li class="aside__item">
-                                <a href="#schedule" class="aside__link" data-section="schedule">Schedule</a>
-                            </li>
-                            <li class="aside__item">
-                                <a href="#curriculum" class="aside__link" data-section="curriculum">Curriculum</a>
-                            </li>
-                        </ul>
-                    </div>
-                    
-                    <div class="aside__group aside__group--optional">
-                        <h3 class="aside__group-title">Optional</h3>
-                        <ul class="aside__menu">
-                            <li class="aside__item">
-                                <a href="#marketplace" class="aside__link" data-section="marketplace">Marketplace</a>
-                            </li>
-                            <li class="aside__item">
-                                <a href="#resources" class="aside__link" data-section="resources">Resources</a>
-                            </li>
-                        </ul>
-                    </div>
-                    
-                    <div class="aside__group aside__group--settings">
-                        <ul class="aside__menu">
-                            <li class="aside__item">
-                                <a href="#settings" class="aside__link" data-section="settings">Settings</a>
-                            </li>
-                        </ul>
-                    </div>
-                </nav>
-            </aside>
-
-        
-                <!-- Essentials Article -->
-                <article id="essentials" class="article article--active">
-                <section class="card">
-                    <form class="form" id="course-essentials-form">
-                        <div class="form__group">
-                            <label class="form__label" for="course-name">Course Name</label>
-                            <input class="form__input" type="text" id="course-name" name="course_name" placeholder="Enter course name" required>
-                        </div>
-                        <div class="form__group">
-                            <label class="form__label" for="course-description">Course Description</label>
-                            <textarea class="form__input" id="course-description" name="course_description" rows="4" placeholder="Describe what students will learn" required></textarea>
-                        </div>
-                        <div class="form__group">
-                            <label class="form__label" for="teacher-id">Teacher</label>
-                            <input class="form__input" type="text" id="teacher-id" name="teacher_id" placeholder="Loading..." readonly>
-                        </div>
-                        <div class="form__group">
-                            <label class="form__label" for="institution">Institution</label>
-                            <input class="form__input" type="text" id="institution" name="institution" placeholder="Loading..." readonly>
-                        </div>
-                        <div class="form__group">
-                            <label class="form__label" for="course-language">Course Language</label>
-                            <select class="form__input" id="course-language" name="course_language" required>
-                                <option value="">Select language...</option>
-                            </select>
-                        </div>
-                        <div class="form__group">
-                            <label class="form__label" for="course-image">Course Image</label>
-                            <div class="file-upload file-upload--compact">
-                                <input type="file" id="course-image" name="course_image" accept="image/*" class="file-upload__input" required>
-                                <div class="file-upload__compact-layout">
-                                    <label for="course-image" class="file-upload__compact-label">
-                                        <span class="file-upload__text">Change course image</span>
-                                    </label>
-                                    <div class="file-upload__thumbnail" id="image-preview" style="display: none;">
-                                        <img id="preview-img" src="" alt="Course preview" class="file-upload__thumbnail-image">
-                                        <button type="button" class="file-upload__remove file-upload__remove--compact" id="remove-image">×</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="form__actions">
-                            <div class="form__actions-row">
-                                <button type="submit" id="create-course-btn" class="button button--primary button--disabled" disabled>
-                                    Create Course
-                                </button>
-                                <div class="course-code-display" id="course-code-display" style="display: none;">
-                                    <div class="course-code-container">
-                                        <span class="course-code-label">Course Code:</span>
-                                        <span class="course-code-value" id="course-code-value"></span>
-                                        <button type="button" class="course-code-copy-btn" id="course-code-copy-btn" title="Copy course code">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="form__status" id="form-status"></div>
-                        </div>
-                    </form>
-                </section>
-            </article>
-
-            <!-- Classification Article -->
-            <article id="classification" class="article">
-                <section class="card">
-                    <form class="form" id="course-classification-form">
-                        <!-- Row 1: Class Year + Curricular Framework -->
-                        <div class="dropdown-group dropdown-group--classification-row">
-                            <div class="form__group">
-                                <label class="form__label" for="class-year-dropdown">Class Year</label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger" id="class-year-dropdown" aria-haspopup="listbox" aria-expanded="false">
-                                        <span class="dropdown__label dropdown__label--placeholder">Select class year...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="class-year-menu">
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="class_year" id="class-year-value">
-                            </div>
-                            
-                            <div class="form__group">
-                                <label class="form__label" for="curricular-framework-dropdown">Curricular Framework</label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger" id="curricular-framework-dropdown" aria-haspopup="listbox" aria-expanded="false">
-                                        <span class="dropdown__label dropdown__label--placeholder">Select framework...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="curricular-framework-menu">
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="curricular_framework" id="curricular-framework-value">
-                            </div>
-                        </div>
-
-                        <!-- Row 2: Domain + Subject + Topic + Subtopic -->
-                        <div class="dropdown-group dropdown-group--classification-row dropdown-group--with-arrows">
-                            <div class="form__group">
-                                <label class="form__label" for="domain-dropdown">Domain</label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger" id="domain-dropdown" aria-haspopup="listbox" aria-expanded="false">
-                                        <span class="dropdown__label dropdown__label--placeholder">Select domain...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="domain-menu">
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="domain" id="domain-value">
-                            </div>
-                            
-                            <div class="dropdown-arrow">→</div>
-                            
-                            <div class="form__group">
-                                <label class="form__label" for="subject-dropdown">Subject</label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger dropdown__trigger--disabled" id="subject-dropdown" aria-haspopup="listbox" aria-expanded="false" disabled>
-                                        <span class="dropdown__label dropdown__label--placeholder">Select domain first...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="subject-menu">
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="subject" id="subject-value">
-                            </div>
-                            
-                            <div class="dropdown-arrow">→</div>
-                            
-                            <div class="form__group">
-                                <label class="form__label" for="topic-dropdown">Topic</label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger dropdown__trigger--disabled" id="topic-dropdown" aria-haspopup="listbox" aria-expanded="false" disabled>
-                                        <span class="dropdown__label dropdown__label--placeholder">Select subject first...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="topic-menu">
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="topic" id="topic-value">
-                            </div>
-                            
-                            <div class="dropdown-arrow">→</div>
-                            
-                            <div class="form__group">
-                                <label class="form__label" for="subtopic-dropdown">Subtopic <span class="text text--muted">(Optional)</span></label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger dropdown__trigger--disabled" id="subtopic-dropdown" aria-haspopup="listbox" aria-expanded="false" disabled>
-                                        <span class="dropdown__label dropdown__label--placeholder">Select topic first...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="subtopic-menu">
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="subtopic" id="subtopic-value">
-                            </div>
-                        </div>
-
-                        <!-- Row 3: Course Sequence -->
-                        <div class="dropdown-group dropdown-group--classification-row">
-                            <div class="form__group">
-                                <label class="form__label" for="previous-course-dropdown">Previous Course <span class="text text--muted">(Optional)</span></label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger" id="previous-course-dropdown" aria-haspopup="listbox" aria-expanded="false">
-                                        <span class="dropdown__label dropdown__label--placeholder">Select previous course...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="previous-course-menu">
-                                        <div class="dropdown__option dropdown__option--header">Your Courses</div>
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="previous_course" id="previous-course-value">
-                            </div>
-                            
-                            <div class="form__group">
-                                <label class="form__label" for="current-course-dropdown">Current Course <span class="text text--muted">(Optional)</span></label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger" id="current-course-dropdown" aria-haspopup="listbox" aria-expanded="false">
-                                        <span class="dropdown__label dropdown__label--placeholder">Select current course...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="current-course-menu">
-                                        <div class="dropdown__option dropdown__option--header">Your Courses</div>
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="current_course" id="current-course-value">
-                            </div>
-                            
-                            <div class="form__group">
-                                <label class="form__label" for="next-course-dropdown">Next Course <span class="text text--muted">(Optional)</span></label>
-                                <div class="dropdown dropdown--classification">
-                                    <button type="button" class="dropdown__trigger" id="next-course-dropdown" aria-haspopup="listbox" aria-expanded="false">
-                                        <span class="dropdown__label dropdown__label--placeholder">Select next course...</span>
-                                        <span class="dropdown__icon">▼</span>
-                                    </button>
-                                    <div class="dropdown__menu" role="listbox" id="next-course-menu">
-                                        <div class="dropdown__option dropdown__option--header">Your Courses</div>
-                                        <!-- Options will be populated by JavaScript -->
-                                    </div>
-                                </div>
-                                <input type="hidden" name="next_course" id="next-course-value">
-                            </div>
-                        </div>
-
-                        <!-- Last saved indicator -->
-                        <div class="form__footer">
-                            <div class="save-indicator" id="classification-last-saved">
-                                <span class="save-indicator__text" id="classification-save-status">Changes will be saved automatically</span>
-                            </div>
-                        </div>
-                    </form>
-                </section>
-            </article>
-
-            <!-- Templates Article -->
-            <article id="templates" class="article">
-                <section class="card">
-                    <!-- Template Action Buttons -->
-                    <div class="template-header">
-                        <div class="template-header__actions">
-                            <button id="create-template-btn" class="button button--primary">
-                                <span class="button__icon">+</span>
-                                Create New Template
-                            </button>
-                            <button id="load-template-btn" class="button button--secondary">
-                                <span class="button__icon">↗</span>
-                                Load Template
-                            </button>
-                        </div>
-                    </div>
-               
-                    <!-- Template Builder Layout -->
-                    <div class="template-layout">
-                        <div class="template-config">
-                            <div class="template-config-placeholder">
-                                <h3 class="heading heading--tertiary">Template Configuration</h3>
-                                <p class="text">Select or create a template to configure its settings.</p>
-                            </div>
-                        </div>
-                        <div class="template-preview">
-                        
-                            <div class="preview-container">
-                                <div class="preview-placeholder">
-                                    <h4 class="preview-placeholder__title">No Template Selected</h4>
-                                    <p class="preview-placeholder__text">Create a new template or select an existing one to see the preview here.</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </section>
-            </article>
-
-            <!-- Create Template Modal -->
-            <div id="create-template-modal" class="modal" style="display: none;">
-                <div class="modal__content">
-                    <div class="modal__header">
-                        <h2 class="modal__title">Create New Template</h2>
-                        <button class="modal__close" type="button" onclick="TemplateManager.hideCreateTemplateModal()">&times;</button>
-                    </div>
-                    <div class="modal__body">
-                        <form id="create-template-form" class="form">
-                            <div class="form__group">
-                                <label class="form__label" for="template-name">Template Name*</label>
-                                <input type="text" id="template-name" name="template-name" class="form__input" required placeholder="Enter template name">
-                            </div>
-                            <div class="form__group">
-                                <label class="form__label" for="template-type">Template Type*</label>
-                                <select id="template-type" name="template-type" class="form__input" required>
-                                    <option value="">Select template type</option>
-                                    <option value="lesson">Lesson</option>
-                                </select>
-                            </div>
-                            <div class="form__group">
-                                <label class="form__label" for="template-description">Description (Optional)</label>
-                                <textarea id="template-description" name="template-description" class="form__input" rows="3" placeholder="Describe your template..."></textarea>
-                            </div>
-                            <div class="form__actions">
-                                <button type="button" class="btn btn--secondary modal__close" onclick="TemplateManager.hideCreateTemplateModal()">Cancel</button>
-                                <button type="submit" class="btn btn--primary">Create Template</button>
-                            </div>
-                        </form>
-                    </div>
-                </div>
+      <!-- Setup Section (with aside navigation) -->
+      <section id="setup" class="section section--active">
+        <aside class="aside">
+          <nav class="aside__nav">
+            <div class="aside__group aside__group--required">
+              <h3 class="aside__group-title">Required</h3>
+              <ul class="aside__menu">
+                <li class="aside__item">
+                  <a
+                    href="#essentials"
+                    class="aside__link aside__link--active"
+                    data-section="essentials"
+                    >Essentials</a
+                  >
+                </li>
+                <li class="aside__item">
+                  <a
+                    href="#classification"
+                    class="aside__link"
+                    data-section="classification"
+                    >Classification</a
+                  >
+                </li>
+                <li class="aside__item">
+                  <a
+                    href="#templates"
+                    class="aside__link"
+                    data-section="templates"
+                    >Templates</a
+                  >
+                </li>
+                <li class="aside__item">
+                  <a
+                    href="#schedule"
+                    class="aside__link"
+                    data-section="schedule"
+                    >Schedule</a
+                  >
+                </li>
+                <li class="aside__item">
+                  <a
+                    href="#curriculum"
+                    class="aside__link"
+                    data-section="curriculum"
+                    >Curriculum</a
+                  >
+                </li>
+              </ul>
             </div>
 
-            <!-- Load Template Modal -->
-            <div id="load-template-modal" class="modal" style="display: none;">
-                <div class="modal__content modal__content--large">
-                    <div class="modal__header">
-                        <h2 class="modal__title">Load Existing Template</h2>
-                        <button class="modal__close" type="button" onclick="TemplateManager.hideLoadTemplateModal()">&times;</button>
-                    </div>
-                    <div class="modal__body">
-                        <div class="template-loader">
-                            <div class="template-loader__search">
-                                <input type="text" id="template-search" class="form__input" placeholder="Search templates..." />
-                                <div class="template-filters">
-                                    <select id="template-type-filter" class="form__input form__input--small">
-                                        <option value="">All Types</option>
-                                        <option value="lesson">Lesson</option>
-                                    </select>
-                                    <select id="template-sort" class="form__input form__input--small">
-                                        <option value="created_at">Newest First</option>
-                                        <option value="name">Name (A-Z)</option>
-                                        <option value="modified_at">Recently Modified</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="template-list-container">
-                                <div id="template-loading" class="template-loading" style="display: none;">
-                                    <div class="loading-spinner"></div>
-                                    <p>Loading your templates...</p>
-                                </div>
-                                <div id="template-list-content" class="template-list-grid">
-                                    <!-- Templates will be loaded here -->
-                                </div>
-                                <div id="no-templates-message" class="no-templates" style="display: none;">
-                                    <div class="no-templates__icon">!</div>
-                                    <h3>No Templates Found</h3>
-                                    <p>You haven't created any templates yet. Create your first template to get started!</p>
-                                    <button class="button button--primary" onclick="TemplateManager.hideLoadTemplateModal(); TemplateManager.showCreateTemplateModal();">
-                                        Create First Template
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="modal__footer">
-                        <button type="button" class="button button--secondary" onclick="TemplateManager.hideLoadTemplateModal()">
-                            Cancel
-                        </button>
-                        <button type="button" id="load-selected-template" class="button button--primary" disabled onclick="TemplateManager.loadSelectedTemplate()">
-                            Load Template
-                        </button>
-                    </div>
-                </div>
+            <div class="aside__group aside__group--optional">
+              <h3 class="aside__group-title">Optional</h3>
+              <ul class="aside__menu">
+                <li class="aside__item">
+                  <a
+                    href="#marketplace"
+                    class="aside__link"
+                    data-section="marketplace"
+                    >Marketplace</a
+                  >
+                </li>
+                <li class="aside__item">
+                  <a
+                    href="#resources"
+                    class="aside__link"
+                    data-section="resources"
+                    >Resources</a
+                  >
+                </li>
+              </ul>
             </div>
 
-            <!-- Schedule Article -->
-            <article id="schedule" class="article">
-                <section class="card">
-                    <!-- Schedule Layout -->
-                    <div class="schedule-layout">
-                        <!-- Schedule Configuration -->
-                        <div id="schedule-config" class="schedule-config">
-                            <h3 class="heading heading--tertiary">Schedule Configuration</h3>
-                            
-                            <form class="form">
-                                <!-- Date Range Row -->
-                                <div class="form__row">
-                                    <div class="form__group">
-                                        <label class="form__label" for="start-date">Start Date</label>
-                                        <input class="form__input" type="date" id="start-date" required>
-                                    </div>
-                                    <div class="form__group">
-                                        <label class="form__label" for="end-date">End Date</label>
-                                        <input class="form__input" type="date" id="end-date" required>
-                                    </div>
-                                </div>
+            <div class="aside__group aside__group--settings">
+              <ul class="aside__menu">
+                <li class="aside__item">
+                  <a
+                    href="#settings"
+                    class="aside__link"
+                    data-section="settings"
+                    >Settings</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </nav>
+        </aside>
 
-                                <!-- Days of Week Selection -->
-                                <div class="form__group">
-                                    <label class="form__label">Days of the Week</label>
-                                    <div class="day-buttons">
-                                        <button type="button" class="day-button" data-day="monday">Mon</button>
-                                        <button type="button" class="day-button" data-day="tuesday">Tue</button>
-                                        <button type="button" class="day-button" data-day="wednesday">Wed</button>
-                                        <button type="button" class="day-button" data-day="thursday">Thu</button>
-                                        <button type="button" class="day-button" data-day="friday">Fri</button>
-                                        <button type="button" class="day-button" data-day="saturday">Sat</button>
-                                        <button type="button" class="day-button" data-day="sunday">Sun</button>
-                                    </div>
-                                </div>
-
-                                <!-- Time Range Row -->
-                                <div class="form__row">
-                                    <div class="form__group">
-                                        <label class="form__label" for="start-time">Start Time</label>
-                                        <input class="form__input" type="time" id="start-time" required>
-                                    </div>
-                                    <div class="form__group">
-                                        <label class="form__label" for="end-time">End Time</label>
-                                        <input class="form__input" type="time" id="end-time" required>
-                                    </div>
-                                </div>
-
-                                <!-- Schedule Action Buttons -->
-                                <div class="form__actions">
-                                    <button type="button" id="schedule-course-btn" class="button button--primary button--disabled" disabled>
-                                        Schedule Course
-                                    </button>
-                                    <button type="button" id="delete-schedule-btn" class="button button--danger hidden">
-                                        Delete Schedule
-                                    </button>
-                                </div>
-                            </form>
-                        </div>
-
-                        <!-- Schedule Preview -->
-                        <div id="schedule-preview" class="schedule-preview hidden">
-                            <h3 class="heading heading--tertiary">Schedule Preview</h3>
-                            
-                            <div class="schedule-list-container">
-                                <div class="schedule-list-header">
-                                    <span class="header-lesson">Lesson #</span>
-                                    <span class="header-day">Day</span>
-                                    <span class="header-start">Start Time</span>
-                                    <span class="header-end">End Time</span>
-                                    <span class="header-actions">Actions</span>
-                                </div>
-                                
-                                <div class="schedule-list">
-                                    <!-- Schedule rows will be generated here -->
-                                </div>
-                                
-                                <div class="schedule-summary">
-                                    <div class="total-lessons">Total lessons: 0</div>
-                                </div>
-                            </div>
-                        </div>
+        <!-- Essentials Article -->
+        <article id="essentials" class="article article--active">
+          <section class="card">
+            <form class="form" id="course-essentials-form">
+              <div class="form__group">
+                <label class="form__label" for="course-name">Course Name</label>
+                <input
+                  class="form__input"
+                  type="text"
+                  id="course-name"
+                  name="course_name"
+                  placeholder="Enter course name"
+                  required
+                />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="course-description"
+                  >Course Description</label
+                >
+                <textarea
+                  class="form__input"
+                  id="course-description"
+                  name="course_description"
+                  rows="4"
+                  placeholder="Describe what students will learn"
+                  required
+                ></textarea>
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="teacher-id">Teacher</label>
+                <input
+                  class="form__input"
+                  type="text"
+                  id="teacher-id"
+                  name="teacher_id"
+                  placeholder="Loading..."
+                  readonly
+                />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="institution">Institution</label>
+                <input
+                  class="form__input"
+                  type="text"
+                  id="institution"
+                  name="institution"
+                  placeholder="Loading..."
+                  readonly
+                />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="course-language"
+                  >Course Language</label
+                >
+                <select
+                  class="form__input"
+                  id="course-language"
+                  name="course_language"
+                  required
+                >
+                  <option value="">Select language...</option>
+                </select>
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="course-image"
+                  >Course Image</label
+                >
+                <div class="file-upload file-upload--compact">
+                  <input
+                    type="file"
+                    id="course-image"
+                    name="course_image"
+                    accept="image/*"
+                    class="file-upload__input"
+                    required
+                  />
+                  <div class="file-upload__compact-layout">
+                    <label
+                      for="course-image"
+                      class="file-upload__compact-label"
+                    >
+                      <span class="file-upload__text">Change course image</span>
+                    </label>
+                    <div
+                      class="file-upload__thumbnail"
+                      id="image-preview"
+                      style="display: none"
+                    >
+                      <img
+                        id="preview-img"
+                        src=""
+                        alt="Course preview"
+                        class="file-upload__thumbnail-image"
+                      />
+                      <button
+                        type="button"
+                        class="file-upload__remove file-upload__remove--compact"
+                        id="remove-image"
+                      >
+                        ×
+                      </button>
                     </div>
-                </section>
-            </article>
-
-            <!-- Curriculum Article -->
-            <article id="curriculum" class="article">
-                <section class="card">
-                    <!-- Curriculum Layout -->
-                    <div class="curriculum-layout">
-                        <!-- Curriculum Configuration -->
-                        <div id="curriculum-config" class="curriculum-config">
-                
-                            
-                            <div class="content-load-section">
-                                <div id="content-load-display" class="content-load-display">
-                                    <!-- Content load info will be displayed here -->
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Curriculum Preview -->
-                        <div id="curriculum-preview" class="curriculum-preview hidden">
-                            <div class="curriculum-preview-header">
-                          
-                                <!-- Preview Mode Buttons -->
-                                <div class="preview-mode-controls">
-                                    <span class="preview-mode-label">Display:</span>
-                                    <button type="button" class="preview-mode-btn active" data-mode="titles">
-                                        Lesson Titles
-                                    </button>
-                                    <button type="button" class="preview-mode-btn" data-mode="topics">
-                                        Lesson Topics
-                                    </button>
-                                    <button type="button" class="preview-mode-btn" data-mode="objectives">
-                                        Lesson Objectives
-                                    </button>
-                                </div>
-                            </div>
-                            
-                            <div class="curriculum-preview-content">
-                                <!-- Curriculum content will be rendered here -->
-                            </div>
-                        </div>
-                    </div>
-                </section>
-            </article>
-
-            <!-- Settings Article -->
-            <article id="settings" class="article">
-                <section class="card">
-                    <!-- Margins Section -->
-                    <div class="margins-section">
-                        <h4 class="margins-title">Margins</h4>
-                        
-                        <!-- Display Unit Selection -->
-                        <div class="margins-unit-selection">
-                            <span class="unit-label">Display in</span>
-                            <div class="unit-toggle">
-                                <input type="radio" id="unit-inches" name="margin-unit" value="inches" class="unit-toggle__input">
-                                <label for="unit-inches" class="unit-toggle__label">Inches</label>
-                                
-                                <input type="radio" id="unit-centimeters" name="margin-unit" value="centimeters" class="unit-toggle__input" checked>
-                                <label for="unit-centimeters" class="unit-toggle__label">Centimeters</label>
-                            </div>
-                        </div>
-
-                        <!-- Margin Inputs Grid -->
-                        <div class="margins-input-grid">
-                            <div class="margin-input-item">
-                                <label class="margin-label" for="margin-top">Top</label>
-                                <div class="margin-input-group">
-                                    <input class="margin-input" type="number" id="margin-top" name="margin_top" value="2.54" step="0.01" min="0">
-                                    <span class="margin-unit-display">cm</span>
-                                </div>
-                            </div>
-                            
-                            <div class="margin-input-item">
-                                <label class="margin-label" for="margin-bottom">Bottom</label>
-                                <div class="margin-input-group">
-                                    <input class="margin-input" type="number" id="margin-bottom" name="margin_bottom" value="2.54" step="0.01" min="0">
-                                    <span class="margin-unit-display">cm</span>
-                                </div>
-                            </div>
-                            
-                            <div class="margin-input-item">
-                                <label class="margin-label" for="margin-left">Left</label>
-                                <div class="margin-input-group">
-                                    <input class="margin-input" type="number" id="margin-left" name="margin_left" value="2.54" step="0.01" min="0">
-                                    <span class="margin-unit-display">cm</span>
-                                </div>
-                            </div>
-                            
-                            <div class="margin-input-item">
-                                <label class="margin-label" for="margin-right">Right</label>
-                                <div class="margin-input-group">
-                                    <input class="margin-input" type="number" id="margin-right" name="margin_right" value="2.54" step="0.01" min="0">
-                                    <span class="margin-unit-display">cm</span>
-                                </div>
-                            </div>
-                        </div>
-                        
-                        <!-- Save Status -->
-                        <div class="margins-save-status">
-                            <div class="save-indicator" id="margins-save-status">
-                                <span class="save-indicator__text">Margins will be saved automatically</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Course Visibility Settings -->
-             
-                    <!-- Course Visibility Settings -->
-                    <div class="course-settings-section">
-                        <form class="settings-form">
-                            <div class="settings-checkbox-group">
-                                <div class="settings-checkbox-item">
-                                    <input class="settings-checkbox" type="checkbox" id="course-visible">
-                                    <label class="settings-checkbox-label" for="course-visible">Course visible to students</label>
-                                </div>
-                                <div class="settings-checkbox-item">
-                                    <input class="settings-checkbox" type="checkbox" id="allow-enrollment">
-                                    <label class="settings-checkbox-label" for="allow-enrollment">Allow new enrollments</label>
-                                </div>
-                                <div class="settings-checkbox-item">
-                                    <input class="settings-checkbox" type="checkbox" id="require-approval">
-                                    <label class="settings-checkbox-label" for="require-approval">Require enrollment approval</label>
-                                </div>
-                            </div>
-                        </form>
-                    </div>
-                    
-                    <div class="danger-zone">
-                        <h3 class="danger-zone-title">Danger Zone</h3>
-                        <p class="danger-zone-text">Once you delete a course, there is no going back. Please be certain.</p>
-                        <button class="danger-zone-button">Delete Course</button>
-                    </div>
-                </section>
-            </article>
-
-            <!-- Marketplace Article -->
-            <article id="marketplace" class="article">
-                <section class="card">
-                
-                    <p class="text">Marketplace integration features will be available here...</p>
-                </section>
-            </article>
-
-            <!-- Resources Article -->
-            <article id="resources" class="article">
-                <section class="card">
-              
-                </section>
-            </article>
-        </section>
-
-        <!-- Create Section (no aside navigation) -->
-        <section id="create" class="section">
-            <article class="article article--active">
-                <!-- Course Builder Layout -->
-                <div class="coursebuilder">
-                    <!-- Options Bar (Top Left - above media areas) -->
-                    <div class="coursebuilder__options-bar">
-                        <!-- This area can be used for general course options -->
-                        <div class="course-options">
-                            <span>Course Builder</span>
-                        </div>
-                    </div>
-
-                    <!-- Canvas Toolbar (Top Center - above canvas) -->
-                    <div class="coursebuilder__canvas-toolbar">
-                        <div class="toolbar">
-                            <div class="toolbar__tools">
-                                <!-- Drawing Tools -->
-                                <button class="tool tool--selected" data-tool="selection" title="Selection Tool">
-                                    <div class="tool__icon">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="m3 3 7.07 16.97 2.51-7.39 7.39-2.51L3 3z"/>
-                                        </svg>
-                                    </div>
-                                    <span class="tool__label">Select</span>
-                                </button>
-
-                                <button class="tool" data-tool="pen" title="Pen Tool">
-                                    <div class="tool__icon">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M20.71 7.04C21.1 6.65 21.1 6 20.71 5.63L18.37 3.29C18 2.9 17.35 2.9 16.96 3.29L15.12 5.12L18.87 8.87M3 17.25V21H6.75L17.81 9.93L14.06 6.18L3 17.25Z"/>
-                                        </svg>
-                                    </div>
-                                    <span class="tool__label">Pen</span>
-                                </button>
-
-                                <button class="tool" data-tool="highlighter" title="Highlighter Tool">
-                                    <div class="tool__icon">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M18.5 1.15L20.85 3.5L17.5 6.85L15.15 4.5L18.5 1.15M12.5 6.15L14.85 8.5L4.85 18.5L2.5 16.15L12.5 6.15M22 23H2V21H22V23Z"/>
-                                        </svg>
-                                    </div>
-                                    <span class="tool__label">Highlight</span>
-                                </button>
-
-                                <button class="tool" data-tool="text" title="Text Tool">
-                                    <div class="tool__icon">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M5 4V7H10.5V19H13.5V7H19V4H5Z"/>
-                                        </svg>
-                                    </div>
-                                    <span class="tool__label">Text</span>
-                                </button>
-
-                                <button class="tool" data-tool="shapes" title="Shapes Tool">
-                                    <div class="tool__icon">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6A2,2 0 0,1 10,4A2,2 0 0,1 12,2M21,9V7L15,1H5C3.89,1 3,1.89 3,3V21A2,2 0 0,0 5,23H19A2,2 0 0,0 21,21V9M19,9H14V4H19V9Z"/>
-                                        </svg>
-                                    </div>
-                                    <span class="tool__label">Shapes</span>
-                                </button>
-
-                                <button class="tool" data-tool="eraser" title="Eraser Tool">
-                                    <div class="tool__icon">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M16.24 3.56L21.19 8.5C21.97 9.29 21.97 10.55 21.19 11.34L12 20.53C10.44 22.09 7.91 22.09 6.34 20.53L2.81 17C2.03 16.21 2.03 14.95 2.81 14.16L13.41 3.56C14.2 2.78 15.46 2.78 16.24 3.56M4.22 15.58L7.76 19.11C8.54 19.9 9.8 19.9 10.59 19.11L14.12 15.58L9.17 10.63L4.22 15.58Z"/>
-                                        </svg>
-                                    </div>
-                                    <span class="tool__label">Eraser</span>
-                                </button>
-                            </div>
-
-                            <!-- Tool Settings Panel -->
-                            <div class="toolbar__settings">
-                                <!-- Pen Tool Settings -->
-                                <div class="tool-settings" data-tool="pen">
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Color:</span>
-                                        <div class="color-palette">
-                                            <div class="color-palette__color color-palette__color--active" data-color="#000000" style="background-color: #000000;" title="Black"></div>
-                                            <div class="color-palette__color" data-color="#ff0000" style="background-color: #ff0000;" title="Red"></div>
-                                            <div class="color-palette__color" data-color="#0066ff" style="background-color: #0066ff;" title="Blue"></div>
-                                            <div class="color-palette__color" data-color="#00cc00" style="background-color: #00cc00;" title="Green"></div>
-                                            <div class="color-palette__color" data-color="#ff6600" style="background-color: #ff6600;" title="Orange"></div>
-                                            <div class="color-palette__color" data-color="#800080" style="background-color: #800080;" title="Purple"></div>
-                                        </div>
-                                    </div>
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Size:</span>
-                                        <div class="size-slider">
-                                            <input type="range" min="1" max="20" value="4" data-setting="size">
-                                            <span class="size-slider__value">4px</span>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- Highlighter Tool Settings -->
-                                <div class="tool-settings" data-tool="highlighter">
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Color:</span>
-                                        <div class="color-palette">
-                                            <div class="color-palette__color color-palette__color--active" data-color="#ffff00" style="background-color: #ffff00;" title="Yellow"></div>
-                                            <div class="color-palette__color" data-color="#00ffff" style="background-color: #00ffff;" title="Cyan"></div>
-                                            <div class="color-palette__color" data-color="#ff69b4" style="background-color: #ff69b4;" title="Pink"></div>
-                                            <div class="color-palette__color" data-color="#90ee90" style="background-color: #90ee90;" title="Light Green"></div>
-                                            <div class="color-palette__color" data-color="#ffa500" style="background-color: #ffa500;" title="Orange"></div>
-                                            <div class="color-palette__color" data-color="#dda0dd" style="background-color: #dda0dd;" title="Plum"></div>
-                                        </div>
-                                    </div>
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Size:</span>
-                                        <div class="size-slider">
-                                            <input type="range" min="10" max="50" value="20" data-setting="size">
-                                            <span class="size-slider__value">20px</span>
-                                        </div>
-                                    </div>
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Opacity:</span>
-                                        <div class="size-slider">
-                                            <input type="range" min="0.1" max="1" step="0.1" value="0.8" data-setting="opacity">
-                                            <span class="size-slider__value">80%</span>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- Text Tool Settings -->
-                                <div class="tool-settings" data-tool="text">
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Font:</span>
-                                        <select class="font-controls__select" data-setting="fontFamily">
-                                            <option value="Arial">Arial</option>
-                                            <option value="Helvetica">Helvetica</option>
-                                            <option value="Times New Roman">Times New Roman</option>
-                                            <option value="Georgia">Georgia</option>
-                                            <option value="Courier New">Courier New</option>
-                                        </select>
-                                    </div>
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Size:</span>
-                                        <div class="size-slider">
-                                            <input type="range" min="8" max="72" value="16" data-setting="fontSize">
-                                            <span class="size-slider__value">16px</span>
-                                        </div>
-                                    </div>
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Color:</span>
-                                        <div class="color-palette">
-                                            <div class="color-palette__color color-palette__color--active" data-color="#000000" style="background-color: #000000;" title="Black"></div>
-                                            <div class="color-palette__color" data-color="#ff0000" style="background-color: #ff0000;" title="Red"></div>
-                                            <div class="color-palette__color" data-color="#0066ff" style="background-color: #0066ff;" title="Blue"></div>
-                                            <div class="color-palette__color" data-color="#00cc00" style="background-color: #00cc00;" title="Green"></div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- Shapes Tool Settings -->
-                                <div class="tool-settings" data-tool="shapes">
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Shape:</span>
-                                        <div class="shape-buttons">
-                                            <button class="shape-btn shape-btn--active" data-shape="rectangle" title="Rectangle">
-                                                <svg viewBox="0 0 24 24" fill="currentColor">
-                                                    <rect x="3" y="6" width="18" height="12" rx="2" ry="2" stroke="currentColor" stroke-width="2" fill="none"/>
-                                                </svg>
-                                            </button>
-                                            <button class="shape-btn" data-shape="triangle" title="Triangle">
-                                                <svg viewBox="0 0 24 24" fill="currentColor">
-                                                    <polygon points="12,3 21,18 3,18" stroke="currentColor" stroke-width="2" fill="none"/>
-                                                </svg>
-                                            </button>
-                                            <button class="shape-btn" data-shape="circle" title="Circle">
-                                                <svg viewBox="0 0 24 24" fill="currentColor">
-                                                    <circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="2" fill="none"/>
-                                                </svg>
-                                            </button>
-                                        </div>
-                                    </div>
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Stroke:</span>
-                                        <div class="color-palette">
-                                            <div class="color-palette__color color-palette__color--active" data-color="#000000" style="background-color: #000000;" title="Black"></div>
-                                            <div class="color-palette__color" data-color="#ff0000" style="background-color: #ff0000;" title="Red"></div>
-                                            <div class="color-palette__color" data-color="#0066ff" style="background-color: #0066ff;" title="Blue"></div>
-                                            <div class="color-palette__color" data-color="#00cc00" style="background-color: #00cc00;" title="Green"></div>
-                                        </div>
-                                    </div>
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Width:</span>
-                                        <div class="size-slider">
-                                            <input type="range" min="1" max="10" value="2" data-setting="strokeWidth">
-                                            <span class="size-slider__value">2px</span>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- Eraser Tool Settings -->
-                                <div class="tool-settings" data-tool="eraser">
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Size:</span>
-                                        <div class="size-slider">
-                                            <input type="range" min="5" max="100" value="20" data-setting="size">
-                                            <span class="size-slider__value">20px</span>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <!-- Selection Tool Settings -->
-                                <div class="tool-settings tool-settings--active" data-tool="selection">
-                                    <div class="settings-section">
-                                        <span class="settings-section__label">Selection tool active</span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Table of Contents Options -->
-                    <div class="coursebuilder__toc-options">
-                        <button class="action-btn" title="Add Page">
-                            <div class="action-btn__icon">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"/>
-                                </svg>
-                            </div>
-                            <span class="action-btn__label">Add Page</span>
-                        </button>
-
-                        <button class="action-btn" title="Page Settings">
-                            <div class="action-btn__icon">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.68 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"/>
-                                </svg>
-                            </div>
-                            <span class="action-btn__label">Settings</span>
-                        </button>
-                    </div>
-
-                    <!-- Media Bar (Left Sidebar) -->
-                    <div class="coursebuilder__media-bar">
-                        <button class="media-btn" data-media="images" title="Images">
-                            <div class="media-btn__icon">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M8.5,13.5L11,16.5L14.5,12L19,18H5M21,19V5C21,3.89 20.1,3 19,3H5A2,2 0 0,0 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19Z"/>
-                                </svg>
-                            </div>
-                            <span class="media-btn__label">Images</span>
-                        </button>
-
-                        <button class="media-btn" data-media="videos" title="Videos">
-                            <div class="media-btn__icon">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M17,10.5V7A1,1 0 0,0 16,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 17,17V13.5L21,17.5V6.5L17,10.5Z"/>
-                                </svg>
-                            </div>
-                            <span class="media-btn__label">Videos</span>
-                        </button>
-
-                        <button class="media-btn" data-media="audio" title="Audio">
-                            <div class="media-btn__icon">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z"/>
-                                </svg>
-                            </div>
-                            <span class="media-btn__label">Audio</span>
-                        </button>
-
-                        <button class="media-btn" data-media="templates" title="Templates">
-                            <div class="media-btn__icon">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M5,3C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H5M5,5H19V19H5V5Z"/>
-                                </svg>
-                            </div>
-                            <span class="media-btn__label">Templates</span>
-                        </button>
-                    </div>
-
-                    <!-- Media Search Panel -->
-                    <div class="coursebuilder__media-search">
-                        <div class="media-search">
-                            <h3 class="media-search__title">Media Library</h3>
-                            <input type="search" class="media-search__input" placeholder="Search media...">
-                            <div class="media-search__content">
-                                Select a media type from the sidebar to browse available content.
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Main Canvas Area (Layout Protected) -->
-                    <div class="coursebuilder__canvas" id="canvas-container">
-                        <!-- PixiJS canvas will be inserted here directly -->
-                        <div class="canvas-placeholder">
-                            <svg width="48" height="48" viewBox="0 0 24 24" fill="#ccc">
-                                <path d="M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6A2,2 0 0,1 10,4A2,2 0 0,1 12,2M21,9V7L15,1H5C3.89,1 3,1.89 3,3V21A2,2 0 0,0 5,23H19A2,2 0 0,0 21,21V9M19,9H14V4H19V9Z"/>
-                            </svg>
-                            <div class="canvas-placeholder__title">🔒 Layout-Protected Canvas</div>
-                            <div class="canvas-placeholder__subtitle">
-                                Draw within pedagogical areas only<br>
-                                <small>Layout structure cannot be erased</small>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Table of Contents Sidebar -->
-                    <div class="coursebuilder__toc">
-                        <div class="toc">
-                            <h3 class="toc__title">Pages</h3>
-                            <div class="toc__page">
-                                <div class="toc__page-header">
-                                    <span class="toc__page-name">Page 1</span>
-                                    <span class="toc__page-format">A4</span>
-                                </div>
-                                <div class="toc__page-preview">
-                                    <div class="toc__page-preview-content">Preview</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                  </div>
                 </div>
-            </article>
-        </section>
+              </div>
+              <div class="form__actions">
+                <div class="form__actions-row">
+                  <button
+                    type="submit"
+                    id="create-course-btn"
+                    class="button button--primary button--disabled"
+                    disabled
+                  >
+                    Create Course
+                  </button>
+                  <div
+                    class="course-code-display"
+                    id="course-code-display"
+                    style="display: none"
+                  >
+                    <div class="course-code-container">
+                      <span class="course-code-label">Course Code:</span>
+                      <span
+                        class="course-code-value"
+                        id="course-code-value"
+                      ></span>
+                      <button
+                        type="button"
+                        class="course-code-copy-btn"
+                        id="course-code-copy-btn"
+                        title="Copy course code"
+                      >
+                        <svg
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                        >
+                          <rect
+                            x="9"
+                            y="9"
+                            width="13"
+                            height="13"
+                            rx="2"
+                            ry="2"
+                          ></rect>
+                          <path
+                            d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                          ></path>
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div class="form__status" id="form-status"></div>
+              </div>
+            </form>
+          </section>
+        </article>
 
-        <!-- Preview Section (no aside navigation) -->
-        <section id="preview" class="section">
-            <article class="article article--active">
-                <section class="card">
-                    <p class="text">Course preview will be displayed here...</p>
-                </section>
-            </article>
-        </section>
+        <!-- Classification Article -->
+        <article id="classification" class="article">
+          <section class="card">
+            <form class="form" id="course-classification-form">
+              <!-- Row 1: Class Year + Curricular Framework -->
+              <div class="dropdown-group dropdown-group--classification-row">
+                <div class="form__group">
+                  <label class="form__label" for="class-year-dropdown"
+                    >Class Year</label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger"
+                      id="class-year-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select class year...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div
+                      class="dropdown__menu"
+                      role="listbox"
+                      id="class-year-menu"
+                    >
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input
+                    type="hidden"
+                    name="class_year"
+                    id="class-year-value"
+                  />
+                </div>
 
-        <!-- Launch Section (no aside navigation) -->
-        <section id="launch" class="section">
-            <article class="article article--active">
-                <section class="card">
-                    <p class="text">Course launch options will be available here...</p>
-                </section>
-            </article>
-        </section>
+                <div class="form__group">
+                  <label class="form__label" for="curricular-framework-dropdown"
+                    >Curricular Framework</label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger"
+                      id="curricular-framework-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select framework...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div
+                      class="dropdown__menu"
+                      role="listbox"
+                      id="curricular-framework-menu"
+                    >
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input
+                    type="hidden"
+                    name="curricular_framework"
+                    id="curricular-framework-value"
+                  />
+                </div>
+              </div>
+
+              <!-- Row 2: Domain + Subject + Topic + Subtopic -->
+              <div
+                class="dropdown-group dropdown-group--classification-row dropdown-group--with-arrows"
+              >
+                <div class="form__group">
+                  <label class="form__label" for="domain-dropdown"
+                    >Domain</label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger"
+                      id="domain-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select domain...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div class="dropdown__menu" role="listbox" id="domain-menu">
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input type="hidden" name="domain" id="domain-value" />
+                </div>
+
+                <div class="dropdown-arrow">→</div>
+
+                <div class="form__group">
+                  <label class="form__label" for="subject-dropdown"
+                    >Subject</label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger dropdown__trigger--disabled"
+                      id="subject-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                      disabled
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select domain first...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div
+                      class="dropdown__menu"
+                      role="listbox"
+                      id="subject-menu"
+                    >
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input type="hidden" name="subject" id="subject-value" />
+                </div>
+
+                <div class="dropdown-arrow">→</div>
+
+                <div class="form__group">
+                  <label class="form__label" for="topic-dropdown">Topic</label>
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger dropdown__trigger--disabled"
+                      id="topic-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                      disabled
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select subject first...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div class="dropdown__menu" role="listbox" id="topic-menu">
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input type="hidden" name="topic" id="topic-value" />
+                </div>
+
+                <div class="dropdown-arrow">→</div>
+
+                <div class="form__group">
+                  <label class="form__label" for="subtopic-dropdown"
+                    >Subtopic
+                    <span class="text text--muted">(Optional)</span></label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger dropdown__trigger--disabled"
+                      id="subtopic-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                      disabled
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select topic first...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div
+                      class="dropdown__menu"
+                      role="listbox"
+                      id="subtopic-menu"
+                    >
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input type="hidden" name="subtopic" id="subtopic-value" />
+                </div>
+              </div>
+
+              <!-- Row 3: Course Sequence -->
+              <div class="dropdown-group dropdown-group--classification-row">
+                <div class="form__group">
+                  <label class="form__label" for="previous-course-dropdown"
+                    >Previous Course
+                    <span class="text text--muted">(Optional)</span></label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger"
+                      id="previous-course-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select previous course...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div
+                      class="dropdown__menu"
+                      role="listbox"
+                      id="previous-course-menu"
+                    >
+                      <div class="dropdown__option dropdown__option--header">
+                        Your Courses
+                      </div>
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input
+                    type="hidden"
+                    name="previous_course"
+                    id="previous-course-value"
+                  />
+                </div>
+
+                <div class="form__group">
+                  <label class="form__label" for="current-course-dropdown"
+                    >Current Course
+                    <span class="text text--muted">(Optional)</span></label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger"
+                      id="current-course-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select current course...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div
+                      class="dropdown__menu"
+                      role="listbox"
+                      id="current-course-menu"
+                    >
+                      <div class="dropdown__option dropdown__option--header">
+                        Your Courses
+                      </div>
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input
+                    type="hidden"
+                    name="current_course"
+                    id="current-course-value"
+                  />
+                </div>
+
+                <div class="form__group">
+                  <label class="form__label" for="next-course-dropdown"
+                    >Next Course
+                    <span class="text text--muted">(Optional)</span></label
+                  >
+                  <div class="dropdown dropdown--classification">
+                    <button
+                      type="button"
+                      class="dropdown__trigger"
+                      id="next-course-dropdown"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                    >
+                      <span class="dropdown__label dropdown__label--placeholder"
+                        >Select next course...</span
+                      >
+                      <span class="dropdown__icon">▼</span>
+                    </button>
+                    <div
+                      class="dropdown__menu"
+                      role="listbox"
+                      id="next-course-menu"
+                    >
+                      <div class="dropdown__option dropdown__option--header">
+                        Your Courses
+                      </div>
+                      <!-- Options will be populated by JavaScript -->
+                    </div>
+                  </div>
+                  <input
+                    type="hidden"
+                    name="next_course"
+                    id="next-course-value"
+                  />
+                </div>
+              </div>
+
+              <!-- Last saved indicator -->
+              <div class="form__footer">
+                <div class="save-indicator" id="classification-last-saved">
+                  <span
+                    class="save-indicator__text"
+                    id="classification-save-status"
+                    >Changes will be saved automatically</span
+                  >
+                </div>
+              </div>
+            </form>
+          </section>
+        </article>
+
+        <!-- Templates Article -->
+        <article id="templates" class="article">
+          <section class="card">
+            <!-- Template Action Buttons -->
+            <div class="template-header">
+              <div class="template-header__actions">
+                <button id="create-template-btn" class="button button--primary">
+                  <span class="button__icon">+</span>
+                  Create New Template
+                </button>
+                <button id="load-template-btn" class="button button--secondary">
+                  <span class="button__icon">↗</span>
+                  Load Template
+                </button>
+              </div>
+            </div>
+
+            <!-- Template Builder Layout -->
+            <div class="template-layout">
+              <div class="template-config">
+                <div class="template-config-placeholder">
+                  <h3 class="heading heading--tertiary">
+                    Template Configuration
+                  </h3>
+                  <p class="text">
+                    Select or create a template to configure its settings.
+                  </p>
+                </div>
+              </div>
+              <div class="template-preview">
+                <div class="preview-container">
+                  <div class="preview-placeholder">
+                    <h4 class="preview-placeholder__title">
+                      No Template Selected
+                    </h4>
+                    <p class="preview-placeholder__text">
+                      Create a new template or select an existing one to see the
+                      preview here.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </article>
+
+        <!-- Create Template Modal -->
+        <div id="create-template-modal" class="modal" style="display: none">
+          <div class="modal__content">
+            <div class="modal__header">
+              <h2 class="modal__title">Create New Template</h2>
+              <button
+                class="modal__close"
+                type="button"
+                onclick="TemplateManager.hideCreateTemplateModal()"
+              >
+                &times;
+              </button>
+            </div>
+            <div class="modal__body">
+              <form id="create-template-form" class="form">
+                <div class="form__group">
+                  <label class="form__label" for="template-name"
+                    >Template Name*</label
+                  >
+                  <input
+                    type="text"
+                    id="template-name"
+                    name="template-name"
+                    class="form__input"
+                    required
+                    placeholder="Enter template name"
+                  />
+                </div>
+                <div class="form__group">
+                  <label class="form__label" for="template-type"
+                    >Template Type*</label
+                  >
+                  <select
+                    id="template-type"
+                    name="template-type"
+                    class="form__input"
+                    required
+                  >
+                    <option value="">Select template type</option>
+                    <option value="lesson">Lesson</option>
+                  </select>
+                </div>
+                <div class="form__group">
+                  <label class="form__label" for="template-description"
+                    >Description (Optional)</label
+                  >
+                  <textarea
+                    id="template-description"
+                    name="template-description"
+                    class="form__input"
+                    rows="3"
+                    placeholder="Describe your template..."
+                  ></textarea>
+                </div>
+                <div class="form__actions">
+                  <button
+                    type="button"
+                    class="btn btn--secondary modal__close"
+                    onclick="TemplateManager.hideCreateTemplateModal()"
+                  >
+                    Cancel
+                  </button>
+                  <button type="submit" class="btn btn--primary">
+                    Create Template
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <!-- Load Template Modal -->
+        <div id="load-template-modal" class="modal" style="display: none">
+          <div class="modal__content modal__content--large">
+            <div class="modal__header">
+              <h2 class="modal__title">Load Existing Template</h2>
+              <button
+                class="modal__close"
+                type="button"
+                onclick="TemplateManager.hideLoadTemplateModal()"
+              >
+                &times;
+              </button>
+            </div>
+            <div class="modal__body">
+              <div class="template-loader">
+                <div class="template-loader__search">
+                  <input
+                    type="text"
+                    id="template-search"
+                    class="form__input"
+                    placeholder="Search templates..."
+                  />
+                  <div class="template-filters">
+                    <select
+                      id="template-type-filter"
+                      class="form__input form__input--small"
+                    >
+                      <option value="">All Types</option>
+                      <option value="lesson">Lesson</option>
+                    </select>
+                    <select
+                      id="template-sort"
+                      class="form__input form__input--small"
+                    >
+                      <option value="created_at">Newest First</option>
+                      <option value="name">Name (A-Z)</option>
+                      <option value="modified_at">Recently Modified</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="template-list-container">
+                  <div
+                    id="template-loading"
+                    class="template-loading"
+                    style="display: none"
+                  >
+                    <div class="loading-spinner"></div>
+                    <p>Loading your templates...</p>
+                  </div>
+                  <div id="template-list-content" class="template-list-grid">
+                    <!-- Templates will be loaded here -->
+                  </div>
+                  <div
+                    id="no-templates-message"
+                    class="no-templates"
+                    style="display: none"
+                  >
+                    <div class="no-templates__icon">!</div>
+                    <h3>No Templates Found</h3>
+                    <p>
+                      You haven't created any templates yet. Create your first
+                      template to get started!
+                    </p>
+                    <button
+                      class="button button--primary"
+                      onclick="TemplateManager.hideLoadTemplateModal(); TemplateManager.showCreateTemplateModal();"
+                    >
+                      Create First Template
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="modal__footer">
+              <button
+                type="button"
+                class="button button--secondary"
+                onclick="TemplateManager.hideLoadTemplateModal()"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                id="load-selected-template"
+                class="button button--primary"
+                disabled
+                onclick="TemplateManager.loadSelectedTemplate()"
+              >
+                Load Template
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Schedule Article -->
+        <article id="schedule" class="article">
+          <section class="card">
+            <!-- Schedule Layout -->
+            <div class="schedule-layout">
+              <!-- Schedule Configuration -->
+              <div id="schedule-config" class="schedule-config">
+                <h3 class="heading heading--tertiary">
+                  Schedule Configuration
+                </h3>
+
+                <form class="form">
+                  <!-- Date Range Row -->
+                  <div class="form__row">
+                    <div class="form__group">
+                      <label class="form__label" for="start-date"
+                        >Start Date</label
+                      >
+                      <input
+                        class="form__input"
+                        type="date"
+                        id="start-date"
+                        required
+                      />
+                    </div>
+                    <div class="form__group">
+                      <label class="form__label" for="end-date">End Date</label>
+                      <input
+                        class="form__input"
+                        type="date"
+                        id="end-date"
+                        required
+                      />
+                    </div>
+                  </div>
+
+                  <!-- Days of Week Selection -->
+                  <div class="form__group">
+                    <label class="form__label">Days of the Week</label>
+                    <div class="day-buttons">
+                      <button
+                        type="button"
+                        class="day-button"
+                        data-day="monday"
+                      >
+                        Mon
+                      </button>
+                      <button
+                        type="button"
+                        class="day-button"
+                        data-day="tuesday"
+                      >
+                        Tue
+                      </button>
+                      <button
+                        type="button"
+                        class="day-button"
+                        data-day="wednesday"
+                      >
+                        Wed
+                      </button>
+                      <button
+                        type="button"
+                        class="day-button"
+                        data-day="thursday"
+                      >
+                        Thu
+                      </button>
+                      <button
+                        type="button"
+                        class="day-button"
+                        data-day="friday"
+                      >
+                        Fri
+                      </button>
+                      <button
+                        type="button"
+                        class="day-button"
+                        data-day="saturday"
+                      >
+                        Sat
+                      </button>
+                      <button
+                        type="button"
+                        class="day-button"
+                        data-day="sunday"
+                      >
+                        Sun
+                      </button>
+                    </div>
+                  </div>
+
+                  <!-- Time Range Row -->
+                  <div class="form__row">
+                    <div class="form__group">
+                      <label class="form__label" for="start-time"
+                        >Start Time</label
+                      >
+                      <input
+                        class="form__input"
+                        type="time"
+                        id="start-time"
+                        required
+                      />
+                    </div>
+                    <div class="form__group">
+                      <label class="form__label" for="end-time">End Time</label>
+                      <input
+                        class="form__input"
+                        type="time"
+                        id="end-time"
+                        required
+                      />
+                    </div>
+                  </div>
+
+                  <!-- Schedule Action Buttons -->
+                  <div class="form__actions">
+                    <button
+                      type="button"
+                      id="schedule-course-btn"
+                      class="button button--primary button--disabled"
+                      disabled
+                    >
+                      Schedule Course
+                    </button>
+                    <button
+                      type="button"
+                      id="delete-schedule-btn"
+                      class="button button--danger hidden"
+                    >
+                      Delete Schedule
+                    </button>
+                  </div>
+                </form>
+              </div>
+
+              <!-- Schedule Preview -->
+              <div id="schedule-preview" class="schedule-preview hidden">
+                <h3 class="heading heading--tertiary">Schedule Preview</h3>
+
+                <div class="schedule-list-container">
+                  <div class="schedule-list-header">
+                    <span class="header-lesson">Lesson #</span>
+                    <span class="header-day">Day</span>
+                    <span class="header-start">Start Time</span>
+                    <span class="header-end">End Time</span>
+                    <span class="header-actions">Actions</span>
+                  </div>
+
+                  <div class="schedule-list">
+                    <!-- Schedule rows will be generated here -->
+                  </div>
+
+                  <div class="schedule-summary">
+                    <div class="total-lessons">Total lessons: 0</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </article>
+
+        <!-- Curriculum Article -->
+        <article id="curriculum" class="article">
+          <section class="card">
+            <!-- Curriculum Layout -->
+            <div class="curriculum-layout">
+              <!-- Curriculum Configuration -->
+              <div id="curriculum-config" class="curriculum-config">
+                <div class="content-load-section">
+                  <div id="content-load-display" class="content-load-display">
+                    <!-- Content load info will be displayed here -->
+                  </div>
+                </div>
+              </div>
+
+              <!-- Curriculum Preview -->
+              <div id="curriculum-preview" class="curriculum-preview hidden">
+                <div class="curriculum-preview-header">
+                  <!-- Preview Mode Buttons -->
+                  <div class="preview-mode-controls">
+                    <span class="preview-mode-label">Display:</span>
+                    <button
+                      type="button"
+                      class="preview-mode-btn active"
+                      data-mode="titles"
+                    >
+                      Lesson Titles
+                    </button>
+                    <button
+                      type="button"
+                      class="preview-mode-btn"
+                      data-mode="topics"
+                    >
+                      Lesson Topics
+                    </button>
+                    <button
+                      type="button"
+                      class="preview-mode-btn"
+                      data-mode="objectives"
+                    >
+                      Lesson Objectives
+                    </button>
+                  </div>
+                </div>
+
+                <div class="curriculum-preview-content">
+                  <!-- Curriculum content will be rendered here -->
+                </div>
+              </div>
+            </div>
+          </section>
+        </article>
+
+        <!-- Settings Article -->
+        <article id="settings" class="article">
+          <section class="card">
+            <!-- Margins Section -->
+            <div class="margins-section">
+              <h4 class="margins-title">Margins</h4>
+
+              <!-- Display Unit Selection -->
+              <div class="margins-unit-selection">
+                <span class="unit-label">Display in</span>
+                <div class="unit-toggle">
+                  <input
+                    type="radio"
+                    id="unit-inches"
+                    name="margin-unit"
+                    value="inches"
+                    class="unit-toggle__input"
+                  />
+                  <label for="unit-inches" class="unit-toggle__label"
+                    >Inches</label
+                  >
+
+                  <input
+                    type="radio"
+                    id="unit-centimeters"
+                    name="margin-unit"
+                    value="centimeters"
+                    class="unit-toggle__input"
+                    checked
+                  />
+                  <label for="unit-centimeters" class="unit-toggle__label"
+                    >Centimeters</label
+                  >
+                </div>
+              </div>
+
+              <!-- Margin Inputs Grid -->
+              <div class="margins-input-grid">
+                <div class="margin-input-item">
+                  <label class="margin-label" for="margin-top">Top</label>
+                  <div class="margin-input-group">
+                    <input
+                      class="margin-input"
+                      type="number"
+                      id="margin-top"
+                      name="margin_top"
+                      value="2.54"
+                      step="0.01"
+                      min="0"
+                    />
+                    <span class="margin-unit-display">cm</span>
+                  </div>
+                </div>
+
+                <div class="margin-input-item">
+                  <label class="margin-label" for="margin-bottom">Bottom</label>
+                  <div class="margin-input-group">
+                    <input
+                      class="margin-input"
+                      type="number"
+                      id="margin-bottom"
+                      name="margin_bottom"
+                      value="2.54"
+                      step="0.01"
+                      min="0"
+                    />
+                    <span class="margin-unit-display">cm</span>
+                  </div>
+                </div>
+
+                <div class="margin-input-item">
+                  <label class="margin-label" for="margin-left">Left</label>
+                  <div class="margin-input-group">
+                    <input
+                      class="margin-input"
+                      type="number"
+                      id="margin-left"
+                      name="margin_left"
+                      value="2.54"
+                      step="0.01"
+                      min="0"
+                    />
+                    <span class="margin-unit-display">cm</span>
+                  </div>
+                </div>
+
+                <div class="margin-input-item">
+                  <label class="margin-label" for="margin-right">Right</label>
+                  <div class="margin-input-group">
+                    <input
+                      class="margin-input"
+                      type="number"
+                      id="margin-right"
+                      name="margin_right"
+                      value="2.54"
+                      step="0.01"
+                      min="0"
+                    />
+                    <span class="margin-unit-display">cm</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Save Status -->
+              <div class="margins-save-status">
+                <div class="save-indicator" id="margins-save-status">
+                  <span class="save-indicator__text"
+                    >Margins will be saved automatically</span
+                  >
+                </div>
+              </div>
+            </div>
+
+            <!-- Course Visibility Settings -->
+
+            <!-- Course Visibility Settings -->
+            <div class="course-settings-section">
+              <form class="settings-form">
+                <div class="settings-checkbox-group">
+                  <div class="settings-checkbox-item">
+                    <input
+                      class="settings-checkbox"
+                      type="checkbox"
+                      id="course-visible"
+                    />
+                    <label class="settings-checkbox-label" for="course-visible"
+                      >Course visible to students</label
+                    >
+                  </div>
+                  <div class="settings-checkbox-item">
+                    <input
+                      class="settings-checkbox"
+                      type="checkbox"
+                      id="allow-enrollment"
+                    />
+                    <label
+                      class="settings-checkbox-label"
+                      for="allow-enrollment"
+                      >Allow new enrollments</label
+                    >
+                  </div>
+                  <div class="settings-checkbox-item">
+                    <input
+                      class="settings-checkbox"
+                      type="checkbox"
+                      id="require-approval"
+                    />
+                    <label
+                      class="settings-checkbox-label"
+                      for="require-approval"
+                      >Require enrollment approval</label
+                    >
+                  </div>
+                </div>
+              </form>
+            </div>
+
+            <div class="danger-zone">
+              <h3 class="danger-zone-title">Danger Zone</h3>
+              <p class="danger-zone-text">
+                Once you delete a course, there is no going back. Please be
+                certain.
+              </p>
+              <button class="danger-zone-button">Delete Course</button>
+            </div>
+          </section>
+        </article>
+
+        <!-- Marketplace Article -->
+        <article id="marketplace" class="article">
+          <section class="card">
+            <p class="text">
+              Marketplace integration features will be available here...
+            </p>
+          </section>
+        </article>
+
+        <!-- Resources Article -->
+        <article id="resources" class="article">
+          <section class="card"></section>
+        </article>
+      </section>
+
+      <!-- Create Section (no aside navigation) -->
+      <section id="create" class="section">
+        <article class="article article--active">
+          <!-- Course Builder Layout -->
+          <div class="coursebuilder">
+            <!-- Options Bar (Top Left - above media areas) -->
+            <div class="coursebuilder__options-bar">
+              <!-- This area can be used for general course options -->
+              <div class="course-options">
+                <span>Course Builder</span>
+              </div>
+            </div>
+
+            <!-- Canvas Toolbar (Top Center - above canvas) -->
+            <div class="coursebuilder__canvas-toolbar">
+              <div class="toolbar">
+                <div class="toolbar__tools">
+                  <!-- Drawing Tools -->
+                  <button
+                    class="tool tool--selected"
+                    data-tool="selection"
+                    title="Selection Tool"
+                  >
+                    <div class="tool__icon">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path d="m3 3 7.07 16.97 2.51-7.39 7.39-2.51L3 3z" />
+                      </svg>
+                    </div>
+                    <span class="tool__label">Select</span>
+                  </button>
+
+                  <button class="tool" data-tool="pen" title="Pen Tool">
+                    <div class="tool__icon">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path
+                          d="M20.71 7.04C21.1 6.65 21.1 6 20.71 5.63L18.37 3.29C18 2.9 17.35 2.9 16.96 3.29L15.12 5.12L18.87 8.87M3 17.25V21H6.75L17.81 9.93L14.06 6.18L3 17.25Z"
+                        />
+                      </svg>
+                    </div>
+                    <span class="tool__label">Pen</span>
+                  </button>
+
+                  <button
+                    class="tool"
+                    data-tool="highlighter"
+                    title="Highlighter Tool"
+                  >
+                    <div class="tool__icon">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path
+                          d="M18.5 1.15L20.85 3.5L17.5 6.85L15.15 4.5L18.5 1.15M12.5 6.15L14.85 8.5L4.85 18.5L2.5 16.15L12.5 6.15M22 23H2V21H22V23Z"
+                        />
+                      </svg>
+                    </div>
+                    <span class="tool__label">Highlight</span>
+                  </button>
+
+                  <button class="tool" data-tool="text" title="Text Tool">
+                    <div class="tool__icon">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path d="M5 4V7H10.5V19H13.5V7H19V4H5Z" />
+                      </svg>
+                    </div>
+                    <span class="tool__label">Text</span>
+                  </button>
+
+                  <button class="tool" data-tool="shapes" title="Shapes Tool">
+                    <div class="tool__icon">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path
+                          d="M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6A2,2 0 0,1 10,4A2,2 0 0,1 12,2M21,9V7L15,1H5C3.89,1 3,1.89 3,3V21A2,2 0 0,0 5,23H19A2,2 0 0,0 21,21V9M19,9H14V4H19V9Z"
+                        />
+                      </svg>
+                    </div>
+                    <span class="tool__label">Shapes</span>
+                  </button>
+
+                  <button class="tool" data-tool="eraser" title="Eraser Tool">
+                    <div class="tool__icon">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path
+                          d="M16.24 3.56L21.19 8.5C21.97 9.29 21.97 10.55 21.19 11.34L12 20.53C10.44 22.09 7.91 22.09 6.34 20.53L2.81 17C2.03 16.21 2.03 14.95 2.81 14.16L13.41 3.56C14.2 2.78 15.46 2.78 16.24 3.56M4.22 15.58L7.76 19.11C8.54 19.9 9.8 19.9 10.59 19.11L14.12 15.58L9.17 10.63L4.22 15.58Z"
+                        />
+                      </svg>
+                    </div>
+                    <span class="tool__label">Eraser</span>
+                  </button>
+                </div>
+
+                <!-- Tool Settings Panel -->
+                <div class="toolbar__settings">
+                  <!-- Pen Tool Settings -->
+                  <div class="tool-settings" data-tool="pen">
+                    <div class="settings-section">
+                      <span class="settings-section__label">Color:</span>
+                      <div class="color-palette">
+                        <div
+                          class="color-palette__color color-palette__color--active"
+                          data-color="#000000"
+                          style="background-color: #000000"
+                          title="Black"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#ff0000"
+                          style="background-color: #ff0000"
+                          title="Red"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#0066ff"
+                          style="background-color: #0066ff"
+                          title="Blue"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#00cc00"
+                          style="background-color: #00cc00"
+                          title="Green"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#ff6600"
+                          style="background-color: #ff6600"
+                          title="Orange"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#800080"
+                          style="background-color: #800080"
+                          title="Purple"
+                        ></div>
+                      </div>
+                    </div>
+                    <div class="settings-section">
+                      <span class="settings-section__label">Size:</span>
+                      <div class="size-slider">
+                        <input
+                          type="range"
+                          min="1"
+                          max="20"
+                          value="4"
+                          data-setting="size"
+                        />
+                        <span class="size-slider__value">4px</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Highlighter Tool Settings -->
+                  <div class="tool-settings" data-tool="highlighter">
+                    <div class="settings-section">
+                      <span class="settings-section__label">Color:</span>
+                      <div class="color-palette">
+                        <div
+                          class="color-palette__color color-palette__color--active"
+                          data-color="#ffff00"
+                          style="background-color: #ffff00"
+                          title="Yellow"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#00ffff"
+                          style="background-color: #00ffff"
+                          title="Cyan"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#ff69b4"
+                          style="background-color: #ff69b4"
+                          title="Pink"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#90ee90"
+                          style="background-color: #90ee90"
+                          title="Light Green"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#ffa500"
+                          style="background-color: #ffa500"
+                          title="Orange"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#dda0dd"
+                          style="background-color: #dda0dd"
+                          title="Plum"
+                        ></div>
+                      </div>
+                    </div>
+                    <div class="settings-section">
+                      <span class="settings-section__label">Size:</span>
+                      <div class="size-slider">
+                        <input
+                          type="range"
+                          min="10"
+                          max="50"
+                          value="20"
+                          data-setting="size"
+                        />
+                        <span class="size-slider__value">20px</span>
+                      </div>
+                    </div>
+                    <div class="settings-section">
+                      <span class="settings-section__label">Opacity:</span>
+                      <div class="size-slider">
+                        <input
+                          type="range"
+                          min="0.1"
+                          max="1"
+                          step="0.1"
+                          value="0.8"
+                          data-setting="opacity"
+                        />
+                        <span class="size-slider__value">80%</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Text Tool Settings -->
+                  <div class="tool-settings" data-tool="text">
+                    <div class="settings-section">
+                      <span class="settings-section__label">Font:</span>
+                      <select
+                        class="font-controls__select"
+                        data-setting="fontFamily"
+                      >
+                        <option value="Arial">Arial</option>
+                        <option value="Helvetica">Helvetica</option>
+                        <option value="Times New Roman">Times New Roman</option>
+                        <option value="Georgia">Georgia</option>
+                        <option value="Courier New">Courier New</option>
+                      </select>
+                    </div>
+                    <div class="settings-section">
+                      <span class="settings-section__label">Size:</span>
+                      <div class="size-slider">
+                        <input
+                          type="range"
+                          min="8"
+                          max="72"
+                          value="16"
+                          data-setting="fontSize"
+                        />
+                        <span class="size-slider__value">16px</span>
+                      </div>
+                    </div>
+                    <div class="settings-section">
+                      <span class="settings-section__label">Color:</span>
+                      <div class="color-palette">
+                        <div
+                          class="color-palette__color color-palette__color--active"
+                          data-color="#000000"
+                          style="background-color: #000000"
+                          title="Black"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#ff0000"
+                          style="background-color: #ff0000"
+                          title="Red"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#0066ff"
+                          style="background-color: #0066ff"
+                          title="Blue"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#00cc00"
+                          style="background-color: #00cc00"
+                          title="Green"
+                        ></div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Shapes Tool Settings -->
+                  <div class="tool-settings" data-tool="shapes">
+                    <div class="settings-section">
+                      <span class="settings-section__label">Shape:</span>
+                      <div class="shape-buttons">
+                        <button
+                          class="shape-btn shape-btn--active"
+                          data-shape="rectangle"
+                          title="Rectangle"
+                        >
+                          <svg viewBox="0 0 24 24" fill="currentColor">
+                            <rect
+                              x="3"
+                              y="6"
+                              width="18"
+                              height="12"
+                              rx="2"
+                              ry="2"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              fill="none"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          class="shape-btn"
+                          data-shape="triangle"
+                          title="Triangle"
+                        >
+                          <svg viewBox="0 0 24 24" fill="currentColor">
+                            <polygon
+                              points="12,3 21,18 3,18"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              fill="none"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          class="shape-btn"
+                          data-shape="circle"
+                          title="Circle"
+                        >
+                          <svg viewBox="0 0 24 24" fill="currentColor">
+                            <circle
+                              cx="12"
+                              cy="12"
+                              r="8"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              fill="none"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="settings-section">
+                      <span class="settings-section__label">Stroke:</span>
+                      <div class="color-palette">
+                        <div
+                          class="color-palette__color color-palette__color--active"
+                          data-color="#000000"
+                          style="background-color: #000000"
+                          title="Black"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#ff0000"
+                          style="background-color: #ff0000"
+                          title="Red"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#0066ff"
+                          style="background-color: #0066ff"
+                          title="Blue"
+                        ></div>
+                        <div
+                          class="color-palette__color"
+                          data-color="#00cc00"
+                          style="background-color: #00cc00"
+                          title="Green"
+                        ></div>
+                      </div>
+                    </div>
+                    <div class="settings-section">
+                      <span class="settings-section__label">Width:</span>
+                      <div class="size-slider">
+                        <input
+                          type="range"
+                          min="1"
+                          max="10"
+                          value="2"
+                          data-setting="strokeWidth"
+                        />
+                        <span class="size-slider__value">2px</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Eraser Tool Settings -->
+                  <div class="tool-settings" data-tool="eraser">
+                    <div class="settings-section">
+                      <span class="settings-section__label">Size:</span>
+                      <div class="size-slider">
+                        <input
+                          type="range"
+                          min="5"
+                          max="100"
+                          value="20"
+                          data-setting="size"
+                        />
+                        <span class="size-slider__value">20px</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Selection Tool Settings -->
+                  <div
+                    class="tool-settings tool-settings--active"
+                    data-tool="selection"
+                  >
+                    <div class="settings-section">
+                      <span class="settings-section__label"
+                        >Selection tool active</span
+                      >
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Table of Contents Options -->
+            <div class="coursebuilder__toc-options">
+              <button class="action-btn" title="Add Page">
+                <div class="action-btn__icon">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                  </svg>
+                </div>
+                <span class="action-btn__label">Add Page</span>
+              </button>
+
+              <button class="action-btn" title="Page Settings">
+                <div class="action-btn__icon">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.68 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
+                    />
+                  </svg>
+                </div>
+                <span class="action-btn__label">Settings</span>
+              </button>
+            </div>
+
+            <!-- Media Bar (Left Sidebar) -->
+            <div class="coursebuilder__media-bar">
+              <button class="media-btn" data-media="images" title="Images">
+                <div class="media-btn__icon">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M8.5,13.5L11,16.5L14.5,12L19,18H5M21,19V5C21,3.89 20.1,3 19,3H5A2,2 0 0,0 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19Z"
+                    />
+                  </svg>
+                </div>
+                <span class="media-btn__label">Images</span>
+              </button>
+
+              <button class="media-btn" data-media="videos" title="Videos">
+                <div class="media-btn__icon">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M17,10.5V7A1,1 0 0,0 16,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 17,17V13.5L21,17.5V6.5L17,10.5Z"
+                    />
+                  </svg>
+                </div>
+                <span class="media-btn__label">Videos</span>
+              </button>
+
+              <button class="media-btn" data-media="audio" title="Audio">
+                <div class="media-btn__icon">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z"
+                    />
+                  </svg>
+                </div>
+                <span class="media-btn__label">Audio</span>
+              </button>
+
+              <button
+                class="media-btn"
+                data-media="templates"
+                title="Templates"
+              >
+                <div class="media-btn__icon">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M5,3C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H5M5,5H19V19H5V5Z"
+                    />
+                  </svg>
+                </div>
+                <span class="media-btn__label">Templates</span>
+              </button>
+            </div>
+
+            <!-- Media Search Panel -->
+            <div class="coursebuilder__media-search">
+              <div class="media-search">
+                <h3 class="media-search__title">Media Library</h3>
+                <input
+                  type="search"
+                  class="media-search__input"
+                  placeholder="Search media..."
+                />
+                <div class="media-search__content">
+                  Select a media type from the sidebar to browse available
+                  content.
+                </div>
+              </div>
+            </div>
+
+            <!-- Main Canvas Area (Layout Protected) -->
+            <div class="coursebuilder__canvas" id="canvas-container">
+              <!-- PixiJS canvas will be inserted here directly -->
+              <div class="canvas-placeholder">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="#ccc">
+                  <path
+                    d="M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6A2,2 0 0,1 10,4A2,2 0 0,1 12,2M21,9V7L15,1H5C3.89,1 3,1.89 3,3V21A2,2 0 0,0 5,23H19A2,2 0 0,0 21,21V9M19,9H14V4H19V9Z"
+                  />
+                </svg>
+                <div class="canvas-placeholder__title">
+                  🔒 Layout-Protected Canvas
+                </div>
+                <div class="canvas-placeholder__subtitle">
+                  Draw within pedagogical areas only<br />
+                  <small>Layout structure cannot be erased</small>
+                </div>
+              </div>
+            </div>
+
+            <!-- Table of Contents Sidebar -->
+            <div class="coursebuilder__toc">
+              <div class="toc">
+                <h3 class="toc__title">Pages</h3>
+                <div class="toc__page">
+                  <div class="toc__page-header">
+                    <span class="toc__page-name">Page 1</span>
+                    <span class="toc__page-format">A4</span>
+                  </div>
+                  <div class="toc__page-preview">
+                    <div class="toc__page-preview-content">Preview</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <!-- Preview Section (no aside navigation) -->
+      <section id="preview" class="section">
+        <article class="article article--active">
+          <section class="card">
+            <p class="text">Course preview will be displayed here...</p>
+          </section>
+        </article>
+      </section>
+
+      <!-- Launch Section (no aside navigation) -->
+      <section id="launch" class="section">
+        <article class="article article--active">
+          <section class="card">
+            <p class="text">Course launch options will be available here...</p>
+          </section>
+        </article>
+      </section>
     </main>
 
-    <script type="module" src="/src/scripts/coursebuilder/devtools-setup.ts"></script>
+    <script
+      type="module"
+      src="/src/scripts/coursebuilder/devtools-setup.ts"
+    ></script>
     <script type="module" src="/src/scripts/app.ts"></script>
     <script type="module" src="/src/scripts/navigation/index.ts"></script>
     <script type="module" src="/src/scripts/backend/courses/index.ts"></script>
-    <script type="module" src="/src/scripts/backend/courses/classificationFormHandler.ts"></script>
-    <script type="module" src="/src/scripts/backend/courses/createTemplate.ts"></script>
-    <script type="module" src="/src/scripts/backend/courses/templates/templateConfigHandler.ts"></script>
-    <script type="module" src="/src/scripts/backend/courses/templates/templatePreviewHandler.ts"></script>
-    <script type="module" src="/src/scripts/backend/courses/scheduleCourse.ts"></script>
-    <script type="module" src="/src/scripts/backend/courses/marginSettings.ts"></script>
-</body>
+    <script
+      type="module"
+      src="/src/scripts/backend/courses/classificationFormHandler.ts"
+    ></script>
+    <script
+      type="module"
+      src="/src/scripts/backend/courses/createTemplate.ts"
+    ></script>
+    <script
+      type="module"
+      src="/src/scripts/backend/courses/templates/templateConfigHandler.ts"
+    ></script>
+    <script
+      type="module"
+      src="/src/scripts/backend/courses/templates/templatePreviewHandler.ts"
+    ></script>
+    <script
+      type="module"
+      src="/src/scripts/backend/courses/scheduleCourse.ts"
+    ></script>
+    <script
+      type="module"
+      src="/src/scripts/backend/courses/marginSettings.ts"
+    ></script>
+  </body>
 </html>

--- a/src/pages/teacher/courses.html
+++ b/src/pages/teacher/courses.html
@@ -1,89 +1,110 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Courses - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
 
-<body class="body grid">
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/src/pages/teacher/home.html" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/src/pages/teacher/home.html" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
 
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/teacher/courses.html" class="link link--nav link--active">My Courses</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#students" class="link link--nav">Students</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#assignments" class="link link--nav">Assignments</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#analytics" class="link link--nav">Analytics</a>
-                    </li>
-                </ul>
-            </div>
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a
+                href="/src/pages/teacher/courses.html"
+                class="link link--nav link--active"
+                >My Courses</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="#students" class="link link--nav">Students</a>
+            </li>
+            <li class="list__item">
+              <a href="#assignments" class="link link--nav">Assignments</a>
+            </li>
+            <li class="list__item">
+              <a href="#analytics" class="link link--nav">Analytics</a>
+            </li>
+          </ul>
+        </div>
 
-            <div class="nav__actions-section">
-                <button id="logout-btn" class="button button--secondary">Sign Out</button>
-            </div>
-        </nav>
+        <div class="nav__actions-section">
+          <button id="logout-btn" class="button button--secondary">
+            Sign Out
+          </button>
+        </div>
+      </nav>
     </header>
 
     <main class="main grid__main">
-        <div class="courses-header">
-            <h1 class="heading heading--primary">My Courses</h1>
-            <a href="/src/pages/teacher/coursebuilder.html#setup" id="create-course-btn" class="button button--primary">Create New Course</a>
+      <div class="courses-header">
+        <h1 class="heading heading--primary">My Courses</h1>
+        <a
+          href="/src/pages/teacher/coursebuilder.html#setup"
+          id="create-course-btn"
+          class="button button--primary"
+          >Create New Course</a
+        >
+      </div>
+
+      <div class="courses-container" id="courses-container">
+        <!-- Course cards will be dynamically loaded here -->
+        <div id="no-courses-message" class="no-courses">
+          <p class="text text--muted">
+            No courses yet. Create your first course to get started!
+          </p>
         </div>
-        
-        <div class="courses-container" id="courses-container">
-            <!-- Course cards will be dynamically loaded here -->
-            <div id="no-courses-message" class="no-courses">
-                <p class="text text--muted">No courses yet. Create your first course to get started!</p>
-            </div>
-        </div>
+      </div>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/src/pages/teacher/home.html" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo"
-                        class="logo__image logo__image--small">
-                </a>
-            </div>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/src/pages/teacher/home.html" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
 
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
-    <script type="module" src="/src/scripts/backend/courses/createCourseCard.ts"></script>
-</body>
-
+    <script
+      type="module"
+      src="/src/scripts/backend/courses/createCourseCard.ts"
+    ></script>
+  </body>
 </html>

--- a/src/pages/teacher/home.html
+++ b/src/pages/teacher/home.html
@@ -1,409 +1,516 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Teacher Dashboard - Neptino</title>
-    <link rel="stylesheet" href="/src/scss/main.scss">
-</head>
-<body class="body grid">
+    <link rel="stylesheet" href="/src/scss/main.scss" />
+  </head>
+  <body class="body grid">
     <header class="header grid__header">
-        <nav class="nav">
-            <div class="nav__logo-section">
-                <a href="/src/pages/teacher/home.html" class="logo logo--header">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav">
-                    <li class="list__item">
-                        <a href="/src/pages/teacher/courses.html" class="link link--nav">My Courses</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#students" class="link link--nav">Students</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#assignments" class="link link--nav">Assignments</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#analytics" class="link link--nav">Analytics</a>
-                    </li>
-                </ul>
-            </div>
-            
-            <div class="nav__actions-section">
-                <button id="logout-btn" class="button button--secondary">Sign Out</button>
-            </div>
-        </nav>
+      <nav class="nav">
+        <div class="nav__logo-section">
+          <a href="/src/pages/teacher/home.html" class="logo logo--header">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav">
+            <li class="list__item">
+              <a href="/src/pages/teacher/courses.html" class="link link--nav"
+                >My Courses</a
+              >
+            </li>
+            <li class="list__item">
+              <a href="#students" class="link link--nav">Students</a>
+            </li>
+            <li class="list__item">
+              <a href="#assignments" class="link link--nav">Assignments</a>
+            </li>
+            <li class="list__item">
+              <a href="#analytics" class="link link--nav">Analytics</a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="nav__actions-section">
+          <button id="logout-btn" class="button button--secondary">
+            Sign Out
+          </button>
+        </div>
+      </nav>
     </header>
- 
+
     <main class="main grid__main">
-        <aside class="aside">
-            <nav class="aside__nav">
-                <ul class="aside__menu">
-                    <li class="aside__item">
-                        <a href="#home" class="aside__link aside__link--active" data-section="home">Home</a>
-                    </li>
-                    <li class="aside__item">
-                        <a href="#courses" class="aside__link" data-section="courses">Courses</a>
-                    </li>
-                    <li class="aside__item">
-                        <a href="#subscription" class="aside__link" data-section="subscription">Subscription</a>
-                    </li>
-                    <li class="aside__item">
-                        <a href="#settings" class="aside__link" data-section="settings">Settings</a>
-                    </li>
-                </ul>
-            </nav>
-        </aside>
-        <!-- Home Section -->
-        <article id="home" class="article article--active">
-            <section class="card">
-          
-                    <h2 class="heading heading--secondary">Welcome Back!</h2>
-            
-                <p class="text">Here's what's happening with your courses today.</p>
-                <ul class="metrics">
-                    <li class="metric">
-                        <span class="metric__number">5</span>
-                        <span class="metric__label">Active Courses</span>
-                    </li>
-                    <li class="metric">
-                        <span class="metric__number">127</span>
-                        <span class="metric__label">Total Students</span>
-                    </li>
-                    <li class="metric">
-                        <span class="metric__number">12</span>
-                        <span class="metric__label">Pending Reviews</span>
-                    </li>
-                </ul>
-            </section>            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Recent Activity</h2>
-                </header>
-                <p class="text">Latest submissions and student activities.</p>
-                <ul class="activity-list list">
-                    <li class="list__item">
-                        <span class="activity__icon"></span>
-                        <h4>New submission: HTML Assignment</h4>
-                        <span class="text text--secondary text--small">30 minutes ago</span>
-                    </li>
-                    <li class="list__item">
-                        <span class="activity__icon"></span>
-                        <h4>Student question in Programming 101</h4>
-                        <span class="text text--secondary text--small">2 hours ago</span>
-                    </li>
-                    <li class="list__item">
-                        <span class="activity__icon"></span>
-                        <h4>Assignment graded: JavaScript Basics</h4>
-                        <span class="text text--secondary text--small">4 hours ago</span>
-                    </li>
-                    <li class="list__item">
-                        <span class="activity__icon"></span>
-                        <h4>New student enrolled: Web Development</h4>
-                        <span class="text text--secondary text--small">1 day ago</span>
-                    </li>
-                </ul>
-                <footer class="card__footer">
-                    <a href="#" class="button button--primary">View All Activity</a>
-                </footer>
-            </section>
+      <aside class="aside">
+        <nav class="aside__nav">
+          <ul class="aside__menu">
+            <li class="aside__item">
+              <a
+                href="#home"
+                class="aside__link aside__link--active"
+                data-section="home"
+                >Home</a
+              >
+            </li>
+            <li class="aside__item">
+              <a href="#courses" class="aside__link" data-section="courses"
+                >Courses</a
+              >
+            </li>
+            <li class="aside__item">
+              <a
+                href="#subscription"
+                class="aside__link"
+                data-section="subscription"
+                >Subscription</a
+              >
+            </li>
+            <li class="aside__item">
+              <a href="#settings" class="aside__link" data-section="settings"
+                >Settings</a
+              >
+            </li>
+          </ul>
+        </nav>
+      </aside>
+      <!-- Home Section -->
+      <article id="home" class="article article--active">
+        <section class="card">
+          <h2 class="heading heading--secondary">Welcome Back!</h2>
 
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Quick Actions</h2>
-                </header>
-                <ul class="quick-actions">
-                    <li><button class="button button--primary">Create Assignment</button></li>
-                    <li><button class="button button--secondary">Grade Submissions</button></li>
-                    <li><button class="button button--secondary">Message Students</button></li>
-                    <li><button class="button button--secondary">View Analytics</button></li>
-                </ul>
-            </section>
-        </article>
+          <p class="text">Here's what's happening with your courses today.</p>
+          <ul class="metrics">
+            <li class="metric">
+              <span class="metric__number">5</span>
+              <span class="metric__label">Active Courses</span>
+            </li>
+            <li class="metric">
+              <span class="metric__number">127</span>
+              <span class="metric__label">Total Students</span>
+            </li>
+            <li class="metric">
+              <span class="metric__number">12</span>
+              <span class="metric__label">Pending Reviews</span>
+            </li>
+          </ul>
+        </section>
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Recent Activity</h2>
+          </header>
+          <p class="text">Latest submissions and student activities.</p>
+          <ul class="activity-list list">
+            <li class="list__item">
+              <span class="activity__icon"></span>
+              <h4>New submission: HTML Assignment</h4>
+              <span class="text text--secondary text--small"
+                >30 minutes ago</span
+              >
+            </li>
+            <li class="list__item">
+              <span class="activity__icon"></span>
+              <h4>Student question in Programming 101</h4>
+              <span class="text text--secondary text--small">2 hours ago</span>
+            </li>
+            <li class="list__item">
+              <span class="activity__icon"></span>
+              <h4>Assignment graded: JavaScript Basics</h4>
+              <span class="text text--secondary text--small">4 hours ago</span>
+            </li>
+            <li class="list__item">
+              <span class="activity__icon"></span>
+              <h4>New student enrolled: Web Development</h4>
+              <span class="text text--secondary text--small">1 day ago</span>
+            </li>
+          </ul>
+          <footer class="card__footer">
+            <a href="#" class="button button--primary">View All Activity</a>
+          </footer>
+        </section>
 
-        <!-- Courses Section -->
-        <article id="courses" class="article">
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">My Courses</h2>
-                </header>
-                <p class="text">Create and manage your teaching courses.</p>
-                <ul class="metrics">
-                    <li class="metric">
-                        <span class="metric__number">5</span>
-                        <span class="metric__label">Active Courses</span>
-                    </li>
-                    <li class="metric">
-                        <span class="metric__number">127</span>
-                        <span class="metric__label">Enrolled Students</span>
-                    </li>
-                </ul>
-                <ul class="course-list list">
-                    <li class="list__item">
-                        <h3>Introduction to Programming</h3>
-                        <span class="text text--secondary">45 students</span>
-                        <ul class="button-group">
-                            <li><button class="button button--small">Edit</button></li>
-                            <li><button class="button button--small button--secondary">View</button></li>
-                        </ul>
-                    </li>
-                    <li class="list__item">
-                        <h3>Web Development Fundamentals</h3>
-                        <span class="text text--secondary">32 students</span>
-                        <ul class="button-group">
-                            <li><button class="button button--small">Edit</button></li>
-                            <li><button class="button button--small button--secondary">View</button></li>
-                        </ul>
-                    </li>
-                    <li class="list__item">
-                        <h3>Advanced JavaScript</h3>
-                        <span class="text text--secondary">28 students</span>
-                        <ul class="button-group">
-                            <li><button class="button button--small">Edit</button></li>
-                            <li><button class="button button--small button--secondary">View</button></li>
-                        </ul>
-                    </li>
-                </ul>
-                <footer class="card__footer">
-                    <a href="#" class="button button--primary">Create New Course</a>
-                    <a href="#" class="button button--secondary">Import Course</a>
-                </footer>
-            </section>
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Student Progress</h2>
-                </header>
-                <p class="text">Monitor your students' learning progress and performance.</p>
-                <ul class="metrics">
-                    <li class="metric">
-                        <span class="metric__number">78%</span>
-                        <span class="metric__label">Avg. Completion</span>
-                    </li>
-                    <li class="metric">
-                        <span class="metric__number">4.2</span>
-                        <span class="metric__label">Avg. Rating</span>
-                    </li>
-                </ul>
-                <footer class="card__footer">
-                    <a href="#students" class="button button--primary">View All Students</a>
-                </footer>
-            </section>
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Assignment Management</h2>
-                </header>
-                <p class="text">Create and grade assignments for your students.</p>
-                <ul class="metrics">
-                    <li class="metric">
-                        <span class="metric__number">12</span>
-                        <span class="metric__label">Pending Reviews</span>
-                    </li>
-                    <li class="metric">
-                        <span class="metric__number">8</span>
-                        <span class="metric__label">Due This Week</span>
-                    </li>
-                </ul>
-                <footer class="card__footer">
-                    <a href="#assignments" class="button button--primary">Manage Assignments</a>
-                    <a href="#" class="button button--secondary">Create Assignment</a>
-                </footer>
-            </section>
-        </article>
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Quick Actions</h2>
+          </header>
+          <ul class="quick-actions">
+            <li>
+              <button class="button button--primary">Create Assignment</button>
+            </li>
+            <li>
+              <button class="button button--secondary">
+                Grade Submissions
+              </button>
+            </li>
+            <li>
+              <button class="button button--secondary">Message Students</button>
+            </li>
+            <li>
+              <button class="button button--secondary">View Analytics</button>
+            </li>
+          </ul>
+        </section>
+      </article>
 
-        <!-- Subscription Section -->
-        <article id="subscription" class="article">
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Current Plan</h2>
-                </header>
-                <section class="subscription subscription--pro">
-                    <h3 class="subscription__plan">Teacher Pro Plan</h3>
-                    <p class="subscription__price">$29.99/month</p>
-                    <p class="subscription__status">Active until March 15, 2026</p>
-                </section>
-                <section class="subscription__features">
-                    <h4>Plan Features:</h4>
-                    <ul class="list">
-                        <li class="list__item">Unlimited courses</li>
-                        <li class="list__item">Up to 200 students per course</li>
-                        <li class="list__item">Advanced analytics</li>
-                        <li class="list__item">Priority support</li>
-                        <li class="list__item">Custom branding</li>
-                    </ul>
-                </section>
-                <footer class="card__footer">
-                    <button class="button button--primary">Upgrade Plan</button>
-                    <button class="button button--secondary">Change Plan</button>
-                </footer>
-            </section>
+      <!-- Courses Section -->
+      <article id="courses" class="article">
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">My Courses</h2>
+          </header>
+          <p class="text">Create and manage your teaching courses.</p>
+          <ul class="metrics">
+            <li class="metric">
+              <span class="metric__number">5</span>
+              <span class="metric__label">Active Courses</span>
+            </li>
+            <li class="metric">
+              <span class="metric__number">127</span>
+              <span class="metric__label">Enrolled Students</span>
+            </li>
+          </ul>
+          <ul class="course-list list">
+            <li class="list__item">
+              <h3>Introduction to Programming</h3>
+              <span class="text text--secondary">45 students</span>
+              <ul class="button-group">
+                <li><button class="button button--small">Edit</button></li>
+                <li>
+                  <button class="button button--small button--secondary">
+                    View
+                  </button>
+                </li>
+              </ul>
+            </li>
+            <li class="list__item">
+              <h3>Web Development Fundamentals</h3>
+              <span class="text text--secondary">32 students</span>
+              <ul class="button-group">
+                <li><button class="button button--small">Edit</button></li>
+                <li>
+                  <button class="button button--small button--secondary">
+                    View
+                  </button>
+                </li>
+              </ul>
+            </li>
+            <li class="list__item">
+              <h3>Advanced JavaScript</h3>
+              <span class="text text--secondary">28 students</span>
+              <ul class="button-group">
+                <li><button class="button button--small">Edit</button></li>
+                <li>
+                  <button class="button button--small button--secondary">
+                    View
+                  </button>
+                </li>
+              </ul>
+            </li>
+          </ul>
+          <footer class="card__footer">
+            <a href="#" class="button button--primary">Create New Course</a>
+            <a href="#" class="button button--secondary">Import Course</a>
+          </footer>
+        </section>
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Student Progress</h2>
+          </header>
+          <p class="text">
+            Monitor your students' learning progress and performance.
+          </p>
+          <ul class="metrics">
+            <li class="metric">
+              <span class="metric__number">78%</span>
+              <span class="metric__label">Avg. Completion</span>
+            </li>
+            <li class="metric">
+              <span class="metric__number">4.2</span>
+              <span class="metric__label">Avg. Rating</span>
+            </li>
+          </ul>
+          <footer class="card__footer">
+            <a href="#students" class="button button--primary"
+              >View All Students</a
+            >
+          </footer>
+        </section>
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Assignment Management</h2>
+          </header>
+          <p class="text">Create and grade assignments for your students.</p>
+          <ul class="metrics">
+            <li class="metric">
+              <span class="metric__number">12</span>
+              <span class="metric__label">Pending Reviews</span>
+            </li>
+            <li class="metric">
+              <span class="metric__number">8</span>
+              <span class="metric__label">Due This Week</span>
+            </li>
+          </ul>
+          <footer class="card__footer">
+            <a href="#assignments" class="button button--primary"
+              >Manage Assignments</a
+            >
+            <a href="#" class="button button--secondary">Create Assignment</a>
+          </footer>
+        </section>
+      </article>
 
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Usage Statistics</h2>
-                </header>
-                <ul class="usage-stats">
-                    <li class="progress-bar">
-                        <span class="progress-bar__label">Courses Created</span>
-                        <span class="progress-bar__track">
-                            <span class="progress-bar__fill" style="width: 25%"></span>
-                        </span>
-                        <span class="progress-bar__value">5 / 20</span>
-                    </li>
-                    <li class="progress-bar">
-                        <span class="progress-bar__label">Students Enrolled</span>
-                        <span class="progress-bar__track">
-                            <span class="progress-bar__fill" style="width: 63%"></span>
-                        </span>
-                        <span class="progress-bar__value">127 / 200</span>
-                    </li>
-                    <li class="progress-bar">
-                        <span class="progress-bar__label">Storage Used</span>
-                        <span class="progress-bar__track">
-                            <span class="progress-bar__fill" style="width: 45%"></span>
-                        </span>
-                        <span class="progress-bar__value">2.3GB / 5GB</span>
-                    </li>
-                </ul>
-            </section>
+      <!-- Subscription Section -->
+      <article id="subscription" class="article">
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Current Plan</h2>
+          </header>
+          <section class="subscription subscription--pro">
+            <h3 class="subscription__plan">Teacher Pro Plan</h3>
+            <p class="subscription__price">$29.99/month</p>
+            <p class="subscription__status">Active until March 15, 2026</p>
+          </section>
+          <section class="subscription__features">
+            <h4>Plan Features:</h4>
+            <ul class="list">
+              <li class="list__item">Unlimited courses</li>
+              <li class="list__item">Up to 200 students per course</li>
+              <li class="list__item">Advanced analytics</li>
+              <li class="list__item">Priority support</li>
+              <li class="list__item">Custom branding</li>
+            </ul>
+          </section>
+          <footer class="card__footer">
+            <button class="button button--primary">Upgrade Plan</button>
+            <button class="button button--secondary">Change Plan</button>
+          </footer>
+        </section>
 
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Billing History</h2>
-                </header>
-                <div class="billing">
-                    <div class="billing__item">
-                        <span class="text text--secondary">Feb 15, 2026</span>
-                        <span class="text">$29.99</span>
-                        <span class="badge badge--success">Paid</span>
-                    </div>
-                    <div class="billing__item">
-                        <span class="text text--secondary">Jan 15, 2026</span>
-                        <span class="text">$29.99</span>
-                        <span class="badge badge--success">Paid</span>
-                    </div>
-                    <div class="billing__item">
-                        <span class="text text--secondary">Dec 15, 2025</span>
-                        <span class="text">$29.99</span>
-                        <span class="badge badge--success">Paid</span>
-                    </div>
-                </div>
-                <footer class="card__footer">
-                    <button class="button button--secondary">Download Invoice</button>
-                    <button class="button button--secondary">Update Payment Method</button>
-                </footer>
-            </section>
-        </article>
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Usage Statistics</h2>
+          </header>
+          <ul class="usage-stats">
+            <li class="progress-bar">
+              <span class="progress-bar__label">Courses Created</span>
+              <span class="progress-bar__track">
+                <span class="progress-bar__fill" style="width: 25%"></span>
+              </span>
+              <span class="progress-bar__value">5 / 20</span>
+            </li>
+            <li class="progress-bar">
+              <span class="progress-bar__label">Students Enrolled</span>
+              <span class="progress-bar__track">
+                <span class="progress-bar__fill" style="width: 63%"></span>
+              </span>
+              <span class="progress-bar__value">127 / 200</span>
+            </li>
+            <li class="progress-bar">
+              <span class="progress-bar__label">Storage Used</span>
+              <span class="progress-bar__track">
+                <span class="progress-bar__fill" style="width: 45%"></span>
+              </span>
+              <span class="progress-bar__value">2.3GB / 5GB</span>
+            </li>
+          </ul>
+        </section>
 
-        <!-- Settings Section -->
-        <article id="settings" class="article">
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Profile Settings</h2>
-                </header>
-                <form class="form">
-                    <div class="form__group">
-                        <label class="form__label" for="first-name">First Name</label>
-                        <input class="form__input" type="text" id="first-name" value="John">
-                    </div>
-                    <div class="form__group">
-                        <label class="form__label" for="last-name">Last Name</label>
-                        <input class="form__input" type="text" id="last-name" value="Doe">
-                    </div>
-                    <div class="form__group">
-                        <label class="form__label" for="email">Email</label>
-                        <input class="form__input" type="email" id="email" value="john.doe@example.com">
-                    </div>
-                    <div class="form__group">
-                        <label class="form__label" for="bio">Bio</label>
-                        <textarea class="form__input" id="bio" rows="3">Experienced programming instructor with 10+ years in education.</textarea>
-                    </div>
-                </form>
-                <footer class="card__footer">
-                    <button class="button button--primary">Save Changes</button>
-                    <button class="button button--secondary">Cancel</button>
-                </footer>
-            </section>            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Notification Preferences</h2>
-                </header>
-                <form class="form">
-                    <div class="form__group form__group--checkbox">
-                        <input class="form__checkbox" type="checkbox" id="email-notifications" checked>
-                        <label class="form__label" for="email-notifications">Email notifications</label>
-                    </div>
-                    <div class="form__group form__group--checkbox">
-                        <input class="form__checkbox" type="checkbox" id="student-submissions" checked>
-                        <label class="form__label" for="student-submissions">New student submissions</label>
-                    </div>
-                    <div class="form__group form__group--checkbox">
-                        <input class="form__checkbox" type="checkbox" id="course-enrollments" checked>
-                        <label class="form__label" for="course-enrollments">Course enrollments</label>
-                    </div>
-                    <div class="form__group form__group--checkbox">
-                        <input class="form__checkbox" type="checkbox" id="weekly-reports">
-                        <label class="form__label" for="weekly-reports">Weekly progress reports</label>
-                    </div>
-                </form>
-                <footer class="card__footer">
-                    <button class="button button--primary">Update Preferences</button>
-                </footer>
-            </section>
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Billing History</h2>
+          </header>
+          <div class="billing">
+            <div class="billing__item">
+              <span class="text text--secondary">Feb 15, 2026</span>
+              <span class="text">$29.99</span>
+              <span class="badge badge--success">Paid</span>
+            </div>
+            <div class="billing__item">
+              <span class="text text--secondary">Jan 15, 2026</span>
+              <span class="text">$29.99</span>
+              <span class="badge badge--success">Paid</span>
+            </div>
+            <div class="billing__item">
+              <span class="text text--secondary">Dec 15, 2025</span>
+              <span class="text">$29.99</span>
+              <span class="badge badge--success">Paid</span>
+            </div>
+          </div>
+          <footer class="card__footer">
+            <button class="button button--secondary">Download Invoice</button>
+            <button class="button button--secondary">
+              Update Payment Method
+            </button>
+          </footer>
+        </section>
+      </article>
 
-            <section class="card">
-                <header class="card__header">
-                    <h2 class="heading heading--secondary">Security</h2>
-                </header>
-                <ul class="security">
-                    <li class="security__item">
-                        <h4>Change Password</h4>
-                        <p class="text text--small">Update your password to keep your account secure</p>
-                        <button class="button button--secondary">Change Password</button>
-                    </li>
-                    <li class="security__item">
-                        <h4>Two-Factor Authentication</h4>
-                        <p class="text text--small">Add an extra layer of security to your account</p>
-                        <button class="button button--secondary">Enable 2FA</button>
-                    </li>
-                    <li class="security__item">
-                        <h4>Login Sessions</h4>
-                        <p class="text text--small">Manage your active login sessions</p>
-                        <button class="button button--secondary">View Sessions</button>
-                    </li>
-                </ul>
-            </section>
-        </article>
+      <!-- Settings Section -->
+      <article id="settings" class="article">
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Profile Settings</h2>
+          </header>
+          <form class="form">
+            <div class="form__group">
+              <label class="form__label" for="first-name">First Name</label>
+              <input
+                class="form__input"
+                type="text"
+                id="first-name"
+                value="John"
+              />
+            </div>
+            <div class="form__group">
+              <label class="form__label" for="last-name">Last Name</label>
+              <input
+                class="form__input"
+                type="text"
+                id="last-name"
+                value="Doe"
+              />
+            </div>
+            <div class="form__group">
+              <label class="form__label" for="email">Email</label>
+              <input
+                class="form__input"
+                type="email"
+                id="email"
+                value="john.doe@example.com"
+              />
+            </div>
+            <div class="form__group">
+              <label class="form__label" for="bio">Bio</label>
+              <textarea class="form__input" id="bio" rows="3">
+Experienced programming instructor with 10+ years in education.</textarea
+              >
+            </div>
+          </form>
+          <footer class="card__footer">
+            <button class="button button--primary">Save Changes</button>
+            <button class="button button--secondary">Cancel</button>
+          </footer>
+        </section>
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Notification Preferences</h2>
+          </header>
+          <form class="form">
+            <div class="form__group form__group--checkbox">
+              <input
+                class="form__checkbox"
+                type="checkbox"
+                id="email-notifications"
+                checked
+              />
+              <label class="form__label" for="email-notifications"
+                >Email notifications</label
+              >
+            </div>
+            <div class="form__group form__group--checkbox">
+              <input
+                class="form__checkbox"
+                type="checkbox"
+                id="student-submissions"
+                checked
+              />
+              <label class="form__label" for="student-submissions"
+                >New student submissions</label
+              >
+            </div>
+            <div class="form__group form__group--checkbox">
+              <input
+                class="form__checkbox"
+                type="checkbox"
+                id="course-enrollments"
+                checked
+              />
+              <label class="form__label" for="course-enrollments"
+                >Course enrollments</label
+              >
+            </div>
+            <div class="form__group form__group--checkbox">
+              <input
+                class="form__checkbox"
+                type="checkbox"
+                id="weekly-reports"
+              />
+              <label class="form__label" for="weekly-reports"
+                >Weekly progress reports</label
+              >
+            </div>
+          </form>
+          <footer class="card__footer">
+            <button class="button button--primary">Update Preferences</button>
+          </footer>
+        </section>
+
+        <section class="card">
+          <header class="card__header">
+            <h2 class="heading heading--secondary">Security</h2>
+          </header>
+          <ul class="security">
+            <li class="security__item">
+              <h4>Change Password</h4>
+              <p class="text text--small">
+                Update your password to keep your account secure
+              </p>
+              <button class="button button--secondary">Change Password</button>
+            </li>
+            <li class="security__item">
+              <h4>Two-Factor Authentication</h4>
+              <p class="text text--small">
+                Add an extra layer of security to your account
+              </p>
+              <button class="button button--secondary">Enable 2FA</button>
+            </li>
+            <li class="security__item">
+              <h4>Login Sessions</h4>
+              <p class="text text--small">Manage your active login sessions</p>
+              <button class="button button--secondary">View Sessions</button>
+            </li>
+          </ul>
+        </section>
+      </article>
     </main>
 
     <footer class="footer grid__footer">
-        <nav class="nav nav--footer">
-            <div class="nav__logo-section">
-                <a href="/src/pages/teacher/home.html" class="logo logo--footer">
-                    <img src="/src/assets/logo/octopus-logo.png" alt="Neptino Logo" class="logo__image logo__image--small">
-                </a>
-            </div>
-            
-            <div class="nav__links-section">
-                <ul class="list list--nav list--footer">
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Privacy Policy</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Terms of Service</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Support</a>
-                    </li>
-                    <li class="list__item">
-                        <a href="#" class="link link--footer">Contact</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
+      <nav class="nav nav--footer">
+        <div class="nav__logo-section">
+          <a href="/src/pages/teacher/home.html" class="logo logo--footer">
+            <img
+              src="/src/assets/logo/octopus-logo.png"
+              alt="Neptino Logo"
+              class="logo__image logo__image--small"
+            />
+          </a>
+        </div>
+
+        <div class="nav__links-section">
+          <ul class="list list--nav list--footer">
+            <li class="list__item">
+              <a href="#" class="link link--footer">Privacy Policy</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Terms of Service</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Support</a>
+            </li>
+            <li class="list__item">
+              <a href="#" class="link link--footer">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
     </footer>
 
     <script type="module" src="/src/scripts/app.ts"></script>
     <script type="module" src="/src/scripts/navigation/index.ts"></script>
-</body>
+  </body>
 </html>

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -3,8 +3,8 @@
  * Main script that initializes the application and handles page-specific functionality
  */
 
-import { signIn, signUp, signOut, initAuth } from './backend/auth/auth'
-import { supabase } from './backend/supabase'
+import { signIn, signUp, signOut, initAuth } from "./backend/auth/auth";
+import { supabase } from "./backend/supabase";
 
 // Dynamically import coursebuilder only when needed
 // import { CourseBuilder } from './coursebuilder/index.js'
@@ -15,247 +15,265 @@ import { supabase } from './backend/supabase'
 // Initialize CourseBuilder if we're on the coursebuilder page
 async function initCourseBuilder() {
   // Check if we're on the coursebuilder page
-  if (window.location.pathname.includes('coursebuilder.html')) {
+  if (window.location.pathname.includes("coursebuilder.html")) {
     try {
       // Dynamically import CourseBuilder to reduce initial bundle size
-      const { CourseBuilder } = await import('./coursebuilder/coursebuilder.js');
-      
+      const { CourseBuilder } = await import(
+        "./coursebuilder/coursebuilder.js"
+      );
+
       function createCourseBuilder() {
-        console.log('🚀 Initializing CourseBuilder...')
-        const courseBuilder = new CourseBuilder()
-        
+        console.log("🚀 Initializing CourseBuilder...");
+        const courseBuilder = new CourseBuilder();
+
         // Extract course ID from session storage
-        const courseId = sessionStorage.getItem('currentCourseId');
-        
+        const courseId = sessionStorage.getItem("currentCourseId");
+
         if (courseId) {
           console.log(`📚 Setting course ID from session storage: ${courseId}`);
           courseBuilder.setCourseId(courseId);
         } else {
-          console.log('📚 No course ID found in session storage');
+          console.log("📚 No course ID found in session storage");
         }
-        
+
         // Expose for debugging and devtools
-        ;(window as any).courseBuilder = courseBuilder
+        (window as any).courseBuilder = courseBuilder;
       }
-      
+
       // Wait for DOM to be ready
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', createCourseBuilder)
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", createCourseBuilder);
       } else {
-        createCourseBuilder()
+        createCourseBuilder();
       }
     } catch (error) {
-      console.error('❌ Failed to load CourseBuilder:', error);
+      console.error("❌ Failed to load CourseBuilder:", error);
     }
   }
 }
 
 // Check if we're on a protected page that requires authentication
 function isProtectedPage() {
-  const path = window.location.pathname
-  return path.includes('/pages/student/') || 
-         path.includes('/pages/teacher/') || 
-         path.includes('/pages/admin/')
+  const path = window.location.pathname;
+  return (
+    path.includes("/pages/student/") ||
+    path.includes("/pages/teacher/") ||
+    path.includes("/pages/admin/")
+  );
 }
 
 // Always initialize auth state listener
 // The auth system is now smart about when to redirect
-initAuth()
+initAuth();
 
 // On protected pages, also check session immediately
 if (isProtectedPage()) {
-  console.log('📍 On protected page, checking session...')
+  console.log("📍 On protected page, checking session...");
   supabase.auth.getSession().then(({ data: { session } }) => {
     if (!session?.user) {
-      console.log('❌ No session on protected page, redirecting to signin')
-      window.location.href = '/src/pages/shared/signin.html'
+      console.log("❌ No session on protected page, redirecting to signin");
+      window.location.href = "/src/pages/shared/signin.html";
     } else {
-      console.log('✅ Valid session on protected page')
+      console.log("✅ Valid session on protected page");
     }
-  })
+  });
 }
 
 // Handle logout functionality
 function handleLogout() {
-  const logoutBtn = document.getElementById('logout-btn')
-  if (!logoutBtn) return
+  const logoutBtn = document.getElementById("logout-btn");
+  if (!logoutBtn) return;
 
-  logoutBtn.addEventListener('click', async (e) => {
-    e.preventDefault()
-    
+  logoutBtn.addEventListener("click", async (e) => {
+    e.preventDefault();
+
     try {
-      const result = await signOut()
+      const result = await signOut();
       if (result.success) {
         // Redirect to signin page
-        window.location.href = '/src/pages/shared/signin.html'
+        window.location.href = "/src/pages/shared/signin.html";
       } else {
-        console.error('Logout failed:', result.error)
+        console.error("Logout failed:", result.error);
         // Still redirect even if logout fails
-        window.location.href = '/src/pages/shared/signin.html'
+        window.location.href = "/src/pages/shared/signin.html";
       }
     } catch (error) {
-      console.error('Logout error:', error)
+      console.error("Logout error:", error);
       // Still redirect even if logout fails
-      window.location.href = '/src/pages/shared/signin.html'
+      window.location.href = "/src/pages/shared/signin.html";
     }
-  })
+  });
 }
 
 // Handle sign-in form
 function handleSignInForm() {
-  const form = document.getElementById('signin-form') as HTMLFormElement
-  if (!form) return
+  const form = document.getElementById("signin-form") as HTMLFormElement;
+  if (!form) return;
 
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault()
-    
-    const emailInput = document.getElementById('email') as HTMLInputElement
-    const passwordInput = document.getElementById('password') as HTMLInputElement
-    const submitButton = form.querySelector('button[type="submit"]') as HTMLButtonElement
-    
-    if (!emailInput || !passwordInput) return
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
 
-    const email = emailInput.value.trim()
-    const password = passwordInput.value
+    const emailInput = document.getElementById("email") as HTMLInputElement;
+    const passwordInput = document.getElementById(
+      "password",
+    ) as HTMLInputElement;
+    const submitButton = form.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+
+    if (!emailInput || !passwordInput) return;
+
+    const email = emailInput.value.trim();
+    const password = passwordInput.value;
 
     if (!email || !password) {
-      showError('Please fill in all fields')
-      return
+      showError("Please fill in all fields");
+      return;
     }
 
     // Disable submit button and show loading state
-    submitButton.disabled = true
-    submitButton.textContent = 'Signing in...'
+    submitButton.disabled = true;
+    submitButton.textContent = "Signing in...";
 
     try {
-      console.log('Sign in form submitted:', { email })
-      const result = await signIn(email, password)
-      console.log('Sign in result:', result)
-      
+      console.log("Sign in form submitted:", { email });
+      const result = await signIn(email, password);
+      console.log("Sign in result:", result);
+
       if (result.success) {
         // Success! The signIn function will handle the redirect
-        showSuccess('Sign in successful! Redirecting...')
+        showSuccess("Sign in successful! Redirecting...");
       } else {
-        showError(result.error || 'Sign in failed')
+        showError(result.error || "Sign in failed");
       }
     } catch (error) {
-      console.error('Sign in form error:', error)
-      showError('An unexpected error occurred')
+      console.error("Sign in form error:", error);
+      showError("An unexpected error occurred");
     } finally {
       // Re-enable submit button
-      submitButton.disabled = false
-      submitButton.textContent = 'Sign In'
+      submitButton.disabled = false;
+      submitButton.textContent = "Sign In";
     }
-  })
+  });
 }
 
 // Handle sign-up form
 function handleSignUpForm() {
-  const form = document.getElementById('signup-form') as HTMLFormElement
-  if (!form) return
+  const form = document.getElementById("signup-form") as HTMLFormElement;
+  if (!form) return;
 
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault()
-    
-    const firstNameInput = document.getElementById('first-name') as HTMLInputElement
-    const lastNameInput = document.getElementById('last-name') as HTMLInputElement
-    const emailInput = document.getElementById('email') as HTMLInputElement
-    const passwordInput = document.getElementById('password') as HTMLInputElement
-    const roleInput = document.getElementById('role') as HTMLSelectElement
-    const submitButton = form.querySelector('button[type="submit"]') as HTMLButtonElement
-    
-    if (!firstNameInput || !emailInput || !passwordInput || !roleInput) return
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
 
-    const firstName = firstNameInput.value.trim()
-    const lastName = lastNameInput?.value.trim() || ''
-    const email = emailInput.value.trim()
-    const password = passwordInput.value
-    const role = roleInput.value
+    const firstNameInput = document.getElementById(
+      "first-name",
+    ) as HTMLInputElement;
+    const lastNameInput = document.getElementById(
+      "last-name",
+    ) as HTMLInputElement;
+    const emailInput = document.getElementById("email") as HTMLInputElement;
+    const passwordInput = document.getElementById(
+      "password",
+    ) as HTMLInputElement;
+    const roleInput = document.getElementById("role") as HTMLSelectElement;
+    const submitButton = form.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+
+    if (!firstNameInput || !emailInput || !passwordInput || !roleInput) return;
+
+    const firstName = firstNameInput.value.trim();
+    const lastName = lastNameInput?.value.trim() || "";
+    const email = emailInput.value.trim();
+    const password = passwordInput.value;
+    const role = roleInput.value;
 
     if (!firstName || !email || !password || !role) {
-      showError('Please fill in all required fields')
-      return
+      showError("Please fill in all required fields");
+      return;
     }
 
     if (password.length < 6) {
-      showError('Password must be at least 6 characters long')
-      return
+      showError("Password must be at least 6 characters long");
+      return;
     }
 
     // Disable submit button and show loading state
-    submitButton.disabled = true
-    submitButton.textContent = 'Creating account...'
+    submitButton.disabled = true;
+    submitButton.textContent = "Creating account...";
 
     try {
-      const fullName = lastName ? `${firstName} ${lastName}` : firstName
-      const result = await signUp(email, password, fullName, role)
-      
+      const fullName = lastName ? `${firstName} ${lastName}` : firstName;
+      const result = await signUp(email, password, fullName, role);
+
       if (result.success) {
-        showSuccess('Account created successfully! Please check your email for verification.')
-        form.reset()
+        showSuccess(
+          "Account created successfully! Please check your email for verification.",
+        );
+        form.reset();
       } else {
-        showError(result.error || 'Sign up failed')
+        showError(result.error || "Sign up failed");
       }
     } catch (error) {
-      showError('An unexpected error occurred')
+      showError("An unexpected error occurred");
     } finally {
       // Re-enable submit button
-      submitButton.disabled = false
-      submitButton.textContent = 'Create Account'
+      submitButton.disabled = false;
+      submitButton.textContent = "Create Account";
     }
-  })
+  });
 }
 
 // Show error message
 function showError(message: string) {
   // Remove any existing messages
-  removeMessages()
-  
-  const errorDiv = document.createElement('div')
-  errorDiv.className = 'alert alert--error'
-  errorDiv.textContent = message
-  
-  const form = document.querySelector('.form')
+  removeMessages();
+
+  const errorDiv = document.createElement("div");
+  errorDiv.className = "alert alert--error";
+  errorDiv.textContent = message;
+
+  const form = document.querySelector(".form");
   if (form) {
-    form.insertBefore(errorDiv, form.firstChild)
+    form.insertBefore(errorDiv, form.firstChild);
   }
-  
+
   // Auto remove after 5 seconds
   setTimeout(() => {
-    errorDiv.remove()
-  }, 5000)
+    errorDiv.remove();
+  }, 5000);
 }
 
 // Show success message
 function showSuccess(message: string) {
   // Remove any existing messages
-  removeMessages()
-  
-  const successDiv = document.createElement('div')
-  successDiv.className = 'alert alert--success'
-  successDiv.textContent = message
-  
-  const form = document.querySelector('.form')
+  removeMessages();
+
+  const successDiv = document.createElement("div");
+  successDiv.className = "alert alert--success";
+  successDiv.textContent = message;
+
+  const form = document.querySelector(".form");
   if (form) {
-    form.insertBefore(successDiv, form.firstChild)
+    form.insertBefore(successDiv, form.firstChild);
   }
-  
+
   // Auto remove after 5 seconds
   setTimeout(() => {
-    successDiv.remove()
-  }, 5000)
+    successDiv.remove();
+  }, 5000);
 }
 
 // Remove existing messages
 function removeMessages() {
-  const existingMessages = document.querySelectorAll('.alert')
-  existingMessages.forEach(msg => msg.remove())
+  const existingMessages = document.querySelectorAll(".alert");
+  existingMessages.forEach((msg) => msg.remove());
 }
 
 // Initialize everything when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
-  handleSignInForm()
-  handleSignUpForm()
-  handleLogout()
-  initCourseBuilder()
-})
+document.addEventListener("DOMContentLoaded", () => {
+  handleSignInForm();
+  handleSignUpForm();
+  handleLogout();
+  initCourseBuilder();
+});

--- a/src/scripts/backend/auth/auth.ts
+++ b/src/scripts/backend/auth/auth.ts
@@ -3,12 +3,17 @@
  * Handles user sign up, sign in, sign out, and role-based redirects
  */
 
-import { supabase } from '../supabase'
+import { supabase } from "../supabase";
 
-let currentUser: any = null
+let currentUser: any = null;
 
 // Sign up new user
-export async function signUp(email: string, password: string, fullName: string, userRole: string) {
+export async function signUp(
+  email: string,
+  password: string,
+  fullName: string,
+  userRole: string,
+) {
   try {
     const { error } = await supabase.auth.signUp({
       email,
@@ -16,205 +21,211 @@ export async function signUp(email: string, password: string, fullName: string, 
       options: {
         data: {
           full_name: fullName,
-          user_role: userRole
-        }
-      }
-    })
+          user_role: userRole,
+        },
+      },
+    });
 
     if (error) {
-      return { success: false, error: error.message }
+      return { success: false, error: error.message };
     }
 
     // The database trigger will automatically create the user profile
     // No need to manually insert into users table anymore!
-    
-    return { success: true }
+
+    return { success: true };
   } catch (error) {
-    console.error('Unexpected error during sign up:', error)
-    return { success: false, error: 'An unexpected error occurred' }
+    console.error("Unexpected error during sign up:", error);
+    return { success: false, error: "An unexpected error occurred" };
   }
 }
 
 // Sign in existing user
 export async function signIn(email: string, password: string) {
   try {
-    console.log('Attempting to sign in user:', email)
-    
+    console.log("Attempting to sign in user:", email);
+
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
-      password
-    })
+      password,
+    });
 
-    console.log('📋 SignIn response - data:', data)
-    console.log('📋 SignIn response - error:', error)
+    console.log("📋 SignIn response - data:", data);
+    console.log("📋 SignIn response - error:", error);
 
     if (error) {
-      console.error('Sign in error:', error)
-      return { success: false, error: error.message }
+      console.error("Sign in error:", error);
+      return { success: false, error: error.message };
     }
 
     if (data.user) {
-      console.log('User signed in successfully:', data.user.id)
-      currentUser = data.user
-      
+      console.log("User signed in successfully:", data.user.id);
+      currentUser = data.user;
+
       // Don't redirect immediately - let the auth state listener handle it
       // This prevents the "connection refused" issue
-      console.log('✅ Sign in successful - auth state listener will handle redirect')
+      console.log(
+        "✅ Sign in successful - auth state listener will handle redirect",
+      );
     }
 
-    return { success: true }
+    return { success: true };
   } catch (error) {
-    console.error('Unexpected error during sign in:', error)
-    return { success: false, error: 'An unexpected error occurred' }
+    console.error("Unexpected error during sign in:", error);
+    return { success: false, error: "An unexpected error occurred" };
   }
 }
 
 // Sign out user
 export async function signOut() {
   try {
-    const { error } = await supabase.auth.signOut()
+    const { error } = await supabase.auth.signOut();
     if (error) {
-      return { success: false, error: error.message }
+      return { success: false, error: error.message };
     }
-    currentUser = null
-    return { success: true }
+    currentUser = null;
+    return { success: true };
   } catch (error) {
-    return { success: false, error: 'An unexpected error occurred' }
+    return { success: false, error: "An unexpected error occurred" };
   }
 }
 
 // Get current user
 export function getCurrentUser() {
-  return currentUser
+  return currentUser;
 }
 
 // Redirect based on user role
 export function redirectUser(userRole: string) {
-  console.log('🔄 Redirecting user with role:', userRole)
-  const origin = window.location.origin
-  console.log('🌐 Origin:', origin)
-  
+  console.log("🔄 Redirecting user with role:", userRole);
+  const origin = window.location.origin;
+  console.log("🌐 Origin:", origin);
+
   switch (userRole) {
-    case 'administrator':
-      const adminUrl = `${origin}/src/pages/admin/home.html`
-      console.log('🔗 Redirecting to admin:', adminUrl)
-      window.location.href = adminUrl
-      break
-    case 'teacher':
-      const teacherUrl = `${origin}/src/pages/teacher/home.html`
-      console.log('🔗 Redirecting to teacher:', teacherUrl)
-      window.location.href = teacherUrl
-      break
-    case 'student':
-      const studentUrl = `${origin}/src/pages/student/home.html`
-      console.log('🔗 Redirecting to student:', studentUrl)
-      window.location.href = studentUrl
-      break
+    case "administrator":
+      const adminUrl = `${origin}/src/pages/admin/home.html`;
+      console.log("🔗 Redirecting to admin:", adminUrl);
+      window.location.href = adminUrl;
+      break;
+    case "teacher":
+      const teacherUrl = `${origin}/src/pages/teacher/home.html`;
+      console.log("🔗 Redirecting to teacher:", teacherUrl);
+      window.location.href = teacherUrl;
+      break;
+    case "student":
+      const studentUrl = `${origin}/src/pages/student/home.html`;
+      console.log("🔗 Redirecting to student:", studentUrl);
+      window.location.href = studentUrl;
+      break;
     default:
-      console.warn('❌ Unknown role, defaulting to student:', userRole)
-      const defaultUrl = `${origin}/src/pages/student/home.html`
-      console.log('🔗 Redirecting to default (student):', defaultUrl)
-      window.location.href = defaultUrl
+      console.warn("❌ Unknown role, defaulting to student:", userRole);
+      const defaultUrl = `${origin}/src/pages/student/home.html`;
+      console.log("🔗 Redirecting to default (student):", defaultUrl);
+      window.location.href = defaultUrl;
   }
 }
 
 // Helper function to create user profile
 async function createUserProfile(user: any) {
   try {
-    console.log('🔧 Creating user profile for:', user.id)
-    
-    const userMetadata = user.user_metadata || {}
-    const fullName = userMetadata.full_name || user.email?.split('@')[0] || 'User'
-    const userRole = userMetadata.user_role || 'student'
-    
-    const nameParts = fullName.split(' ')
-    const firstName = nameParts[0] || ''
-    const lastName = nameParts.slice(1).join(' ') || ''
-    
-    const { error: insertError } = await supabase
-      .from('users')
-      .insert({
-        id: user.id,
-        first_name: firstName,
-        last_name: lastName,
-        email: user.email,
-        role: userRole
-      })
-    
+    console.log("🔧 Creating user profile for:", user.id);
+
+    const userMetadata = user.user_metadata || {};
+    const fullName =
+      userMetadata.full_name || user.email?.split("@")[0] || "User";
+    const userRole = userMetadata.user_role || "student";
+
+    const nameParts = fullName.split(" ");
+    const firstName = nameParts[0] || "";
+    const lastName = nameParts.slice(1).join(" ") || "";
+
+    const { error: insertError } = await supabase.from("users").insert({
+      id: user.id,
+      first_name: firstName,
+      last_name: lastName,
+      email: user.email,
+      role: userRole,
+    });
+
     if (!insertError) {
-      console.log('✅ Profile created successfully, redirecting to:', userRole)
-      redirectUser(userRole)
+      console.log("✅ Profile created successfully, redirecting to:", userRole);
+      redirectUser(userRole);
     } else {
-      console.error('❌ Failed to create profile:', insertError)
+      console.error("❌ Failed to create profile:", insertError);
       // Still redirect as fallback
-      redirectUser('student')
+      redirectUser("student");
     }
   } catch (error) {
-    console.error('❌ Unexpected error creating profile:', error)
-    redirectUser('student')
+    console.error("❌ Unexpected error creating profile:", error);
+    redirectUser("student");
   }
 }
 
 // Initialize auth state listener
 export function initAuth() {
   supabase.auth.onAuthStateChange(async (event, session) => {
-    console.log('🔐 Auth state change:', event, session?.user?.id)
-    
-    if (event === 'SIGNED_IN' && session?.user) {
-      currentUser = session.user
-      
+    console.log("🔐 Auth state change:", event, session?.user?.id);
+
+    if (event === "SIGNED_IN" && session?.user) {
+      currentUser = session.user;
+
       // Check current page context - ONLY redirect from actual signin/signup pages
-      const currentPath = window.location.pathname
-      console.log('Current path:', currentPath)
-      
+      const currentPath = window.location.pathname;
+      console.log("Current path:", currentPath);
+
       // ONLY redirect from signin and signup pages - nowhere else!
-      const shouldRedirect = currentPath.includes('/pages/shared/signin.html') ||
-                            currentPath.includes('/pages/shared/signup.html')
-      
+      const shouldRedirect =
+        currentPath.includes("/pages/shared/signin.html") ||
+        currentPath.includes("/pages/shared/signup.html");
+
       if (!shouldRedirect) {
-        console.log('✅ Not on signin/signup page, skipping auto-redirect')
-        return
+        console.log("✅ Not on signin/signup page, skipping auto-redirect");
+        return;
       }
-      
-      console.log('📍 On signin/signup page, proceeding with role-based redirect')
-      
+
+      console.log(
+        "📍 On signin/signup page, proceeding with role-based redirect",
+      );
+
       // Get role from user metadata - this is where the role is actually stored!
-      const userMetadata = session.user.user_metadata || {}
-      const userRole = userMetadata.user_role || 'student'
-      
-      console.log('📋 User metadata:', userMetadata)
-      console.log('� User role from metadata:', userRole)
-      
+      const userMetadata = session.user.user_metadata || {};
+      const userRole = userMetadata.user_role || "student";
+
+      console.log("📋 User metadata:", userMetadata);
+      console.log("� User role from metadata:", userRole);
+
       // Add a small delay to ensure everything is ready
       setTimeout(() => {
-        console.log('✅ Redirecting based on metadata role:', userRole)
-        redirectUser(userRole)
-      }, 500)
-      
-    } else if (event === 'SIGNED_OUT') {
-      currentUser = null
-      console.log('🚪 User signed out')
-      
+        console.log("✅ Redirecting based on metadata role:", userRole);
+        redirectUser(userRole);
+      }, 500);
+    } else if (event === "SIGNED_OUT") {
+      currentUser = null;
+      console.log("🚪 User signed out");
+
       // Only redirect to signin if we're on a protected page
-      const currentPath = window.location.pathname
-      const isProtectedPage = currentPath.includes('/pages/student/') || 
-                             currentPath.includes('/pages/teacher/') || 
-                             currentPath.includes('/pages/admin/')
-      
+      const currentPath = window.location.pathname;
+      const isProtectedPage =
+        currentPath.includes("/pages/student/") ||
+        currentPath.includes("/pages/teacher/") ||
+        currentPath.includes("/pages/admin/");
+
       if (isProtectedPage) {
-        console.log('📍 On protected page after sign out, redirecting to signin')
-        window.location.href = '/src/pages/shared/signin.html'
+        console.log(
+          "📍 On protected page after sign out, redirecting to signin",
+        );
+        window.location.href = "/src/pages/shared/signin.html";
       } else {
-        console.log('📍 Not on protected page, staying put')
+        console.log("📍 Not on protected page, staying put");
       }
     }
-  })
-  
+  });
+
   // Check if user is already signed in
   supabase.auth.getSession().then(({ data: { session } }) => {
     if (session?.user) {
-      currentUser = session.user
-      console.log('🔍 Found existing session for user:', session.user.id)
+      currentUser = session.user;
+      console.log("🔍 Found existing session for user:", session.user.id);
     }
-  })
+  });
 }

--- a/src/scripts/backend/courses/classificationFormHandler.ts
+++ b/src/scripts/backend/courses/classificationFormHandler.ts
@@ -15,14 +15,14 @@ import {
   ClassificationFormState,
   initializeClassificationFormState,
   updateClassificationFormState,
-  CourseClassificationData
-} from './classifyCourse';
+  CourseClassificationData,
+} from "./classifyCourse";
 
 export class ClassificationFormHandler {
   private formState: ClassificationFormState;
   private currentCourseId: string | null = null;
   private autoSaveTimeout: NodeJS.Timeout | null = null;
-  private lastSavedData: string = '';
+  private lastSavedData: string = "";
 
   constructor() {
     this.formState = initializeClassificationFormState();
@@ -34,39 +34,39 @@ export class ClassificationFormHandler {
   // ==========================================================================
 
   private async initialize(): Promise<void> {
-    console.log('Initializing Classification Form Handler');
-    
+    console.log("Initializing Classification Form Handler");
+
     try {
       // Get course ID from sessionStorage (set when course is created)
-      this.currentCourseId = sessionStorage.getItem('currentCourseId');
-      
+      this.currentCourseId = sessionStorage.getItem("currentCourseId");
+
       // Initialize classification data
       await initializeClassificationData();
-      
+
       // Setup form event listeners
       this.setupFormHandlers();
-      
+
       // Setup dropdown functionality
       this.setupDropdowns();
-      
+
       // Populate static dropdowns
       await this.populateStaticDropdowns();
-      
+
       // Load available courses for sequence dropdowns
       await this.populateAvailableCourses();
-      
+
       // Load existing classification if course exists
       if (this.currentCourseId) {
         await this.loadExistingClassification(this.currentCourseId);
-        this.updateSaveStatus('Loaded existing data');
+        this.updateSaveStatus("Loaded existing data");
       } else {
-        this.updateSaveStatus('Waiting for course creation...');
+        this.updateSaveStatus("Waiting for course creation...");
       }
-      
-      console.log('Classification Form Handler initialized successfully');
+
+      console.log("Classification Form Handler initialized successfully");
     } catch (error) {
-      console.error('Error initializing Classification Form Handler:', error);
-      this.updateSaveStatus('Error loading data', true);
+      console.error("Error initializing Classification Form Handler:", error);
+      this.updateSaveStatus("Error loading data", true);
     }
   }
 
@@ -76,18 +76,18 @@ export class ClassificationFormHandler {
 
   private setupDropdowns(): void {
     const dropdowns = [
-      'class-year',
-      'curricular-framework',
-      'domain',
-      'subject',
-      'topic',
-      'subtopic',
-      'previous-course',
-      'current-course',
-      'next-course'
+      "class-year",
+      "curricular-framework",
+      "domain",
+      "subject",
+      "topic",
+      "subtopic",
+      "previous-course",
+      "current-course",
+      "next-course",
     ];
 
-    dropdowns.forEach(dropdownId => {
+    dropdowns.forEach((dropdownId) => {
       this.setupSingleDropdown(dropdownId);
     });
   }
@@ -95,7 +95,9 @@ export class ClassificationFormHandler {
   private setupSingleDropdown(dropdownId: string): void {
     const trigger = document.getElementById(`${dropdownId}-dropdown`);
     const menu = document.getElementById(`${dropdownId}-menu`);
-    const hiddenInput = document.getElementById(`${dropdownId}-value`) as HTMLInputElement;
+    const hiddenInput = document.getElementById(
+      `${dropdownId}-value`,
+    ) as HTMLInputElement;
 
     if (!trigger || !menu || !hiddenInput) {
       console.warn(`Dropdown elements not found for: ${dropdownId}`);
@@ -103,22 +105,31 @@ export class ClassificationFormHandler {
     }
 
     // Toggle dropdown
-    trigger.addEventListener('click', (e) => {
+    trigger.addEventListener("click", (e) => {
       e.preventDefault();
       this.toggleDropdown(dropdownId);
     });
 
     // Handle option selection
-    menu.addEventListener('click', (e) => {
-      const option = (e.target as HTMLElement).closest('.dropdown__option') as HTMLElement;
-      if (option && !option.classList.contains('dropdown__option--disabled') && !option.classList.contains('dropdown__option--header')) {
+    menu.addEventListener("click", (e) => {
+      const option = (e.target as HTMLElement).closest(
+        ".dropdown__option",
+      ) as HTMLElement;
+      if (
+        option &&
+        !option.classList.contains("dropdown__option--disabled") &&
+        !option.classList.contains("dropdown__option--header")
+      ) {
         this.selectOption(dropdownId, option);
       }
     });
 
     // Close dropdown when clicking outside
-    document.addEventListener('click', (e) => {
-      if (!trigger.contains(e.target as Node) && !menu.contains(e.target as Node)) {
+    document.addEventListener("click", (e) => {
+      if (
+        !trigger.contains(e.target as Node) &&
+        !menu.contains(e.target as Node)
+      ) {
         this.closeDropdown(dropdownId);
       }
     });
@@ -130,18 +141,18 @@ export class ClassificationFormHandler {
 
     if (!trigger || !menu) return;
 
-    const isOpen = trigger.getAttribute('aria-expanded') === 'true';
-    
+    const isOpen = trigger.getAttribute("aria-expanded") === "true";
+
     // Close all other dropdowns first
     this.closeAllDropdowns();
 
     if (!isOpen) {
-      trigger.setAttribute('aria-expanded', 'true');
-      trigger.classList.add('dropdown__trigger--open');
-      menu.classList.add('dropdown__menu--open');
-      
-      const icon = trigger.querySelector('.dropdown__icon');
-      if (icon) icon.classList.add('dropdown__icon--open');
+      trigger.setAttribute("aria-expanded", "true");
+      trigger.classList.add("dropdown__trigger--open");
+      menu.classList.add("dropdown__menu--open");
+
+      const icon = trigger.querySelector(".dropdown__icon");
+      if (icon) icon.classList.add("dropdown__icon--open");
     }
   }
 
@@ -151,36 +162,38 @@ export class ClassificationFormHandler {
 
     if (!trigger || !menu) return;
 
-    trigger.setAttribute('aria-expanded', 'false');
-    trigger.classList.remove('dropdown__trigger--open');
-    menu.classList.remove('dropdown__menu--open');
-    
-    const icon = trigger.querySelector('.dropdown__icon');
-    if (icon) icon.classList.remove('dropdown__icon--open');
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.classList.remove("dropdown__trigger--open");
+    menu.classList.remove("dropdown__menu--open");
+
+    const icon = trigger.querySelector(".dropdown__icon");
+    if (icon) icon.classList.remove("dropdown__icon--open");
   }
 
   private closeAllDropdowns(): void {
-    const triggers = document.querySelectorAll('.dropdown__trigger');
-    triggers.forEach(trigger => {
-      const dropdownId = trigger.id.replace('-dropdown', '');
+    const triggers = document.querySelectorAll(".dropdown__trigger");
+    triggers.forEach((trigger) => {
+      const dropdownId = trigger.id.replace("-dropdown", "");
       this.closeDropdown(dropdownId);
     });
   }
 
   private selectOption(dropdownId: string, option: HTMLElement): void {
     const trigger = document.getElementById(`${dropdownId}-dropdown`);
-    const hiddenInput = document.getElementById(`${dropdownId}-value`) as HTMLInputElement;
-    const label = trigger?.querySelector('.dropdown__label');
+    const hiddenInput = document.getElementById(
+      `${dropdownId}-value`,
+    ) as HTMLInputElement;
+    const label = trigger?.querySelector(".dropdown__label");
 
     if (!trigger || !hiddenInput || !label) return;
 
-    const value = option.dataset.value || '';
-    const text = option.textContent?.trim() || '';
+    const value = option.dataset.value || "";
+    const text = option.textContent?.trim() || "";
 
     // Update UI
     hiddenInput.value = value;
     label.textContent = text;
-    label.classList.remove('dropdown__label--placeholder');
+    label.classList.remove("dropdown__label--placeholder");
 
     // Handle cascading updates for ISCED hierarchy
     this.handleCascadingUpdates(dropdownId, value);
@@ -189,7 +202,7 @@ export class ClassificationFormHandler {
     this.closeDropdown(dropdownId);
 
     // Mark as success
-    trigger.classList.add('dropdown__trigger--success');
+    trigger.classList.add("dropdown__trigger--success");
 
     // Trigger auto-save
     this.triggerAutoSave();
@@ -203,25 +216,37 @@ export class ClassificationFormHandler {
 
   private handleCascadingUpdates(dropdownId: string, value: string): void {
     switch (dropdownId) {
-      case 'domain':
-        this.formState = updateClassificationFormState(this.formState, 'selectedDomain', value);
+      case "domain":
+        this.formState = updateClassificationFormState(
+          this.formState,
+          "selectedDomain",
+          value,
+        );
         // Reset dependent dropdowns first
-        this.resetDropdown('topic');
-        this.resetDropdown('subtopic');
+        this.resetDropdown("topic");
+        this.resetDropdown("subtopic");
         // Then populate the immediate next dropdown
         this.populateSubjectDropdown();
         break;
-        
-      case 'subject':
-        this.formState = updateClassificationFormState(this.formState, 'selectedSubject', value);
+
+      case "subject":
+        this.formState = updateClassificationFormState(
+          this.formState,
+          "selectedSubject",
+          value,
+        );
         // Reset dependent dropdowns first
-        this.resetDropdown('subtopic');
+        this.resetDropdown("subtopic");
         // Then populate the immediate next dropdown
         this.populateTopicDropdown();
         break;
-        
-      case 'topic':
-        this.formState = updateClassificationFormState(this.formState, 'selectedTopic', value);
+
+      case "topic":
+        this.formState = updateClassificationFormState(
+          this.formState,
+          "selectedTopic",
+          value,
+        );
         // Then populate the immediate next dropdown
         this.populateSubtopicDropdown();
         break;
@@ -231,39 +256,41 @@ export class ClassificationFormHandler {
   private resetDropdown(dropdownId: string): void {
     const trigger = document.getElementById(`${dropdownId}-dropdown`);
     const menu = document.getElementById(`${dropdownId}-menu`);
-    const hiddenInput = document.getElementById(`${dropdownId}-value`) as HTMLInputElement;
-    const label = trigger?.querySelector('.dropdown__label');
+    const hiddenInput = document.getElementById(
+      `${dropdownId}-value`,
+    ) as HTMLInputElement;
+    const label = trigger?.querySelector(".dropdown__label");
 
     if (!trigger || !menu || !hiddenInput || !label) return;
 
     // Reset values
-    hiddenInput.value = '';
-    label.classList.add('dropdown__label--placeholder');
-    
+    hiddenInput.value = "";
+    label.classList.add("dropdown__label--placeholder");
+
     // Clear menu
-    menu.innerHTML = '';
-    
+    menu.innerHTML = "";
+
     // Disable trigger
-    trigger.classList.add('dropdown__trigger--disabled');
-    trigger.setAttribute('disabled', 'true');
-    
+    trigger.classList.add("dropdown__trigger--disabled");
+    trigger.setAttribute("disabled", "true");
+
     // Update placeholder text
     switch (dropdownId) {
-      case 'subject':
-        label.textContent = 'Select domain first...';
+      case "subject":
+        label.textContent = "Select domain first...";
         break;
-      case 'topic':
-        label.textContent = 'Select subject first...';
+      case "topic":
+        label.textContent = "Select subject first...";
         break;
-      case 'subtopic':
-        label.textContent = 'Select topic first...';
+      case "subtopic":
+        label.textContent = "Select topic first...";
         break;
       default:
-        label.textContent = `Select ${dropdownId.replace('-', ' ')}...`;
+        label.textContent = `Select ${dropdownId.replace("-", " ")}...`;
     }
 
     // Remove success styling
-    trigger.classList.remove('dropdown__trigger--success');
+    trigger.classList.remove("dropdown__trigger--success");
   }
 
   // ==========================================================================
@@ -274,168 +301,203 @@ export class ClassificationFormHandler {
     await Promise.all([
       this.populateClassYearDropdown(),
       this.populateCurricularFrameworkDropdown(),
-      this.populateDomainDropdown()
+      this.populateDomainDropdown(),
     ]);
   }
 
   private async populateClassYearDropdown(): Promise<void> {
     try {
       const data = await loadClassYearData();
-      const menu = document.getElementById('class-year-menu');
-      
+      const menu = document.getElementById("class-year-menu");
+
       if (!menu || !data.classYears) return;
 
-      menu.innerHTML = data.classYears.map((year: any) => `
+      menu.innerHTML = data.classYears
+        .map(
+          (year: any) => `
         <div class="dropdown__option" data-value="${year.value}" role="option">
           <div class="dropdown__option-text">
             ${year.label}
-            ${year.description ? `<div class="dropdown__option-description">${year.description}</div>` : ''}
+            ${year.description ? `<div class="dropdown__option-description">${year.description}</div>` : ""}
           </div>
         </div>
-      `).join('');
+      `,
+        )
+        .join("");
 
       // Enable dropdown
-      this.enableDropdown('class-year');
+      this.enableDropdown("class-year");
     } catch (error) {
-      console.error('Error populating class year dropdown:', error);
+      console.error("Error populating class year dropdown:", error);
     }
   }
 
   private async populateCurricularFrameworkDropdown(): Promise<void> {
     try {
       const data = await loadCurricularFrameworkData();
-      const menu = document.getElementById('curricular-framework-menu');
-      
+      const menu = document.getElementById("curricular-framework-menu");
+
       if (!menu || !data.curricularFrameworks) return;
 
-      menu.innerHTML = data.curricularFrameworks.map((framework: any) => `
+      menu.innerHTML = data.curricularFrameworks
+        .map(
+          (framework: any) => `
         <div class="dropdown__option" data-value="${framework.value}" role="option">
           <div class="dropdown__option-text">
             ${framework.label}
-            ${framework.description ? `<div class="dropdown__option-description">${framework.description}</div>` : ''}
+            ${framework.description ? `<div class="dropdown__option-description">${framework.description}</div>` : ""}
           </div>
         </div>
-      `).join('');
+      `,
+        )
+        .join("");
 
       // Enable dropdown
-      this.enableDropdown('curricular-framework');
+      this.enableDropdown("curricular-framework");
     } catch (error) {
-      console.error('Error populating curricular framework dropdown:', error);
+      console.error("Error populating curricular framework dropdown:", error);
     }
   }
 
   private async populateDomainDropdown(): Promise<void> {
     try {
       const data = await loadIscedData();
-      const menu = document.getElementById('domain-menu');
-      
+      const menu = document.getElementById("domain-menu");
+
       if (!menu || !data.domains) return;
 
-      menu.innerHTML = data.domains.map((domain: any) => `
+      menu.innerHTML = data.domains
+        .map(
+          (domain: any) => `
         <div class="dropdown__option" data-value="${domain.value}" role="option">
           <div class="dropdown__option-text">
             ${domain.label}
             <div class="dropdown__option-code">${domain.code}</div>
           </div>
         </div>
-      `).join('');
+      `,
+        )
+        .join("");
 
       // Enable dropdown
-      this.enableDropdown('domain');
+      this.enableDropdown("domain");
     } catch (error) {
-      console.error('Error populating domain dropdown:', error);
+      console.error("Error populating domain dropdown:", error);
     }
   }
 
   private populateSubjectDropdown(): void {
     const subjects = this.formState.availableSubjects;
-    const menu = document.getElementById('subject-menu');
-    
+    const menu = document.getElementById("subject-menu");
+
     if (!menu) return;
 
     if (subjects.length === 0) {
-      menu.innerHTML = '<div class="dropdown__option dropdown__option--disabled">No subjects available</div>';
+      menu.innerHTML =
+        '<div class="dropdown__option dropdown__option--disabled">No subjects available</div>';
       return;
     }
 
-    menu.innerHTML = subjects.map((subject: any) => `
+    menu.innerHTML = subjects
+      .map(
+        (subject: any) => `
       <div class="dropdown__option" data-value="${subject.value}" role="option">
         <div class="dropdown__option-text">
           ${subject.label}
           <div class="dropdown__option-code">${subject.code}</div>
         </div>
       </div>
-    `).join('');
+    `,
+      )
+      .join("");
 
     // Enable dropdown
-    this.enableDropdown('subject');
+    this.enableDropdown("subject");
   }
 
   private populateTopicDropdown(): void {
     const topics = this.formState.availableTopics;
-    const menu = document.getElementById('topic-menu');
-    
+    const menu = document.getElementById("topic-menu");
+
     if (!menu) return;
 
     if (topics.length === 0) {
-      menu.innerHTML = '<div class="dropdown__option dropdown__option--disabled">No topics available</div>';
+      menu.innerHTML =
+        '<div class="dropdown__option dropdown__option--disabled">No topics available</div>';
       return;
     }
 
-    menu.innerHTML = topics.map((topic: any) => `
+    menu.innerHTML = topics
+      .map(
+        (topic: any) => `
       <div class="dropdown__option" data-value="${topic.value}" role="option">
         <div class="dropdown__option-text">
           ${topic.label}
           <div class="dropdown__option-code">${topic.code}</div>
         </div>
       </div>
-    `).join('');
+    `,
+      )
+      .join("");
 
     // Enable dropdown
-    this.enableDropdown('topic');
+    this.enableDropdown("topic");
   }
 
   private populateSubtopicDropdown(): void {
     const subtopics = this.formState.availableSubtopics;
-    const menu = document.getElementById('subtopic-menu');
-    
+    const menu = document.getElementById("subtopic-menu");
+
     if (!menu) return;
 
     if (subtopics.length === 0) {
-      menu.innerHTML = '<div class="dropdown__option dropdown__option--disabled">No subtopics available</div>';
+      menu.innerHTML =
+        '<div class="dropdown__option dropdown__option--disabled">No subtopics available</div>';
       return;
     }
 
-    menu.innerHTML = subtopics.map((subtopic: any) => `
+    menu.innerHTML = subtopics
+      .map(
+        (subtopic: any) => `
       <div class="dropdown__option" data-value="${subtopic.value}" role="option">
         <div class="dropdown__option-text">
           ${subtopic.label}
           <div class="dropdown__option-code">${subtopic.code}</div>
         </div>
       </div>
-    `).join('');
+    `,
+      )
+      .join("");
 
     // Enable dropdown
-    this.enableDropdown('subtopic');
+    this.enableDropdown("subtopic");
   }
 
   private async populateAvailableCourses(): Promise<void> {
     try {
       const courses = await getAvailableCourses();
-      const courseDropdowns = ['previous-course', 'current-course', 'next-course'];
+      const courseDropdowns = [
+        "previous-course",
+        "current-course",
+        "next-course",
+      ];
 
-      courseDropdowns.forEach(dropdownId => {
+      courseDropdowns.forEach((dropdownId) => {
         const menu = document.getElementById(`${dropdownId}-menu`);
         if (!menu) return;
 
-        const coursesHtml = courses.map(course => `
+        const coursesHtml = courses
+          .map(
+            (course) => `
           <div class="dropdown__option" data-value="${course.id}" role="option">
             <div class="dropdown__option-text">${course.course_name}</div>
           </div>
-        `).join('');
+        `,
+          )
+          .join("");
 
         // Keep the header and add courses
-        const existingHeader = menu.querySelector('.dropdown__option--header');
+        const existingHeader = menu.querySelector(".dropdown__option--header");
         if (existingHeader) {
           menu.innerHTML = existingHeader.outerHTML + coursesHtml;
         } else {
@@ -446,7 +508,7 @@ export class ClassificationFormHandler {
         this.enableDropdown(dropdownId);
       });
     } catch (error) {
-      console.error('Error populating available courses:', error);
+      console.error("Error populating available courses:", error);
     }
   }
 
@@ -454,21 +516,21 @@ export class ClassificationFormHandler {
     const trigger = document.getElementById(`${dropdownId}-dropdown`);
     if (!trigger) return;
 
-    trigger.classList.remove('dropdown__trigger--disabled');
-    trigger.removeAttribute('disabled');
-    
+    trigger.classList.remove("dropdown__trigger--disabled");
+    trigger.removeAttribute("disabled");
+
     // Update placeholder if needed
-    const label = trigger.querySelector('.dropdown__label');
-    if (label && label.classList.contains('dropdown__label--placeholder')) {
+    const label = trigger.querySelector(".dropdown__label");
+    if (label && label.classList.contains("dropdown__label--placeholder")) {
       switch (dropdownId) {
-        case 'subject':
-          label.textContent = 'Select subject...';
+        case "subject":
+          label.textContent = "Select subject...";
           break;
-        case 'topic':
-          label.textContent = 'Select topic...';
+        case "topic":
+          label.textContent = "Select topic...";
           break;
-        case 'subtopic':
-          label.textContent = 'Select subtopic...';
+        case "subtopic":
+          label.textContent = "Select subtopic...";
           break;
       }
     }
@@ -487,10 +549,10 @@ export class ClassificationFormHandler {
   private watchForCourseId(): void {
     // Check for course ID periodically in case it's set after initialization
     const checkInterval = setInterval(() => {
-      const courseId = sessionStorage.getItem('currentCourseId');
+      const courseId = sessionStorage.getItem("currentCourseId");
       if (courseId && courseId !== this.currentCourseId) {
         this.currentCourseId = courseId;
-        this.updateSaveStatus('Course connected - auto-save enabled');
+        this.updateSaveStatus("Course connected - auto-save enabled");
         clearInterval(checkInterval);
       }
     }, 500);
@@ -510,18 +572,18 @@ export class ClassificationFormHandler {
       this.performAutoSave();
     }, 1000); // Save 1 second after last change
 
-    this.updateSaveStatus('Saving...');
+    this.updateSaveStatus("Saving...");
   }
 
   private async performAutoSave(): Promise<void> {
     if (!this.currentCourseId) {
-      this.updateSaveStatus('Waiting for course creation...', true);
+      this.updateSaveStatus("Waiting for course creation...", true);
       return;
     }
 
     try {
       const classificationData = this.getCurrentFormData();
-      
+
       // Check if data has actually changed
       const currentDataString = JSON.stringify(classificationData);
       if (currentDataString === this.lastSavedData) {
@@ -529,20 +591,26 @@ export class ClassificationFormHandler {
       }
 
       // Use partial save for auto-save (doesn't require all fields to be filled)
-      const result = await savePartialCourseClassification(this.currentCourseId, classificationData);
+      const result = await savePartialCourseClassification(
+        this.currentCourseId,
+        classificationData,
+      );
 
       if (result.success) {
         this.lastSavedData = currentDataString;
         const now = new Date();
-        const timeString = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        const timeString = now.toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
         this.updateSaveStatus(`Last saved at ${timeString}`);
       } else {
-        throw new Error(result.error || 'Failed to save classification');
+        throw new Error(result.error || "Failed to save classification");
       }
     } catch (error) {
-      console.error('Error in auto-save:', error);
-      this.updateSaveStatus('Save failed - will retry', true);
-      
+      console.error("Error in auto-save:", error);
+      this.updateSaveStatus("Save failed - will retry", true);
+
       // Retry after 3 seconds
       setTimeout(() => {
         this.triggerAutoSave();
@@ -551,33 +619,36 @@ export class ClassificationFormHandler {
   }
 
   private getCurrentFormData(): CourseClassificationData {
-    const form = document.getElementById('course-classification-form') as HTMLFormElement;
-    if (!form) throw new Error('Classification form not found');
+    const form = document.getElementById(
+      "course-classification-form",
+    ) as HTMLFormElement;
+    if (!form) throw new Error("Classification form not found");
 
     const formData = new FormData(form);
     return {
-      class_year: formData.get('class_year') as string || '',
-      curricular_framework: formData.get('curricular_framework') as string || '',
-      domain: formData.get('domain') as string || '',
-      subject: formData.get('subject') as string || '',
-      topic: formData.get('topic') as string || '',
-      subtopic: formData.get('subtopic') as string || undefined,
-      previous_course: formData.get('previous_course') as string || undefined,
-      current_course: formData.get('current_course') as string || undefined,
-      next_course: formData.get('next_course') as string || undefined,
+      class_year: (formData.get("class_year") as string) || "",
+      curricular_framework:
+        (formData.get("curricular_framework") as string) || "",
+      domain: (formData.get("domain") as string) || "",
+      subject: (formData.get("subject") as string) || "",
+      topic: (formData.get("topic") as string) || "",
+      subtopic: (formData.get("subtopic") as string) || undefined,
+      previous_course: (formData.get("previous_course") as string) || undefined,
+      current_course: (formData.get("current_course") as string) || undefined,
+      next_course: (formData.get("next_course") as string) || undefined,
     };
   }
 
   private updateSaveStatus(message: string, isError: boolean = false): void {
-    const statusElement = document.getElementById('classification-save-status');
+    const statusElement = document.getElementById("classification-save-status");
     if (!statusElement) return;
 
     statusElement.textContent = message;
-    
+
     // Update styling based on status
-    const indicator = document.getElementById('classification-last-saved');
+    const indicator = document.getElementById("classification-last-saved");
     if (indicator) {
-      indicator.className = `save-indicator ${isError ? 'save-indicator--error' : 'save-indicator--success'}`;
+      indicator.className = `save-indicator ${isError ? "save-indicator--error" : "save-indicator--success"}`;
     }
   }
 
@@ -587,8 +658,8 @@ export class ClassificationFormHandler {
 
   public setCourseId(courseId: string): void {
     this.currentCourseId = courseId;
-    sessionStorage.setItem('currentCourseId', courseId);
-    this.updateSaveStatus('Course connected - auto-save enabled');
+    sessionStorage.setItem("currentCourseId", courseId);
+    this.updateSaveStatus("Course connected - auto-save enabled");
   }
 
   public async loadExistingClassification(courseId: string): Promise<void> {
@@ -597,68 +668,86 @@ export class ClassificationFormHandler {
       if (classification) {
         this.populateFormWithData(classification);
         this.lastSavedData = JSON.stringify(classification);
-        this.updateSaveStatus('Loaded existing data');
+        this.updateSaveStatus("Loaded existing data");
       }
     } catch (error) {
-      console.error('Error loading existing classification:', error);
-      this.updateSaveStatus('Error loading existing data', true);
+      console.error("Error loading existing classification:", error);
+      this.updateSaveStatus("Error loading existing data", true);
     }
   }
 
   private populateFormWithData(data: CourseClassificationData): void {
     // Update form state
-    this.formState.selectedDomain = data.domain || '';
-    this.formState.selectedSubject = data.subject || '';
-    this.formState.selectedTopic = data.topic || '';
-    this.formState.selectedSubtopic = data.subtopic || '';
+    this.formState.selectedDomain = data.domain || "";
+    this.formState.selectedSubject = data.subject || "";
+    this.formState.selectedTopic = data.topic || "";
+    this.formState.selectedSubtopic = data.subtopic || "";
 
     // Populate dropdowns with cascade
     if (data.domain) {
-      this.setDropdownValue('domain', data.domain);
-      this.formState = updateClassificationFormState(this.formState, 'selectedDomain', data.domain);
+      this.setDropdownValue("domain", data.domain);
+      this.formState = updateClassificationFormState(
+        this.formState,
+        "selectedDomain",
+        data.domain,
+      );
       this.populateSubjectDropdown();
-      
+
       if (data.subject) {
-        this.setDropdownValue('subject', data.subject);
-        this.formState = updateClassificationFormState(this.formState, 'selectedSubject', data.subject);
+        this.setDropdownValue("subject", data.subject);
+        this.formState = updateClassificationFormState(
+          this.formState,
+          "selectedSubject",
+          data.subject,
+        );
         this.populateTopicDropdown();
-        
+
         if (data.topic) {
-          this.setDropdownValue('topic', data.topic);
-          this.formState = updateClassificationFormState(this.formState, 'selectedTopic', data.topic);
+          this.setDropdownValue("topic", data.topic);
+          this.formState = updateClassificationFormState(
+            this.formState,
+            "selectedTopic",
+            data.topic,
+          );
           this.populateSubtopicDropdown();
-          
+
           if (data.subtopic) {
-            this.setDropdownValue('subtopic', data.subtopic);
+            this.setDropdownValue("subtopic", data.subtopic);
           }
         }
       }
     }
 
     // Set other dropdowns
-    if (data.class_year) this.setDropdownValue('class-year', data.class_year);
-    if (data.curricular_framework) this.setDropdownValue('curricular-framework', data.curricular_framework);
-    if (data.previous_course) this.setDropdownValue('previous-course', data.previous_course);
-    if (data.current_course) this.setDropdownValue('current-course', data.current_course);
-    if (data.next_course) this.setDropdownValue('next-course', data.next_course);
+    if (data.class_year) this.setDropdownValue("class-year", data.class_year);
+    if (data.curricular_framework)
+      this.setDropdownValue("curricular-framework", data.curricular_framework);
+    if (data.previous_course)
+      this.setDropdownValue("previous-course", data.previous_course);
+    if (data.current_course)
+      this.setDropdownValue("current-course", data.current_course);
+    if (data.next_course)
+      this.setDropdownValue("next-course", data.next_course);
   }
 
   private setDropdownValue(dropdownId: string, value: string): void {
     const trigger = document.getElementById(`${dropdownId}-dropdown`);
-    const hiddenInput = document.getElementById(`${dropdownId}-value`) as HTMLInputElement;
-    const label = trigger?.querySelector('.dropdown__label');
+    const hiddenInput = document.getElementById(
+      `${dropdownId}-value`,
+    ) as HTMLInputElement;
+    const label = trigger?.querySelector(".dropdown__label");
 
     if (!trigger || !hiddenInput || !label) return;
 
     hiddenInput.value = value;
-    
+
     // Find the option with this value to get the display text
     const menu = document.getElementById(`${dropdownId}-menu`);
     const option = menu?.querySelector(`[data-value="${value}"]`);
     if (option) {
       label.textContent = option.textContent?.trim() || value;
-      label.classList.remove('dropdown__label--placeholder');
-      trigger.classList.add('dropdown__trigger--success');
+      label.classList.remove("dropdown__label--placeholder");
+      trigger.classList.add("dropdown__trigger--success");
       this.enableDropdown(dropdownId);
     }
   }
@@ -669,9 +758,9 @@ export class ClassificationFormHandler {
 // ==========================================================================
 
 // Initialize when DOM is ready - but only on the classification section
-document.addEventListener('DOMContentLoaded', () => {
-  if (document.getElementById('course-classification-form')) {
+document.addEventListener("DOMContentLoaded", () => {
+  if (document.getElementById("course-classification-form")) {
     new ClassificationFormHandler();
-    console.log('ClassificationFormHandler initialized');
+    console.log("ClassificationFormHandler initialized");
   }
 });

--- a/src/scripts/backend/courses/classifyCourse.ts
+++ b/src/scripts/backend/courses/classifyCourse.ts
@@ -2,7 +2,7 @@
 // COURSE CLASSIFICATION & CRUD OPERATIONS
 // ==========================================================================
 
-import { supabase } from '../supabase';
+import { supabase } from "../supabase";
 
 // Course classification interface
 export interface CourseClassificationData {
@@ -42,10 +42,12 @@ let iscedData: any = null;
 export async function loadClassYearData() {
   if (!classYearData) {
     try {
-      const response = await fetch('/src/scripts/json/classification/classYear.json');
+      const response = await fetch(
+        "/src/scripts/json/classification/classYear.json",
+      );
       classYearData = await response.json();
     } catch (error) {
-      console.error('Error loading class year data:', error);
+      console.error("Error loading class year data:", error);
       classYearData = { classYears: [] };
     }
   }
@@ -55,10 +57,12 @@ export async function loadClassYearData() {
 export async function loadCurricularFrameworkData() {
   if (!curricularFrameworkData) {
     try {
-      const response = await fetch('/src/scripts/json/classification/curricularFramework.json');
+      const response = await fetch(
+        "/src/scripts/json/classification/curricularFramework.json",
+      );
       curricularFrameworkData = await response.json();
     } catch (error) {
-      console.error('Error loading curricular framework data:', error);
+      console.error("Error loading curricular framework data:", error);
       curricularFrameworkData = { curricularFrameworks: [] };
     }
   }
@@ -68,10 +72,12 @@ export async function loadCurricularFrameworkData() {
 export async function loadIscedData() {
   if (!iscedData) {
     try {
-      const response = await fetch('/src/scripts/json/classification/isced2011.json');
+      const response = await fetch(
+        "/src/scripts/json/classification/isced2011.json",
+      );
       iscedData = await response.json();
     } catch (error) {
-      console.error('Error loading ISCED data:', error);
+      console.error("Error loading ISCED data:", error);
       iscedData = { domains: [] };
     }
   }
@@ -88,7 +94,10 @@ export function getSubjectsByDomain(domainValue: string): any[] {
   return domain ? domain.subjects : [];
 }
 
-export function getTopicsBySubject(domainValue: string, subjectValue: string): any[] {
+export function getTopicsBySubject(
+  domainValue: string,
+  subjectValue: string,
+): any[] {
   if (!iscedData) return [];
   const domain = iscedData.domains.find((d: any) => d.value === domainValue);
   if (!domain) return [];
@@ -96,24 +105,32 @@ export function getTopicsBySubject(domainValue: string, subjectValue: string): a
   return subject ? subject.topics : [];
 }
 
-export function getSubtopicsByTopic(domainValue: string, subjectValue: string, topicValue: string): any[] {
+export function getSubtopicsByTopic(
+  domainValue: string,
+  subjectValue: string,
+  topicValue: string,
+): any[] {
   if (!iscedData) return [];
   const domain = iscedData.domains.find((d: any) => d.value === domainValue);
   if (!domain) return [];
   const subject = domain.subjects.find((s: any) => s.value === subjectValue);
   if (!subject) return [];
   const topic = subject.topics.find((t: any) => t.value === topicValue);
-  return topic ? (topic.subtopics || []) : [];
+  return topic ? topic.subtopics || [] : [];
 }
 
 // ==========================================================================
 // VALIDATION
 // ==========================================================================
 
-export function validateClassificationData(data: Partial<CourseClassificationData>): ClassificationValidation {
+export function validateClassificationData(
+  data: Partial<CourseClassificationData>,
+): ClassificationValidation {
   return {
     class_year: Boolean(data.class_year && data.class_year.trim()),
-    curricular_framework: Boolean(data.curricular_framework && data.curricular_framework.trim()),
+    curricular_framework: Boolean(
+      data.curricular_framework && data.curricular_framework.trim(),
+    ),
     domain: Boolean(data.domain && data.domain.trim()),
     subject: Boolean(data.subject && data.subject.trim()),
     topic: Boolean(data.topic && data.topic.trim()),
@@ -124,17 +141,21 @@ export function validateClassificationData(data: Partial<CourseClassificationDat
   };
 }
 
-export function isValidClassification(validation: ClassificationValidation): boolean {
+export function isValidClassification(
+  validation: ClassificationValidation,
+): boolean {
   // Only require the mandatory fields
   const requiredFields = [
-    'class_year',
-    'curricular_framework', 
-    'domain',
-    'subject',
-    'topic'
+    "class_year",
+    "curricular_framework",
+    "domain",
+    "subject",
+    "topic",
   ];
-  
-  return requiredFields.every(field => validation[field as keyof ClassificationValidation]);
+
+  return requiredFields.every(
+    (field) => validation[field as keyof ClassificationValidation],
+  );
 }
 
 // ==========================================================================
@@ -142,39 +163,53 @@ export function isValidClassification(validation: ClassificationValidation): boo
 // ==========================================================================
 
 export async function savePartialCourseClassification(
-  courseId: string, 
-  data: Partial<CourseClassificationData>
+  courseId: string,
+  data: Partial<CourseClassificationData>,
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // Enhanced authentication check with session validation
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
     if (sessionError) {
-      console.error('Session error:', sessionError);
-      return { success: false, error: 'Authentication session error' };
+      console.error("Session error:", sessionError);
+      return { success: false, error: "Authentication session error" };
     }
 
     if (!session?.user) {
-      console.error('No valid session or user found');
-      return { success: false, error: 'User not authenticated - please sign in again' };
+      console.error("No valid session or user found");
+      return {
+        success: false,
+        error: "User not authenticated - please sign in again",
+      };
     }
 
     const user = session.user;
-    console.log('Saving partial course classification for user:', user.id, 'course:', courseId);
+    console.log(
+      "Saving partial course classification for user:",
+      user.id,
+      "course:",
+      courseId,
+    );
 
     // Verify course ownership
     const { data: courseData, error: courseError } = await supabase
-      .from('courses')
-      .select('teacher_id')
-      .eq('id', courseId)
+      .from("courses")
+      .select("teacher_id")
+      .eq("id", courseId)
       .single();
 
     if (courseError) {
-      console.error('Error fetching course:', courseError);
-      return { success: false, error: 'Course not found' };
+      console.error("Error fetching course:", courseError);
+      return { success: false, error: "Course not found" };
     }
 
     if (courseData.teacher_id !== user.id) {
-      return { success: false, error: 'Unauthorized - you can only modify your own courses' };
+      return {
+        success: false,
+        error: "Unauthorized - you can only modify your own courses",
+      };
     }
 
     // Prepare classification data for JSONB column (allow partial data)
@@ -183,80 +218,110 @@ export async function savePartialCourseClassification(
     };
 
     // Only include fields that have values
-    if (data.class_year?.trim()) classificationData.class_year = data.class_year.trim();
-    if (data.curricular_framework?.trim()) classificationData.curricular_framework = data.curricular_framework.trim();
+    if (data.class_year?.trim())
+      classificationData.class_year = data.class_year.trim();
+    if (data.curricular_framework?.trim())
+      classificationData.curricular_framework =
+        data.curricular_framework.trim();
     if (data.domain?.trim()) classificationData.domain = data.domain.trim();
     if (data.subject?.trim()) classificationData.subject = data.subject.trim();
     if (data.topic?.trim()) classificationData.topic = data.topic.trim();
-    if (data.subtopic?.trim()) classificationData.subtopic = data.subtopic.trim();
-    if (data.previous_course?.trim()) classificationData.previous_course = data.previous_course.trim();
-    if (data.current_course?.trim()) classificationData.current_course = data.current_course.trim();
-    if (data.next_course?.trim()) classificationData.next_course = data.next_course.trim();
+    if (data.subtopic?.trim())
+      classificationData.subtopic = data.subtopic.trim();
+    if (data.previous_course?.trim())
+      classificationData.previous_course = data.previous_course.trim();
+    if (data.current_course?.trim())
+      classificationData.current_course = data.current_course.trim();
+    if (data.next_course?.trim())
+      classificationData.next_course = data.next_course.trim();
 
-    console.log('Saving partial course classification data:', classificationData);
+    console.log(
+      "Saving partial course classification data:",
+      classificationData,
+    );
 
     // Update course with classification data in the JSONB column
     const { error: updateError } = await supabase
-      .from('courses')
-      .update({ 
+      .from("courses")
+      .update({
         classification_data: classificationData,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
-      .eq('id', courseId);
+      .eq("id", courseId);
 
     if (updateError) {
-      console.error('Error updating course classification:', updateError);
-      return { success: false, error: `Failed to update classification: ${updateError.message}` };
+      console.error("Error updating course classification:", updateError);
+      return {
+        success: false,
+        error: `Failed to update classification: ${updateError.message}`,
+      };
     }
 
-    console.log('Partial course classification saved successfully');
+    console.log("Partial course classification saved successfully");
     return { success: true };
   } catch (error) {
-    console.error('Error in savePartialCourseClassification:', error);
-    return { success: false, error: 'Unexpected error occurred' };
+    console.error("Error in savePartialCourseClassification:", error);
+    return { success: false, error: "Unexpected error occurred" };
   }
 }
 
 export async function updateCourseClassification(
-  courseId: string, 
-  data: CourseClassificationData
+  courseId: string,
+  data: CourseClassificationData,
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // Enhanced authentication check with session validation
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
     if (sessionError) {
-      console.error('Session error:', sessionError);
-      return { success: false, error: 'Authentication session error' };
+      console.error("Session error:", sessionError);
+      return { success: false, error: "Authentication session error" };
     }
 
     if (!session?.user) {
-      console.error('No valid session or user found');
-      return { success: false, error: 'User not authenticated - please sign in again' };
+      console.error("No valid session or user found");
+      return {
+        success: false,
+        error: "User not authenticated - please sign in again",
+      };
     }
 
     const user = session.user;
-    console.log('Updating course classification for user:', user.id, 'course:', courseId);
+    console.log(
+      "Updating course classification for user:",
+      user.id,
+      "course:",
+      courseId,
+    );
 
     // Validate data
     const validation = validateClassificationData(data);
     if (!isValidClassification(validation)) {
-      return { success: false, error: 'Invalid classification data - required fields missing' };
+      return {
+        success: false,
+        error: "Invalid classification data - required fields missing",
+      };
     }
 
     // Verify course ownership
     const { data: courseData, error: courseError } = await supabase
-      .from('courses')
-      .select('teacher_id')
-      .eq('id', courseId)
+      .from("courses")
+      .select("teacher_id")
+      .eq("id", courseId)
       .single();
 
     if (courseError) {
-      console.error('Error fetching course:', courseError);
-      return { success: false, error: 'Course not found' };
+      console.error("Error fetching course:", courseError);
+      return { success: false, error: "Course not found" };
     }
 
     if (courseData.teacher_id !== user.id) {
-      return { success: false, error: 'Unauthorized - you can only modify your own courses' };
+      return {
+        success: false,
+        error: "Unauthorized - you can only modify your own courses",
+      };
     }
 
     // Prepare classification data for JSONB column
@@ -273,90 +338,100 @@ export async function updateCourseClassification(
       updated_at: new Date().toISOString(),
     };
 
-    console.log('Updating course classification data:', classificationData);
+    console.log("Updating course classification data:", classificationData);
 
     // Update course with classification data in the JSONB column
     const { error: updateError } = await supabase
-      .from('courses')
-      .update({ 
+      .from("courses")
+      .update({
         classification_data: classificationData,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
-      .eq('id', courseId);
+      .eq("id", courseId);
 
     if (updateError) {
-      console.error('Error updating course classification:', updateError);
-      return { success: false, error: `Failed to update classification: ${updateError.message}` };
+      console.error("Error updating course classification:", updateError);
+      return {
+        success: false,
+        error: `Failed to update classification: ${updateError.message}`,
+      };
     }
 
-    console.log('Course classification updated successfully');
+    console.log("Course classification updated successfully");
     return { success: true };
   } catch (error) {
-    console.error('Error in updateCourseClassification:', error);
-    return { success: false, error: 'Unexpected error occurred' };
+    console.error("Error in updateCourseClassification:", error);
+    return { success: false, error: "Unexpected error occurred" };
   }
 }
 
-export async function getCourseClassification(courseId: string): Promise<CourseClassificationData | null> {
+export async function getCourseClassification(
+  courseId: string,
+): Promise<CourseClassificationData | null> {
   try {
     const { data, error } = await supabase
-      .from('courses')
-      .select('classification_data')
-      .eq('id', courseId)
+      .from("courses")
+      .select("classification_data")
+      .eq("id", courseId)
       .single();
 
     if (error) {
-      console.error('Error fetching course classification:', error);
+      console.error("Error fetching course classification:", error);
       return null;
     }
 
     // Extract classification data from JSONB column
     const classificationData = data?.classification_data || {};
-    
+
     // Return the classification data with proper structure
     return {
-      class_year: classificationData.class_year || '',
-      curricular_framework: classificationData.curricular_framework || '',
-      domain: classificationData.domain || '',
-      subject: classificationData.subject || '',
-      topic: classificationData.topic || '',
+      class_year: classificationData.class_year || "",
+      curricular_framework: classificationData.curricular_framework || "",
+      domain: classificationData.domain || "",
+      subject: classificationData.subject || "",
+      topic: classificationData.topic || "",
       subtopic: classificationData.subtopic || undefined,
       previous_course: classificationData.previous_course || undefined,
       current_course: classificationData.current_course || undefined,
       next_course: classificationData.next_course || undefined,
     };
   } catch (error) {
-    console.error('Error in getCourseClassification:', error);
+    console.error("Error in getCourseClassification:", error);
     return null;
   }
 }
 
-export async function getAvailableCourses(userId?: string): Promise<Array<{id: string, course_name: string}>> {
+export async function getAvailableCourses(
+  userId?: string,
+): Promise<Array<{ id: string; course_name: string }>> {
   try {
     let query = supabase
-      .from('courses')
-      .select('id, course_name')
-      .order('course_name');
-    
+      .from("courses")
+      .select("id, course_name")
+      .order("course_name");
+
     if (userId) {
-      query = query.eq('teacher_id', userId);
+      query = query.eq("teacher_id", userId);
     } else {
       // Get current user's courses
-      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
       if (authError || !user) return [];
-      query = query.eq('teacher_id', user.id);
+      query = query.eq("teacher_id", user.id);
     }
 
     const { data, error } = await query;
 
     if (error) {
-      console.error('Error fetching available courses:', error);
+      console.error("Error fetching available courses:", error);
       return [];
     }
 
     return data || [];
   } catch (error) {
-    console.error('Error in getAvailableCourses:', error);
+    console.error("Error in getAvailableCourses:", error);
     return [];
   }
 }
@@ -377,10 +452,10 @@ export interface ClassificationFormState {
 
 export function initializeClassificationFormState(): ClassificationFormState {
   return {
-    selectedDomain: '',
-    selectedSubject: '',
-    selectedTopic: '',
-    selectedSubtopic: '',
+    selectedDomain: "",
+    selectedSubject: "",
+    selectedTopic: "",
+    selectedSubtopic: "",
     availableSubjects: [],
     availableTopics: [],
     availableSubtopics: [],
@@ -390,44 +465,47 @@ export function initializeClassificationFormState(): ClassificationFormState {
 export function updateClassificationFormState(
   state: ClassificationFormState,
   field: keyof ClassificationFormState,
-  value: string
+  value: string,
 ): ClassificationFormState {
   const newState = { ...state };
-  
+
   switch (field) {
-    case 'selectedDomain':
+    case "selectedDomain":
       newState.selectedDomain = value;
-      newState.selectedSubject = '';
-      newState.selectedTopic = '';
-      newState.selectedSubtopic = '';
+      newState.selectedSubject = "";
+      newState.selectedTopic = "";
+      newState.selectedSubtopic = "";
       newState.availableSubjects = getSubjectsByDomain(value);
       newState.availableTopics = [];
       newState.availableSubtopics = [];
       break;
-      
-    case 'selectedSubject':
+
+    case "selectedSubject":
       newState.selectedSubject = value;
-      newState.selectedTopic = '';
-      newState.selectedSubtopic = '';
-      newState.availableTopics = getTopicsBySubject(state.selectedDomain, value);
+      newState.selectedTopic = "";
+      newState.selectedSubtopic = "";
+      newState.availableTopics = getTopicsBySubject(
+        state.selectedDomain,
+        value,
+      );
       newState.availableSubtopics = [];
       break;
-      
-    case 'selectedTopic':
+
+    case "selectedTopic":
       newState.selectedTopic = value;
-      newState.selectedSubtopic = '';
+      newState.selectedSubtopic = "";
       newState.availableSubtopics = getSubtopicsByTopic(
         state.selectedDomain,
         state.selectedSubject,
-        value
+        value,
       );
       break;
-      
-    case 'selectedSubtopic':
+
+    case "selectedSubtopic":
       newState.selectedSubtopic = value;
       break;
   }
-  
+
   return newState;
 }
 
@@ -441,11 +519,11 @@ export async function initializeClassificationData(): Promise<void> {
     await Promise.all([
       loadClassYearData(),
       loadCurricularFrameworkData(),
-      loadIscedData()
+      loadIscedData(),
     ]);
-    
-    console.log('Classification data initialized successfully');
+
+    console.log("Classification data initialized successfully");
   } catch (error) {
-    console.error('Error initializing classification data:', error);
+    console.error("Error initializing classification data:", error);
   }
 }

--- a/src/scripts/backend/courses/courseFormConfig.ts
+++ b/src/scripts/backend/courses/courseFormConfig.ts
@@ -8,7 +8,16 @@
 
 export interface FormFieldConfig {
   name: string;
-  type: 'text' | 'textarea' | 'select' | 'file' | 'number' | 'date' | 'time' | 'display' | 'checkbox';
+  type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "file"
+    | "number"
+    | "date"
+    | "time"
+    | "display"
+    | "checkbox";
   required?: boolean;
   minLength?: number;
   maxLength?: number;
@@ -35,34 +44,40 @@ export interface ValidationState {
 // DYNAMIC FIELD FUNCTIONS
 // ==========================================================================
 
-import { supabase } from '../supabase';
+import { supabase } from "../supabase";
 
 export const displayFunctions = {
   async getTeacherName(): Promise<string> {
-    const { data: { user } } = await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     if (user) {
       const { data: profile } = await supabase
-        .from('users')
-        .select('first_name, last_name')
-        .eq('id', user.id)
+        .from("users")
+        .select("first_name, last_name")
+        .eq("id", user.id)
         .single();
-      return profile ? `${profile.first_name} ${profile.last_name}` : 'Unknown Teacher';
+      return profile
+        ? `${profile.first_name} ${profile.last_name}`
+        : "Unknown Teacher";
     }
-    return 'Unknown Teacher';
+    return "Unknown Teacher";
   },
 
   async getInstitution(): Promise<string> {
-    const { data: { user } } = await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     if (user) {
       const { data: profile } = await supabase
-        .from('users')
-        .select('institution')
-        .eq('id', user.id)
+        .from("users")
+        .select("institution")
+        .eq("id", user.id)
         .single();
-      return profile?.institution || 'Independent';
+      return profile?.institution || "Independent";
     }
-    return 'Independent';
-  }
+    return "Independent";
+  },
 };
 
 // ==========================================================================
@@ -71,132 +86,186 @@ export const displayFunctions = {
 
 export const SECTION_CONFIGS: { [key: string]: SectionConfig } = {
   essentials: {
-    section: 'essentials',
-    requiredFields: ['course_name', 'course_description', 'teacher_id', 'institution', 'course_language', 'course_image'],
-    fields: [
-      { name: 'course_name', type: 'text', required: true, minLength: 3 },
-      { name: 'course_description', type: 'textarea', required: true, minLength: 10 },
-      { 
-        name: 'teacher_id', 
-        type: 'display', 
-        required: true,
-        displayFunction: displayFunctions.getTeacherName
-      },
-      { 
-        name: 'institution', 
-        type: 'display', 
-        required: true,
-        displayFunction: displayFunctions.getInstitution
-      },
-      { 
-        name: 'course_language', 
-        type: 'select', 
-        required: true,
-        options: ['English', 'Spanish', 'French', 'German', 'Italian', 'Portuguese', 'Dutch', 'Chinese', 'Japanese', 'Korean', 'Arabic', 'Other']
-      },
-      { name: 'course_image', type: 'file', required: true, accept: 'image/*' }
+    section: "essentials",
+    requiredFields: [
+      "course_name",
+      "course_description",
+      "teacher_id",
+      "institution",
+      "course_language",
+      "course_image",
     ],
-    submitLabel: 'Create Course',
-    autoSave: false
+    fields: [
+      { name: "course_name", type: "text", required: true, minLength: 3 },
+      {
+        name: "course_description",
+        type: "textarea",
+        required: true,
+        minLength: 10,
+      },
+      {
+        name: "teacher_id",
+        type: "display",
+        required: true,
+        displayFunction: displayFunctions.getTeacherName,
+      },
+      {
+        name: "institution",
+        type: "display",
+        required: true,
+        displayFunction: displayFunctions.getInstitution,
+      },
+      {
+        name: "course_language",
+        type: "select",
+        required: true,
+        options: [
+          "English",
+          "Spanish",
+          "French",
+          "German",
+          "Italian",
+          "Portuguese",
+          "Dutch",
+          "Chinese",
+          "Japanese",
+          "Korean",
+          "Arabic",
+          "Other",
+        ],
+      },
+      { name: "course_image", type: "file", required: true, accept: "image/*" },
+    ],
+    submitLabel: "Create Course",
+    autoSave: false,
   },
-  
+
   classification: {
-    section: 'classification',
-    requiredFields: ['class_year', 'domain', 'subject'],
-    jsonbField: 'classification_data',
+    section: "classification",
+    requiredFields: ["class_year", "domain", "subject"],
+    jsonbField: "classification_data",
     fields: [
-      { 
-        name: 'class_year', 
-        type: 'select', 
+      {
+        name: "class_year",
+        type: "select",
         required: true,
-        options: ['Year 1', 'Year 2', 'Year 3', 'Year 4', 'Year 5', 'Year 6', 'Year 7', 'Year 8', 'Year 9', 'Year 10', 'Year 11', 'Year 12', 'Undergraduate', 'Graduate', 'Postgraduate']
+        options: [
+          "Year 1",
+          "Year 2",
+          "Year 3",
+          "Year 4",
+          "Year 5",
+          "Year 6",
+          "Year 7",
+          "Year 8",
+          "Year 9",
+          "Year 10",
+          "Year 11",
+          "Year 12",
+          "Undergraduate",
+          "Graduate",
+          "Postgraduate",
+        ],
       },
-      { 
-        name: 'curricular_framework', 
-        type: 'select', 
+      {
+        name: "curricular_framework",
+        type: "select",
         required: false,
-        options: ['National Curriculum', 'International Baccalaureate', 'Cambridge International', 'Advanced Placement', 'Custom Framework', 'Other']
+        options: [
+          "National Curriculum",
+          "International Baccalaureate",
+          "Cambridge International",
+          "Advanced Placement",
+          "Custom Framework",
+          "Other",
+        ],
       },
-      { name: 'domain', type: 'text', required: true },
-      { name: 'subject', type: 'text', required: true },
-      { name: 'topic', type: 'text', required: false },
-      { name: 'subtopic', type: 'text', required: false },
-      { name: 'previous_course', type: 'text', required: false },
-      { name: 'current_course', type: 'text', required: false },
-      { name: 'next_course', type: 'text', required: false }
+      { name: "domain", type: "text", required: true },
+      { name: "subject", type: "text", required: true },
+      { name: "topic", type: "text", required: false },
+      { name: "subtopic", type: "text", required: false },
+      { name: "previous_course", type: "text", required: false },
+      { name: "current_course", type: "text", required: false },
+      { name: "next_course", type: "text", required: false },
     ],
-    autoSave: true
+    autoSave: true,
   },
 
   templates: {
-    section: 'templates',
-    requiredFields: ['template_type'],
-    jsonbField: 'template_settings',
+    section: "templates",
+    requiredFields: ["template_type"],
+    jsonbField: "template_settings",
     fields: [
-      { 
-        name: 'template_type', 
-        type: 'select', 
+      {
+        name: "template_type",
+        type: "select",
         required: true,
-        options: ['programming', 'mathematics', 'science', 'language', 'custom']
+        options: [
+          "programming",
+          "mathematics",
+          "science",
+          "language",
+          "custom",
+        ],
       },
-      { 
-        name: 'template_style', 
-        type: 'select', 
+      {
+        name: "template_style",
+        type: "select",
         required: false,
-        options: ['modern', 'classic', 'minimal', 'colorful']
-      }
+        options: ["modern", "classic", "minimal", "colorful"],
+      },
     ],
-    autoSave: true
+    autoSave: true,
   },
 
   schedule: {
-    section: 'schedule',
-    requiredFields: ['start_date', 'schedule_type'],
-    jsonbField: 'schedule_settings',
+    section: "schedule",
+    requiredFields: ["start_date", "schedule_type"],
+    jsonbField: "schedule_settings",
     fields: [
-      { name: 'start_date', type: 'date', required: true },
-      { name: 'end_date', type: 'date', required: false },
-      { 
-        name: 'schedule_type', 
-        type: 'select', 
+      { name: "start_date", type: "date", required: true },
+      { name: "end_date", type: "date", required: false },
+      {
+        name: "schedule_type",
+        type: "select",
         required: true,
-        options: ['weekly', 'bi-weekly', 'daily', 'custom']
+        options: ["weekly", "bi-weekly", "daily", "custom"],
       },
-      { name: 'class_time', type: 'time', required: false },
-      { name: 'class_duration', type: 'number', required: false }
+      { name: "class_time", type: "time", required: false },
+      { name: "class_duration", type: "number", required: false },
     ],
-    autoSave: true
+    autoSave: true,
   },
 
   curriculum: {
-    section: 'curriculum',
-    requiredFields: ['curriculum_approach'],
-    jsonbField: 'curriculum_data',
+    section: "curriculum",
+    requiredFields: ["curriculum_approach"],
+    jsonbField: "curriculum_data",
     fields: [
-      { 
-        name: 'curriculum_approach', 
-        type: 'select', 
+      {
+        name: "curriculum_approach",
+        type: "select",
         required: true,
-        options: ['modular', 'linear', 'spiral', 'project-based']
+        options: ["modular", "linear", "spiral", "project-based"],
       },
-      { name: 'learning_objectives', type: 'textarea', required: false },
-      { name: 'assessment_methods', type: 'textarea', required: false },
-      { name: 'required_materials', type: 'textarea', required: false }
+      { name: "learning_objectives", type: "textarea", required: false },
+      { name: "assessment_methods", type: "textarea", required: false },
+      { name: "required_materials", type: "textarea", required: false },
     ],
-    autoSave: true
+    autoSave: true,
   },
 
   settings: {
-    section: 'settings',
+    section: "settings",
     requiredFields: [],
-    jsonbField: 'course_settings',
+    jsonbField: "course_settings",
     fields: [
-      { name: 'course_visible', type: 'checkbox', required: false },
-      { name: 'allow_enrollment', type: 'checkbox', required: false },
-      { name: 'require_approval', type: 'checkbox', required: false }
+      { name: "course_visible", type: "checkbox", required: false },
+      { name: "allow_enrollment", type: "checkbox", required: false },
+      { name: "require_approval", type: "checkbox", required: false },
     ],
-    autoSave: true
-  }
+    autoSave: true,
+  },
 };
 
 // ==========================================================================
@@ -207,11 +276,14 @@ export function getSectionConfig(sectionName: string): SectionConfig | null {
   return SECTION_CONFIGS[sectionName] || null;
 }
 
-export function getFieldConfig(sectionName: string, fieldName: string): FormFieldConfig | null {
+export function getFieldConfig(
+  sectionName: string,
+  fieldName: string,
+): FormFieldConfig | null {
   const sectionConfig = getSectionConfig(sectionName);
   if (!sectionConfig) return null;
-  
-  return sectionConfig.fields.find(field => field.name === fieldName) || null;
+
+  return sectionConfig.fields.find((field) => field.name === fieldName) || null;
 }
 
 export function getRequiredFields(sectionName: string): string[] {

--- a/src/scripts/backend/courses/courseFormHandler.ts
+++ b/src/scripts/backend/courses/courseFormHandler.ts
@@ -2,9 +2,13 @@
 // COURSE FORM HANDLER - Generic form UI controller for all course sections
 // ==========================================================================
 
-import { SectionConfig, ValidationState, getSectionConfig } from './courseFormConfig';
-import { validateFormSection, isFormSectionValid } from './courseFormValidator';
-import { createCourse, updateCourse, getCourse } from './createCourse';
+import {
+  SectionConfig,
+  ValidationState,
+  getSectionConfig,
+} from "./courseFormConfig";
+import { validateFormSection, isFormSectionValid } from "./courseFormValidator";
+import { createCourse, updateCourse, getCourse } from "./createCourse";
 
 // ==========================================================================
 // COURSE FORM HANDLER CLASS
@@ -22,9 +26,9 @@ export class CourseFormHandler {
     if (!config) {
       throw new Error(`No configuration found for section: ${sectionName}`);
     }
-    
+
     this.sectionConfig = config;
-    this.currentCourseId = sessionStorage.getItem('currentCourseId');
+    this.currentCourseId = sessionStorage.getItem("currentCourseId");
     this.initialize();
   }
 
@@ -44,9 +48,9 @@ export class CourseFormHandler {
   }
 
   private findForm(): void {
-    const activeArticle = document.querySelector('.article--active');
+    const activeArticle = document.querySelector(".article--active");
     if (activeArticle) {
-      this.form = activeArticle.querySelector('form');
+      this.form = activeArticle.querySelector("form");
     }
   }
 
@@ -54,29 +58,38 @@ export class CourseFormHandler {
     if (!this.form) return;
 
     for (const fieldConfig of this.sectionConfig.fields) {
-      const field = this.form.querySelector(`[name="${fieldConfig.name}"]`) as HTMLElement;
-      
+      const field = this.form.querySelector(
+        `[name="${fieldConfig.name}"]`,
+      ) as HTMLElement;
+
       if (!field) continue;
 
       // Handle display fields
-      if (fieldConfig.type === 'display' && fieldConfig.displayFunction) {
+      if (fieldConfig.type === "display" && fieldConfig.displayFunction) {
         try {
           const displayValue = await fieldConfig.displayFunction();
           this.setDisplayField(field, displayValue);
         } catch (error) {
-          console.error(`Error setting display field ${fieldConfig.name}:`, error);
+          console.error(
+            `Error setting display field ${fieldConfig.name}:`,
+            error,
+          );
         }
       }
 
       // Handle select fields with options
-      if (fieldConfig.type === 'select' && fieldConfig.options && field.tagName === 'SELECT') {
+      if (
+        fieldConfig.type === "select" &&
+        fieldConfig.options &&
+        field.tagName === "SELECT"
+      ) {
         this.populateSelectField(field as HTMLSelectElement, fieldConfig);
       }
     }
   }
 
   private setDisplayField(field: HTMLElement, value: string): void {
-    if (field.tagName === 'INPUT') {
+    if (field.tagName === "INPUT") {
       (field as HTMLInputElement).value = value;
       (field as HTMLInputElement).readOnly = true;
     } else {
@@ -84,18 +97,21 @@ export class CourseFormHandler {
     }
   }
 
-  private populateSelectField(select: HTMLSelectElement, fieldConfig: any): void {
-    select.innerHTML = '';
-    
+  private populateSelectField(
+    select: HTMLSelectElement,
+    fieldConfig: any,
+  ): void {
+    select.innerHTML = "";
+
     // Add default option
-    const defaultOption = document.createElement('option');
-    defaultOption.value = '';
-    defaultOption.textContent = `Select ${fieldConfig.name.replace('_', ' ')}...`;
+    const defaultOption = document.createElement("option");
+    defaultOption.value = "";
+    defaultOption.textContent = `Select ${fieldConfig.name.replace("_", " ")}...`;
     select.appendChild(defaultOption);
-    
+
     // Add options
     fieldConfig.options.forEach((option: string) => {
-      const optionElement = document.createElement('option');
+      const optionElement = document.createElement("option");
       optionElement.value = option;
       optionElement.textContent = option;
       select.appendChild(optionElement);
@@ -117,43 +133,52 @@ export class CourseFormHandler {
       this.populateFormFields(courseData);
 
       // Show course code if we're in essentials section and have a course ID
-      if (this.sectionConfig.section === 'essentials') {
+      if (this.sectionConfig.section === "essentials") {
         this.showCourseCode(this.currentCourseId);
       }
 
       setTimeout(() => this.validateForm(), 100);
     } catch (error) {
-      console.error('Error loading existing course data:', error);
+      console.error("Error loading existing course data:", error);
     }
   }
 
   private populateFormFields(courseData: any): void {
-    if (this.sectionConfig.section === 'essentials') {
-      this.setFieldValue('course_name', courseData.course_name);
-      this.setFieldValue('course_description', courseData.course_description);
-      this.setFieldValue('course_language', courseData.course_language);
-      
+    if (this.sectionConfig.section === "essentials") {
+      this.setFieldValue("course_name", courseData.course_name);
+      this.setFieldValue("course_description", courseData.course_description);
+      this.setFieldValue("course_language", courseData.course_language);
+
       if (courseData.course_image) {
         this.displayExistingImage(courseData.course_image);
       }
-    } else if (this.sectionConfig.section === 'classification') {
+    } else if (this.sectionConfig.section === "classification") {
       // Handle classification data from classification_data JSONB field
       if (courseData.classification_data) {
         const classificationData = courseData.classification_data;
-        this.setFieldValue('class_year', classificationData.class_year);
-        this.setFieldValue('curricular_framework', classificationData.curricular_framework);
-        this.setFieldValue('domain', classificationData.domain);
-        this.setFieldValue('subject', classificationData.subject);
-        this.setFieldValue('topic', classificationData.topic);
-        this.setFieldValue('subtopic', classificationData.subtopic);
-        this.setFieldValue('previous_course', classificationData.previous_course);
-        this.setFieldValue('current_course', classificationData.current_course);
-        this.setFieldValue('next_course', classificationData.next_course);
+        this.setFieldValue("class_year", classificationData.class_year);
+        this.setFieldValue(
+          "curricular_framework",
+          classificationData.curricular_framework,
+        );
+        this.setFieldValue("domain", classificationData.domain);
+        this.setFieldValue("subject", classificationData.subject);
+        this.setFieldValue("topic", classificationData.topic);
+        this.setFieldValue("subtopic", classificationData.subtopic);
+        this.setFieldValue(
+          "previous_course",
+          classificationData.previous_course,
+        );
+        this.setFieldValue("current_course", classificationData.current_course);
+        this.setFieldValue("next_course", classificationData.next_course);
       }
-    } else if (this.sectionConfig.jsonbField && courseData[this.sectionConfig.jsonbField]) {
+    } else if (
+      this.sectionConfig.jsonbField &&
+      courseData[this.sectionConfig.jsonbField]
+    ) {
       const sectionData = courseData[this.sectionConfig.jsonbField];
-      
-      this.sectionConfig.fields.forEach(fieldConfig => {
+
+      this.sectionConfig.fields.forEach((fieldConfig) => {
         if (sectionData[fieldConfig.name]) {
           this.setFieldValue(fieldConfig.name, sectionData[fieldConfig.name]);
         }
@@ -165,33 +190,41 @@ export class CourseFormHandler {
     if (!this.form || value === null || value === undefined) return;
 
     // Handle classification dropdown fields
-    if (this.sectionConfig.section === 'classification') {
-      const hiddenInput = this.form.querySelector(`#${fieldName}-value`) as HTMLInputElement;
+    if (this.sectionConfig.section === "classification") {
+      const hiddenInput = this.form.querySelector(
+        `#${fieldName}-value`,
+      ) as HTMLInputElement;
       const dropdownTrigger = this.form.querySelector(`#${fieldName}-dropdown`);
-      const dropdownLabel = dropdownTrigger?.querySelector('.dropdown__label');
-      
+      const dropdownLabel = dropdownTrigger?.querySelector(".dropdown__label");
+
       if (hiddenInput && dropdownTrigger && dropdownLabel) {
         hiddenInput.value = value;
-        dropdownLabel.textContent = this.getDisplayTextForValue(fieldName, value);
-        dropdownLabel.classList.remove('dropdown__label--placeholder');
-        dropdownTrigger.classList.add('dropdown__trigger--success');
+        dropdownLabel.textContent = this.getDisplayTextForValue(
+          fieldName,
+          value,
+        );
+        dropdownLabel.classList.remove("dropdown__label--placeholder");
+        dropdownTrigger.classList.add("dropdown__trigger--success");
         return;
       }
     }
 
     // Handle regular form fields
-    const field = this.form.querySelector(`[name="${fieldName}"]`) as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+    const field = this.form.querySelector(`[name="${fieldName}"]`) as
+      | HTMLInputElement
+      | HTMLSelectElement
+      | HTMLTextAreaElement;
     if (!field) return;
 
     try {
-      if (field.tagName === 'SELECT') {
+      if (field.tagName === "SELECT") {
         (field as HTMLSelectElement).value = value;
-      } else if (field.type !== 'file') {
+      } else if (field.type !== "file") {
         field.value = value;
       }
 
-      field.dispatchEvent(new Event('input', { bubbles: true }));
-      field.dispatchEvent(new Event('change', { bubbles: true }));
+      field.dispatchEvent(new Event("input", { bubbles: true }));
+      field.dispatchEvent(new Event("change", { bubbles: true }));
     } catch (error) {
       console.warn(`Failed to set field ${fieldName}:`, error);
     }
@@ -199,17 +232,17 @@ export class CourseFormHandler {
 
   private getDisplayTextForValue(fieldName: string, value: string): string {
     // For class year, return the value as is since it's user-friendly
-    if (fieldName === 'class_year') {
+    if (fieldName === "class_year") {
       return value;
     }
-    
+
     // For curricular framework, return the value as is
-    if (fieldName === 'curricular_framework') {
+    if (fieldName === "curricular_framework") {
       return value;
     }
-    
+
     // For other fields, return the value (can be enhanced with lookup tables later)
-    return value || '';
+    return value || "";
   }
 
   // ==========================================================================
@@ -217,34 +250,36 @@ export class CourseFormHandler {
   // ==========================================================================
 
   private setupEventListeners(): void {
-    if (!this.form || this.form.dataset.listenersAttached === 'true') return;
+    if (!this.form || this.form.dataset.listenersAttached === "true") return;
 
-    const inputs = this.form.querySelectorAll('input, textarea, select');
-    
-    inputs.forEach(input => {
+    const inputs = this.form.querySelectorAll("input, textarea, select");
+
+    inputs.forEach((input) => {
       const inputElement = input as HTMLInputElement;
-      if (inputElement.type === 'file') {
-        input.addEventListener('change', () => this.handleFileChange(inputElement));
+      if (inputElement.type === "file") {
+        input.addEventListener("change", () =>
+          this.handleFileChange(inputElement),
+        );
       } else {
-        input.addEventListener('input', () => this.handleInputChange());
-        input.addEventListener('change', () => this.handleInputChange());
+        input.addEventListener("input", () => this.handleInputChange());
+        input.addEventListener("change", () => this.handleInputChange());
       }
     });
 
-    this.form.addEventListener('submit', (e) => this.handleSubmit(e));
-    
+    this.form.addEventListener("submit", (e) => this.handleSubmit(e));
+
     // Handle remove image button
-    const removeImageBtn = this.form.querySelector('#remove-image');
+    const removeImageBtn = this.form.querySelector("#remove-image");
     if (removeImageBtn) {
-      removeImageBtn.addEventListener('click', () => this.handleRemoveImage());
+      removeImageBtn.addEventListener("click", () => this.handleRemoveImage());
     }
-    
-    this.form.dataset.listenersAttached = 'true';
+
+    this.form.dataset.listenersAttached = "true";
   }
 
   private handleInputChange(): void {
     this.validateForm();
-    
+
     if (this.sectionConfig.autoSave && this.currentCourseId) {
       this.debouncedSave();
     }
@@ -259,38 +294,42 @@ export class CourseFormHandler {
   }
 
   private handleRemoveImage(): void {
-    const imagePreview = document.getElementById('image-preview');
-    const previewImg = document.getElementById('preview-img') as HTMLImageElement;
-    const fileInput = document.getElementById('course-image') as HTMLInputElement;
-    
+    const imagePreview = document.getElementById("image-preview");
+    const previewImg = document.getElementById(
+      "preview-img",
+    ) as HTMLImageElement;
+    const fileInput = document.getElementById(
+      "course-image",
+    ) as HTMLInputElement;
+
     if (imagePreview && previewImg && fileInput) {
-      imagePreview.style.display = 'none';
-      fileInput.value = '';
-      previewImg.src = '';
+      imagePreview.style.display = "none";
+      fileInput.value = "";
+      previewImg.src = "";
       this.validateForm();
     }
   }
 
   private async handleSubmit(event: Event): Promise<void> {
     event.preventDefault();
-    
-    if (this.form?.dataset.submitting === 'true') return;
-    
+
+    if (this.form?.dataset.submitting === "true") return;
+
     if (!this.isFormValid()) {
-      this.showStatus('Please fill in all required fields', 'error');
+      this.showStatus("Please fill in all required fields", "error");
       return;
     }
 
-    if (this.form) this.form.dataset.submitting = 'true';
+    if (this.form) this.form.dataset.submitting = "true";
 
     try {
-      if (this.sectionConfig.section === 'essentials') {
+      if (this.sectionConfig.section === "essentials") {
         await this.createNewCourse();
       } else {
         await this.updateExistingCourse();
       }
     } finally {
-      if (this.form) this.form.dataset.submitting = 'false';
+      if (this.form) this.form.dataset.submitting = "false";
     }
   }
 
@@ -302,12 +341,18 @@ export class CourseFormHandler {
     if (!this.form) return;
 
     const formData = this.getFormData();
-    this.validationState = validateFormSection(this.sectionConfig.fields, formData);
+    this.validationState = validateFormSection(
+      this.sectionConfig.fields,
+      formData,
+    );
     this.updateUI();
   }
 
   private isFormValid(): boolean {
-    return isFormSectionValid(this.sectionConfig.requiredFields, this.validationState);
+    return isFormSectionValid(
+      this.sectionConfig.requiredFields,
+      this.validationState,
+    );
   }
 
   private getFormData(): { [key: string]: any } {
@@ -329,32 +374,33 @@ export class CourseFormHandler {
 
   private async createNewCourse(): Promise<void> {
     try {
-      this.showStatus('Creating course...', 'loading');
-      
+      this.showStatus("Creating course...", "loading");
+
       const formData = this.getFormData();
       const courseData = {
         course_name: formData.course_name,
         course_description: formData.course_description,
         course_language: formData.course_language,
-        course_image: formData.course_image
+        course_image: formData.course_image,
       };
 
       const result = await createCourse(courseData);
 
       if (result.success && result.courseId) {
         this.currentCourseId = result.courseId;
-        sessionStorage.setItem('currentCourseId', result.courseId);
-        
-        this.showStatus('Course created successfully! 🎉', 'success');
+        sessionStorage.setItem("currentCourseId", result.courseId);
+
+        this.showStatus("Course created successfully! 🎉", "success");
         this.showCourseCode(result.courseId);
         this.navigateToNextSection();
       } else {
-        throw new Error(result.error || 'Failed to create course');
+        throw new Error(result.error || "Failed to create course");
       }
     } catch (error) {
-      console.error('Error creating course:', error);
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-      this.showStatus(`Failed to create course: ${errorMessage}`, 'error');
+      console.error("Error creating course:", error);
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error occurred";
+      this.showStatus(`Failed to create course: ${errorMessage}`, "error");
     }
   }
 
@@ -374,13 +420,13 @@ export class CourseFormHandler {
       const result = await updateCourse(this.currentCourseId, updateData);
 
       if (result.success) {
-        this.showStatus('Saved ✓', 'success');
+        this.showStatus("Saved ✓", "success");
       } else {
-        throw new Error(result.error || 'Failed to save');
+        throw new Error(result.error || "Failed to save");
       }
     } catch (error) {
-      console.error('Error updating course:', error);
-      this.showStatus('Failed to save', 'error');
+      console.error("Error updating course:", error);
+      this.showStatus("Failed to save", "error");
     }
   }
 
@@ -389,50 +435,59 @@ export class CourseFormHandler {
   // ==========================================================================
 
   private displayExistingImage(imageUrl: string): void {
-    const imagePreview = document.getElementById('image-preview');
-    const previewImg = document.getElementById('preview-img') as HTMLImageElement;
-    const fileUploadLabel = this.form?.querySelector('.file-upload__compact-label');
-    
+    const imagePreview = document.getElementById("image-preview");
+    const previewImg = document.getElementById(
+      "preview-img",
+    ) as HTMLImageElement;
+    const fileUploadLabel = this.form?.querySelector(
+      ".file-upload__compact-label",
+    );
+
     if (imagePreview && previewImg) {
       previewImg.src = imageUrl;
-      imagePreview.style.display = 'block';
-      
+      imagePreview.style.display = "block";
+
       if (fileUploadLabel) {
-        const textElement = fileUploadLabel.querySelector('.file-upload__text');
+        const textElement = fileUploadLabel.querySelector(".file-upload__text");
         if (textElement) {
-          textElement.textContent = 'Change course image';
+          textElement.textContent = "Change course image";
         }
       }
     }
   }
 
   private showFilePreview(file: File): void {
-    const preview = document.getElementById('image-preview');
-    const img = document.getElementById('preview-img') as HTMLImageElement;
-    
+    const preview = document.getElementById("image-preview");
+    const img = document.getElementById("preview-img") as HTMLImageElement;
+
     if (preview && img) {
       const reader = new FileReader();
       reader.onload = (e) => {
         img.src = e.target?.result as string;
-        preview.style.display = 'block';
+        preview.style.display = "block";
       };
       reader.readAsDataURL(file);
     }
   }
 
   private updateUI(): void {
-    const submitBtn = this.form?.querySelector('button[type="submit"]') as HTMLButtonElement;
-    
+    const submitBtn = this.form?.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+
     if (submitBtn) {
       const isValid = this.isFormValid();
       submitBtn.disabled = !isValid;
-      submitBtn.classList.toggle('button--disabled', !isValid);
-      submitBtn.classList.toggle('button--primary', isValid);
+      submitBtn.classList.toggle("button--disabled", !isValid);
+      submitBtn.classList.toggle("button--primary", isValid);
     }
   }
 
-  private showStatus(message: string, type: 'success' | 'error' | 'loading'): void {
-    const statusDiv = this.form?.querySelector('.form__status') as HTMLElement;
+  private showStatus(
+    message: string,
+    type: "success" | "error" | "loading",
+  ): void {
+    const statusDiv = this.form?.querySelector(".form__status") as HTMLElement;
     if (statusDiv) {
       statusDiv.textContent = message;
       statusDiv.className = `form__status form__status--${type}`;
@@ -440,24 +495,30 @@ export class CourseFormHandler {
   }
 
   private showCourseCode(courseId: string): void {
-    const courseCodeDisplay = this.form?.querySelector('#course-code-display') as HTMLElement;
-    const courseCodeValue = this.form?.querySelector('#course-code-value') as HTMLElement;
-    const courseCodeCopyBtn = this.form?.querySelector('#course-code-copy-btn') as HTMLElement;
+    const courseCodeDisplay = this.form?.querySelector(
+      "#course-code-display",
+    ) as HTMLElement;
+    const courseCodeValue = this.form?.querySelector(
+      "#course-code-value",
+    ) as HTMLElement;
+    const courseCodeCopyBtn = this.form?.querySelector(
+      "#course-code-copy-btn",
+    ) as HTMLElement;
 
     if (courseCodeDisplay && courseCodeValue && courseCodeCopyBtn) {
       courseCodeValue.textContent = courseId;
-      courseCodeDisplay.style.display = 'block';
+      courseCodeDisplay.style.display = "block";
 
       // Only add copy functionality if not already added
-      if (!courseCodeCopyBtn.hasAttribute('data-copy-listener')) {
-        courseCodeCopyBtn.setAttribute('data-copy-listener', 'true');
-        
-        courseCodeCopyBtn.addEventListener('click', async () => {
+      if (!courseCodeCopyBtn.hasAttribute("data-copy-listener")) {
+        courseCodeCopyBtn.setAttribute("data-copy-listener", "true");
+
+        courseCodeCopyBtn.addEventListener("click", async () => {
           try {
             await navigator.clipboard.writeText(courseId);
             this.showCopyFeedback(courseCodeCopyBtn);
           } catch (err) {
-            console.error('Failed to copy course code:', err);
+            console.error("Failed to copy course code:", err);
             // Fallback for older browsers
             this.fallbackCopy(courseId);
             this.showCopyFeedback(courseCodeCopyBtn);
@@ -469,27 +530,29 @@ export class CourseFormHandler {
 
   private showCopyFeedback(button: HTMLElement): void {
     const originalContent = button.innerHTML;
-    button.innerHTML = '<span>✓</span>';
-    button.style.color = '#10b981'; // green
-    
+    button.innerHTML = "<span>✓</span>";
+    button.style.color = "#10b981"; // green
+
     setTimeout(() => {
       button.innerHTML = originalContent;
-      button.style.color = '';
+      button.style.color = "";
     }, 1500);
   }
 
   private fallbackCopy(text: string): void {
-    const textArea = document.createElement('textarea');
+    const textArea = document.createElement("textarea");
     textArea.value = text;
     document.body.appendChild(textArea);
     textArea.select();
-    document.execCommand('copy');
+    document.execCommand("copy");
     document.body.removeChild(textArea);
   }
 
   private navigateToNextSection(): void {
     setTimeout(() => {
-      const nextLink = document.querySelector('[data-section="classification"]') as HTMLElement;
+      const nextLink = document.querySelector(
+        '[data-section="classification"]',
+      ) as HTMLElement;
       nextLink?.click();
     }, 1500);
   }

--- a/src/scripts/backend/courses/courseFormValidator.ts
+++ b/src/scripts/backend/courses/courseFormValidator.ts
@@ -2,7 +2,7 @@
 // COURSE FORM VALIDATION - Validation logic and rules
 // ==========================================================================
 
-import { FormFieldConfig, ValidationState } from './courseFormConfig';
+import { FormFieldConfig, ValidationState } from "./courseFormConfig";
 
 // ==========================================================================
 // VALIDATION FUNCTIONS
@@ -11,35 +11,35 @@ import { FormFieldConfig, ValidationState } from './courseFormConfig';
 export function validateField(config: FormFieldConfig, value: any): boolean {
   // If field is not required and has no value, it's valid
   if (!value && !config.required) return true;
-  
+
   // If field is required and has no value, it's invalid
   if (!value && config.required) return false;
 
   // Validate based on field type
   switch (config.type) {
-    case 'text':
-    case 'textarea':
+    case "text":
+    case "textarea":
       return validateTextField(config, value);
-    
-    case 'file':
+
+    case "file":
       return validateFileField(config, value);
-    
-    case 'select':
+
+    case "select":
       return validateSelectField(config, value);
-    
-    case 'number':
+
+    case "number":
       return validateNumberField(config, value);
-    
-    case 'date':
-    case 'time':
+
+    case "date":
+    case "time":
       return validateDateTimeField(config, value);
-    
-    case 'checkbox':
+
+    case "checkbox":
       return true; // Checkboxes are always valid
-    
-    case 'display':
+
+    case "display":
       return true; // Display fields are always valid
-    
+
     default:
       return Boolean(value);
   }
@@ -47,85 +47,91 @@ export function validateField(config: FormFieldConfig, value: any): boolean {
 
 function validateTextField(config: FormFieldConfig, value: string): boolean {
   const strValue = String(value).trim();
-  
+
   // Check minimum length
   if (config.minLength && strValue.length < config.minLength) {
     return false;
   }
-  
+
   // Check maximum length
   if (config.maxLength && strValue.length > config.maxLength) {
     return false;
   }
-  
+
   // Check pattern
   if (config.pattern && !config.pattern.test(strValue)) {
     return false;
   }
-  
+
   return true;
 }
 
 function validateFileField(config: FormFieldConfig, value: File): boolean {
   if (!value) return !config.required;
-  
+
   // Check file type if accept is specified
   if (config.accept && !isFileTypeAccepted(value, config.accept)) {
     return false;
   }
-  
+
   return true;
 }
 
 function validateSelectField(config: FormFieldConfig, value: string): boolean {
   if (!value) return !config.required;
-  
+
   // If options are specified, check if value is in the list
   if (config.options && !config.options.includes(value)) {
     return false;
   }
-  
+
   return true;
 }
 
-function validateNumberField(config: FormFieldConfig, value: number | string): boolean {
+function validateNumberField(
+  config: FormFieldConfig,
+  value: number | string,
+): boolean {
   if (!value && value !== 0) return !config.required;
-  
+
   const numValue = Number(value);
   return !isNaN(numValue);
 }
 
-function validateDateTimeField(config: FormFieldConfig, value: string): boolean {
+function validateDateTimeField(
+  config: FormFieldConfig,
+  value: string,
+): boolean {
   if (!value) return !config.required;
-  
+
   // Basic date/time validation
-  if (config.type === 'date') {
+  if (config.type === "date") {
     const date = new Date(value);
     return !isNaN(date.getTime());
   }
-  
-  if (config.type === 'time') {
+
+  if (config.type === "time") {
     // Basic time format validation (HH:MM)
     const timeRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
     return timeRegex.test(value);
   }
-  
+
   return true;
 }
 
 function isFileTypeAccepted(file: File, accept: string): boolean {
-  const acceptedTypes = accept.split(',').map(type => type.trim());
-  
+  const acceptedTypes = accept.split(",").map((type) => type.trim());
+
   for (const acceptedType of acceptedTypes) {
-    if (acceptedType.startsWith('.')) {
+    if (acceptedType.startsWith(".")) {
       // File extension check
       if (file.name.toLowerCase().endsWith(acceptedType.toLowerCase())) {
         return true;
       }
-    } else if (acceptedType.includes('/*')) {
+    } else if (acceptedType.includes("/*")) {
       // MIME type wildcard check (e.g., image/*)
-      const baseType = acceptedType.split('/')[0];
-      if (file.type.startsWith(baseType + '/')) {
+      const baseType = acceptedType.split("/")[0];
+      if (file.type.startsWith(baseType + "/")) {
         return true;
       }
     } else {
@@ -135,7 +141,7 @@ function isFileTypeAccepted(file: File, accept: string): boolean {
       }
     }
   }
-  
+
   return false;
 }
 
@@ -144,25 +150,25 @@ function isFileTypeAccepted(file: File, accept: string): boolean {
 // ==========================================================================
 
 export function validateFormSection(
-  fields: FormFieldConfig[], 
-  formData: { [key: string]: any }
+  fields: FormFieldConfig[],
+  formData: { [key: string]: any },
 ): ValidationState {
   const validationState: ValidationState = {};
-  
-  fields.forEach(fieldConfig => {
+
+  fields.forEach((fieldConfig) => {
     const value = formData[fieldConfig.name];
     validationState[fieldConfig.name] = validateField(fieldConfig, value);
   });
-  
+
   return validationState;
 }
 
 export function isFormSectionValid(
-  requiredFields: string[], 
-  validationState: ValidationState
+  requiredFields: string[],
+  validationState: ValidationState,
 ): boolean {
-  return requiredFields.every(fieldName => 
-    validationState[fieldName] === true
+  return requiredFields.every(
+    (fieldName) => validationState[fieldName] === true,
   );
 }
 
@@ -170,30 +176,33 @@ export function isFormSectionValid(
 // VALIDATION ERROR MESSAGES
 // ==========================================================================
 
-export function getValidationMessage(config: FormFieldConfig, value: any): string {
+export function getValidationMessage(
+  config: FormFieldConfig,
+  value: any,
+): string {
   if (!value && config.required) {
-    return `${config.name.replace('_', ' ')} is required`;
+    return `${config.name.replace("_", " ")} is required`;
   }
-  
-  if (config.type === 'text' || config.type === 'textarea') {
-    const strValue = String(value || '').trim();
-    
+
+  if (config.type === "text" || config.type === "textarea") {
+    const strValue = String(value || "").trim();
+
     if (config.minLength && strValue.length < config.minLength) {
-      return `${config.name.replace('_', ' ')} must be at least ${config.minLength} characters`;
+      return `${config.name.replace("_", " ")} must be at least ${config.minLength} characters`;
     }
-    
+
     if (config.maxLength && strValue.length > config.maxLength) {
-      return `${config.name.replace('_', ' ')} must be no more than ${config.maxLength} characters`;
+      return `${config.name.replace("_", " ")} must be no more than ${config.maxLength} characters`;
     }
   }
-  
-  if (config.type === 'file' && value instanceof File) {
+
+  if (config.type === "file" && value instanceof File) {
     if (config.accept && !isFileTypeAccepted(value, config.accept)) {
       return `Please select a valid file type (${config.accept})`;
     }
   }
-  
-  return ''; // No validation error
+
+  return ""; // No validation error
 }
 
 // ==========================================================================
@@ -201,17 +210,17 @@ export function getValidationMessage(config: FormFieldConfig, value: any): strin
 // ==========================================================================
 
 export function hasValidationErrors(validationState: ValidationState): boolean {
-  return Object.values(validationState).some(isValid => !isValid);
+  return Object.values(validationState).some((isValid) => !isValid);
 }
 
 export function getInvalidFields(validationState: ValidationState): string[] {
-  return Object.keys(validationState).filter(fieldName => 
-    !validationState[fieldName]
+  return Object.keys(validationState).filter(
+    (fieldName) => !validationState[fieldName],
   );
 }
 
 export function getValidFields(validationState: ValidationState): string[] {
-  return Object.keys(validationState).filter(fieldName => 
-    validationState[fieldName]
+  return Object.keys(validationState).filter(
+    (fieldName) => validationState[fieldName],
   );
 }

--- a/src/scripts/backend/courses/createCourse.ts
+++ b/src/scripts/backend/courses/createCourse.ts
@@ -2,7 +2,7 @@
 // COURSE CREATION & CRUD OPERATIONS
 // ==========================================================================
 
-import { supabase } from '../supabase';
+import { supabase } from "../supabase";
 
 // Course creation interface
 export interface CourseCreationData {
@@ -26,50 +26,61 @@ export interface CourseValidation {
 // VALIDATION
 // ==========================================================================
 
-export function validateCourseData(data: Partial<CourseCreationData>): CourseValidation {
+export function validateCourseData(
+  data: Partial<CourseCreationData>,
+): CourseValidation {
   return {
-    course_name: Boolean(data.course_name && data.course_name.trim().length >= 3),
-    course_description: Boolean(data.course_description && data.course_description.trim().length >= 10),
-    course_language: Boolean(data.course_language && data.course_language.trim()),
-    course_image: Boolean(data.course_image) // Course image is required
+    course_name: Boolean(
+      data.course_name && data.course_name.trim().length >= 3,
+    ),
+    course_description: Boolean(
+      data.course_description && data.course_description.trim().length >= 10,
+    ),
+    course_language: Boolean(
+      data.course_language && data.course_language.trim(),
+    ),
+    course_image: Boolean(data.course_image), // Course image is required
   };
 }
 
 export function isValidCourse(validation: CourseValidation): boolean {
-  return Object.values(validation).every(isValid => isValid);
+  return Object.values(validation).every((isValid) => isValid);
 }
 
 // ==========================================================================
 // IMAGE UPLOAD
 // ==========================================================================
 
-export async function uploadCourseImage(file: File, courseId: string): Promise<string | null> {
+export async function uploadCourseImage(
+  file: File,
+  courseId: string,
+): Promise<string | null> {
   try {
-    const fileExt = file.name.split('.').pop();
+    const fileExt = file.name.split(".").pop();
     const fileName = `${courseId}/cover.${fileExt}`;
     const filePath = `course-images/${fileName}`;
 
     // Upload file to Supabase Storage
     const { error } = await supabase.storage
-      .from('courses')
+      .from("courses")
       .upload(filePath, file, {
-        cacheControl: '3600',
-        upsert: true
+        cacheControl: "3600",
+        upsert: true,
       });
 
     if (error) {
-      console.error('Error uploading image:', error);
+      console.error("Error uploading image:", error);
       return null;
     }
 
     // Get public URL
-    const { data: { publicUrl } } = supabase.storage
-      .from('courses')
-      .getPublicUrl(filePath);
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from("courses").getPublicUrl(filePath);
 
     return publicUrl;
   } catch (error) {
-    console.error('Error in uploadCourseImage:', error);
+    console.error("Error in uploadCourseImage:", error);
     return null;
   }
 }
@@ -78,22 +89,30 @@ export async function uploadCourseImage(file: File, courseId: string): Promise<s
 // COURSE CRUD OPERATIONS
 // ==========================================================================
 
-export async function createCourse(data: CourseCreationData): Promise<{ success: boolean; courseId?: string; error?: string }> {
+export async function createCourse(
+  data: CourseCreationData,
+): Promise<{ success: boolean; courseId?: string; error?: string }> {
   try {
     // Enhanced authentication check with session validation
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
     if (sessionError) {
-      console.error('Session error:', sessionError);
-      return { success: false, error: 'Authentication session error' };
+      console.error("Session error:", sessionError);
+      return { success: false, error: "Authentication session error" };
     }
 
     if (!session?.user) {
-      console.error('No valid session or user found');
-      return { success: false, error: 'User not authenticated - please sign in again' };
+      console.error("No valid session or user found");
+      return {
+        success: false,
+        error: "User not authenticated - please sign in again",
+      };
     }
 
     const user = session.user;
-    console.log('Creating course for user:', user.id);
+    console.log("Creating course for user:", user.id);
 
     // Ensure user profile exists in users table
     await ensureUserProfile(user);
@@ -101,7 +120,7 @@ export async function createCourse(data: CourseCreationData): Promise<{ success:
     // Validate data
     const validation = validateCourseData(data);
     if (!isValidCourse(validation)) {
-      return { success: false, error: 'Invalid course data' };
+      return { success: false, error: "Invalid course data" };
     }
 
     // Create course record with your actual schema
@@ -111,49 +130,52 @@ export async function createCourse(data: CourseCreationData): Promise<{ success:
       course_language: data.course_language.trim(),
       teacher_id: user.id, // Use teacher_id from your schema
       created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString()
+      updated_at: new Date().toISOString(),
     };
 
-    console.log('Inserting course data:', courseInsertData);
+    console.log("Inserting course data:", courseInsertData);
 
     const { data: courseData, error: courseError } = await supabase
-      .from('courses')
+      .from("courses")
       .insert(courseInsertData)
-      .select('id')
+      .select("id")
       .single();
 
     if (courseError) {
-      console.error('Error creating course:', courseError);
-      return { success: false, error: `Failed to create course: ${courseError.message}` };
+      console.error("Error creating course:", courseError);
+      return {
+        success: false,
+        error: `Failed to create course: ${courseError.message}`,
+      };
     }
 
     const courseId = courseData.id;
-    console.log('Course created successfully with ID:', courseId);
+    console.log("Course created successfully with ID:", courseId);
 
     // Upload image if provided
     if (data.course_image) {
-      console.log('Uploading course image...');
+      console.log("Uploading course image...");
       const imageUrl = await uploadCourseImage(data.course_image, courseId);
       if (imageUrl) {
-        console.log('Updating course with image URL:', imageUrl);
+        console.log("Updating course with image URL:", imageUrl);
         // Update course with image URL using course_image field
         const { error: updateError } = await supabase
-          .from('courses')
+          .from("courses")
           .update({ course_image: imageUrl })
-          .eq('id', courseId);
-        
+          .eq("id", courseId);
+
         if (updateError) {
-          console.error('Error updating course with image:', updateError);
+          console.error("Error updating course with image:", updateError);
           // Don't fail the entire operation for image update failure
-          console.warn('Course created but image update failed');
+          console.warn("Course created but image update failed");
         }
       }
     }
 
     return { success: true, courseId };
   } catch (error) {
-    console.error('Error in createCourse:', error);
-    return { success: false, error: 'Unexpected error occurred' };
+    console.error("Error in createCourse:", error);
+    return { success: false, error: "Unexpected error occurred" };
   }
 }
 
@@ -161,19 +183,19 @@ export async function createCourse(data: CourseCreationData): Promise<{ success:
 async function ensureUserProfile(user: any): Promise<void> {
   try {
     // First try using the database function
-    const { error: rpcError } = await supabase.rpc('ensure_user_profile', {
+    const { error: rpcError } = await supabase.rpc("ensure_user_profile", {
       user_id: user.id,
       user_email: user.email,
-      user_role: 'teacher'
+      user_role: "teacher",
     });
 
     if (rpcError) {
-      console.warn('RPC call failed, using fallback method:', rpcError);
+      console.warn("RPC call failed, using fallback method:", rpcError);
       // Fallback to direct upsert
       await ensureUserProfileFallback(user);
     }
   } catch (error) {
-    console.warn('Error ensuring user profile, using fallback:', error);
+    console.warn("Error ensuring user profile, using fallback:", error);
     await ensureUserProfileFallback(user);
   }
 }
@@ -182,120 +204,132 @@ async function ensureUserProfile(user: any): Promise<void> {
 async function ensureUserProfileFallback(user: any): Promise<void> {
   try {
     const userMetadata = user.user_metadata || {};
-    const fullName = userMetadata.full_name || user.email?.split('@')[0] || 'User';
-    const userRole = userMetadata.user_role || 'teacher';
-    
-    const nameParts = fullName.split(' ');
-    const firstName = nameParts[0] || '';
-    const lastName = nameParts.slice(1).join(' ') || '';
+    const fullName =
+      userMetadata.full_name || user.email?.split("@")[0] || "User";
+    const userRole = userMetadata.user_role || "teacher";
 
-    const { error } = await supabase
-      .from('users')
-      .upsert({
+    const nameParts = fullName.split(" ");
+    const firstName = nameParts[0] || "";
+    const lastName = nameParts.slice(1).join(" ") || "";
+
+    const { error } = await supabase.from("users").upsert(
+      {
         id: user.id,
         first_name: firstName,
         last_name: lastName,
         email: user.email,
         role: userRole,
-        institution: 'Independent'
-      }, {
-        onConflict: 'id'
-      });
+        institution: "Independent",
+      },
+      {
+        onConflict: "id",
+      },
+    );
 
     if (error) {
-      console.error('Failed to create user profile:', error);
+      console.error("Failed to create user profile:", error);
     } else {
-      console.log('User profile ensured via fallback method');
+      console.log("User profile ensured via fallback method");
     }
   } catch (error) {
-    console.error('Error in ensureUserProfileFallback:', error);
+    console.error("Error in ensureUserProfileFallback:", error);
   }
 }
 
-export async function updateCourse(courseId: string, data: Partial<CourseCreationData>): Promise<{ success: boolean; error?: string }> {
+export async function updateCourse(
+  courseId: string,
+  data: Partial<CourseCreationData>,
+): Promise<{ success: boolean; error?: string }> {
   try {
     const { error } = await supabase
-      .from('courses')
+      .from("courses")
       .update({
         ...data,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
-      .eq('id', courseId);
+      .eq("id", courseId);
 
     if (error) {
-      console.error('Error updating course:', error);
-      return { success: false, error: 'Failed to update course' };
+      console.error("Error updating course:", error);
+      return { success: false, error: "Failed to update course" };
     }
 
     return { success: true };
   } catch (error) {
-    console.error('Error in updateCourse:', error);
-    return { success: false, error: 'Unexpected error occurred' };
+    console.error("Error in updateCourse:", error);
+    return { success: false, error: "Unexpected error occurred" };
   }
 }
 
-export async function deleteCourse(courseId: string): Promise<{ success: boolean; error?: string }> {
+export async function deleteCourse(
+  courseId: string,
+): Promise<{ success: boolean; error?: string }> {
   try {
     const { error } = await supabase
-      .from('courses')
+      .from("courses")
       .delete()
-      .eq('id', courseId);
+      .eq("id", courseId);
 
     if (error) {
-      console.error('Error deleting course:', error);
-      return { success: false, error: 'Failed to delete course' };
+      console.error("Error deleting course:", error);
+      return { success: false, error: "Failed to delete course" };
     }
 
     return { success: true };
   } catch (error) {
-    console.error('Error in deleteCourse:', error);
-    return { success: false, error: 'Unexpected error occurred' };
+    console.error("Error in deleteCourse:", error);
+    return { success: false, error: "Unexpected error occurred" };
   }
 }
 
 export async function getCourse(courseId: string) {
   try {
     const { data, error } = await supabase
-      .from('courses')
-      .select('*')
-      .eq('id', courseId)
+      .from("courses")
+      .select("*")
+      .eq("id", courseId)
       .single();
 
     if (error) {
-      console.error('Error fetching course:', error);
+      console.error("Error fetching course:", error);
       return null;
     }
 
     return data;
   } catch (error) {
-    console.error('Error in getCourse:', error);
+    console.error("Error in getCourse:", error);
     return null;
   }
 }
 
 export async function getUserCourses(userId?: string) {
   try {
-    let query = supabase.from('courses').select('*');
-    
+    let query = supabase.from("courses").select("*");
+
     if (userId) {
-      query = query.eq('teacher_id', userId); // Fixed: using teacher_id instead of user_id
+      query = query.eq("teacher_id", userId); // Fixed: using teacher_id instead of user_id
     } else {
       // Get current user's courses
-      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
       if (authError || !user) return [];
-      query = query.eq('teacher_id', user.id); // Fixed: using teacher_id instead of user_id
+      query = query.eq("teacher_id", user.id); // Fixed: using teacher_id instead of user_id
     }
 
-    const { data, error } = await query.order('created_at', { ascending: false });
+    const { data, error } = await query.order("created_at", {
+      ascending: false,
+    });
 
     if (error) {
-      console.error('Error fetching courses:', error);
+      console.error("Error fetching courses:", error);
       return [];
     }
 
     return data || [];
   } catch (error) {
-    console.error('Error in getUserCourses:', error);
+    console.error("Error in getUserCourses:", error);
     return [];
   }
 }

--- a/src/scripts/backend/courses/createCourseCard.ts
+++ b/src/scripts/backend/courses/createCourseCard.ts
@@ -2,7 +2,7 @@
 // COURSES PAGE - Load and display user courses with navigation
 // ==========================================================================
 
-import { getUserCourses } from './createCourse';
+import { getUserCourses } from "./createCourse";
 
 interface Course {
   id: string;
@@ -20,22 +20,26 @@ export class CoursesManager {
   private noCoursesMessage: HTMLElement;
 
   constructor() {
-    this.coursesContainer = document.getElementById('courses-container') as HTMLElement;
-    this.noCoursesMessage = document.getElementById('no-courses-message') as HTMLElement;
-    
+    this.coursesContainer = document.getElementById(
+      "courses-container",
+    ) as HTMLElement;
+    this.noCoursesMessage = document.getElementById(
+      "no-courses-message",
+    ) as HTMLElement;
+
     this.initialize();
   }
 
   private async initialize(): Promise<void> {
-    console.log('Initializing courses manager...');
+    console.log("Initializing courses manager...");
     await this.loadCourses();
   }
 
   private async loadCourses(): Promise<void> {
     try {
       const courses = await getUserCourses();
-      console.log('Loaded courses:', courses);
-      
+      console.log("Loaded courses:", courses);
+
       if (courses && courses.length > 0) {
         this.displayCourses(courses);
         this.hideNoCoursesMessage();
@@ -43,32 +47,34 @@ export class CoursesManager {
         this.showNoCoursesMessage();
       }
     } catch (error) {
-      console.error('Error loading courses:', error);
+      console.error("Error loading courses:", error);
       this.showNoCoursesMessage();
     }
   }
 
   private displayCourses(courses: Course[]): void {
     // Clear existing courses (except no-courses message)
-    const existingCards = this.coursesContainer.querySelectorAll('.course-card');
-    existingCards.forEach(card => card.remove());
+    const existingCards =
+      this.coursesContainer.querySelectorAll(".course-card");
+    existingCards.forEach((card) => card.remove());
 
-    courses.forEach(course => {
+    courses.forEach((course) => {
       const courseCard = this.createCourseCard(course);
       this.coursesContainer.appendChild(courseCard);
     });
   }
 
   private createCourseCard(course: Course): HTMLElement {
-    const cardElement = document.createElement('div');
-    cardElement.className = 'course-card';
+    const cardElement = document.createElement("div");
+    cardElement.className = "course-card";
     cardElement.dataset.courseId = course.id;
 
     cardElement.innerHTML = `
       <div class="course-card__image-container">
-        ${course.course_image 
-          ? `<img src="${course.course_image}" alt="${course.course_name}" class="course-card__image">`
-          : `<div class="course-card__image-placeholder">${this.getInitials(course.course_name)}</div>`
+        ${
+          course.course_image
+            ? `<img src="${course.course_image}" alt="${course.course_name}" class="course-card__image">`
+            : `<div class="course-card__image-placeholder">${this.getInitials(course.course_name)}</div>`
         }
       </div>
       
@@ -103,15 +109,15 @@ export class CoursesManager {
   }
 
   private addNavigationEventListeners(cardElement: HTMLElement): void {
-    const navItems = cardElement.querySelectorAll('.course-card__nav-item');
-    
-    navItems.forEach(item => {
-      item.addEventListener('click', (e) => {
+    const navItems = cardElement.querySelectorAll(".course-card__nav-item");
+
+    navItems.forEach((item) => {
+      item.addEventListener("click", (e) => {
         e.stopPropagation();
-        
+
         const section = (item as HTMLElement).dataset.section;
         const courseId = (item as HTMLElement).dataset.courseId;
-        
+
         if (section && courseId) {
           this.navigateToCourseSection(courseId, section);
         }
@@ -121,10 +127,10 @@ export class CoursesManager {
 
   private navigateToCourseSection(courseId: string, section: string): void {
     console.log(`Navigating to course ${courseId}, section: ${section}`);
-    
+
     // Store the course ID in session storage for the course builder
-    sessionStorage.setItem('currentCourseId', courseId);
-    
+    sessionStorage.setItem("currentCourseId", courseId);
+
     // Navigate to the course builder with the specific section
     const url = `/src/pages/teacher/coursebuilder.html#${section}`;
     console.log(`Navigating to: ${url}`);
@@ -133,21 +139,21 @@ export class CoursesManager {
 
   private getInitials(courseName: string): string {
     return courseName
-      .split(' ')
-      .map(word => word.charAt(0).toUpperCase())
+      .split(" ")
+      .map((word) => word.charAt(0).toUpperCase())
       .slice(0, 2)
-      .join('');
+      .join("");
   }
 
   private showNoCoursesMessage(): void {
     if (this.noCoursesMessage) {
-      this.noCoursesMessage.style.display = 'block';
+      this.noCoursesMessage.style.display = "block";
     }
   }
 
   private hideNoCoursesMessage(): void {
     if (this.noCoursesMessage) {
-      this.noCoursesMessage.style.display = 'none';
+      this.noCoursesMessage.style.display = "none";
     }
   }
 
@@ -162,7 +168,7 @@ export class CoursesManager {
 // ==========================================================================
 
 // Auto-initialize when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   new CoursesManager();
 });
 

--- a/src/scripts/backend/courses/createTemplate.ts
+++ b/src/scripts/backend/courses/createTemplate.ts
@@ -1,10 +1,10 @@
-import { supabase } from '../supabase.js';
+import { supabase } from "../supabase.js";
 
 export interface TemplateData {
   template_id: string;
   course_id?: string;
   template_description?: string;
-  template_type: 'lesson';
+  template_type: "lesson";
   template_data: {
     name: string;
     blocks: TemplateBlock[];
@@ -14,7 +14,13 @@ export interface TemplateData {
 
 export interface TemplateBlock {
   id: string;
-  type: 'header' | 'program' | 'resources' | 'content' | 'assignment' | 'footer';
+  type:
+    | "header"
+    | "program"
+    | "resources"
+    | "content"
+    | "assignment"
+    | "footer";
   order: number;
   config: Record<string, any>;
   content: string;
@@ -29,32 +35,36 @@ export class TemplateManager {
    * Shows the create template modal
    */
   static showCreateTemplateModal(): void {
-    const modal = document.getElementById('create-template-modal') as HTMLElement;
+    const modal = document.getElementById(
+      "create-template-modal",
+    ) as HTMLElement;
     if (!modal) {
-      console.error('Create template modal not found');
+      console.error("Create template modal not found");
       return;
     }
 
     // Clear the form for new template creation
-    const form = modal.querySelector('#create-template-form') as HTMLFormElement;
+    const form = modal.querySelector(
+      "#create-template-form",
+    ) as HTMLFormElement;
     if (form) {
       form.reset();
     }
 
-    modal.style.display = 'flex';
-    modal.classList.add('modal--active');
+    modal.style.display = "flex";
+    modal.classList.add("modal--active");
   }
 
   /**
    * Hides the create template modal
    */
   static hideCreateTemplateModal(): void {
-    const modal = document.getElementById('create-template-modal');
+    const modal = document.getElementById("create-template-modal");
     if (modal) {
-      modal.classList.remove('modal--active');
-      
+      modal.classList.remove("modal--active");
+
       setTimeout(() => {
-        modal.style.display = 'none';
+        modal.style.display = "none";
       }, 300);
     }
   }
@@ -63,20 +73,20 @@ export class TemplateManager {
    * Shows the load template modal
    */
   static async showLoadTemplateModal(): Promise<void> {
-    const modal = document.getElementById('load-template-modal');
+    const modal = document.getElementById("load-template-modal");
     if (modal) {
-      modal.style.display = 'flex';
-      modal.classList.add('modal--active');
-      
+      modal.style.display = "flex";
+      modal.classList.add("modal--active");
+
       // Load templates when modal is shown
       await this.loadTemplatesForModal();
-      
+
       // Add a small delay to trigger the animation
       setTimeout(() => {
-        const content = modal.querySelector('.modal__content') as HTMLElement;
+        const content = modal.querySelector(".modal__content") as HTMLElement;
         if (content) {
-          content.style.transform = 'scale(1)';
-          content.style.opacity = '1';
+          content.style.transform = "scale(1)";
+          content.style.opacity = "1";
         }
       }, 10);
     }
@@ -86,19 +96,19 @@ export class TemplateManager {
    * Hides the load template modal
    */
   static hideLoadTemplateModal(): void {
-    const modal = document.getElementById('load-template-modal');
+    const modal = document.getElementById("load-template-modal");
     if (modal) {
-      const content = modal.querySelector('.modal__content') as HTMLElement;
+      const content = modal.querySelector(".modal__content") as HTMLElement;
       if (content) {
-        content.style.transform = 'scale(0.9)';
-        content.style.opacity = '0';
+        content.style.transform = "scale(0.9)";
+        content.style.opacity = "0";
       }
-      
+
       setTimeout(() => {
-        modal.style.display = 'none';
-        modal.classList.remove('modal--active');
+        modal.style.display = "none";
+        modal.classList.remove("modal--active");
       }, 300);
-      
+
       // Clear selection
       this.selectedTemplateId = null;
       this.updateLoadButtonState();
@@ -109,41 +119,45 @@ export class TemplateManager {
    * Loads templates for the modal display
    */
   static async loadTemplatesForModal(): Promise<void> {
-    const loadingEl = document.getElementById('template-loading');
-    const contentEl = document.getElementById('template-list-content');
-    const noTemplatesEl = document.getElementById('no-templates-message');
+    const loadingEl = document.getElementById("template-loading");
+    const contentEl = document.getElementById("template-list-content");
+    const noTemplatesEl = document.getElementById("no-templates-message");
 
-    if (loadingEl) loadingEl.style.display = 'flex';
-    if (contentEl) contentEl.style.display = 'none';
-    if (noTemplatesEl) noTemplatesEl.style.display = 'none';
+    if (loadingEl) loadingEl.style.display = "flex";
+    if (contentEl) contentEl.style.display = "none";
+    if (noTemplatesEl) noTemplatesEl.style.display = "none";
 
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) {
-        throw new Error('User not authenticated');
+        throw new Error("User not authenticated");
       }
 
       const { data, error } = await supabase
-        .from('templates')
-        .select('id, template_id, template_type, template_description, created_at, template_data')
-        .eq('created_by', user.id)
-        .order('created_at', { ascending: false });
+        .from("templates")
+        .select(
+          "id, template_id, template_type, template_description, created_at, template_data",
+        )
+        .eq("created_by", user.id)
+        .order("created_at", { ascending: false });
 
       if (error) {
         throw error;
       }
 
-      if (loadingEl) loadingEl.style.display = 'none';
+      if (loadingEl) loadingEl.style.display = "none";
 
       if (!data || data.length === 0) {
-        if (noTemplatesEl) noTemplatesEl.style.display = 'flex';
+        if (noTemplatesEl) noTemplatesEl.style.display = "flex";
       } else {
         this.displayTemplatesInModal(data);
-        if (contentEl) contentEl.style.display = 'grid';
+        if (contentEl) contentEl.style.display = "grid";
       }
     } catch (error) {
-      console.error('Failed to load templates:', error);
-      if (loadingEl) loadingEl.style.display = 'none';
+      console.error("Failed to load templates:", error);
+      if (loadingEl) loadingEl.style.display = "none";
       if (noTemplatesEl) {
         noTemplatesEl.innerHTML = `
           <div class="no-templates__icon">⚠</div>
@@ -153,7 +167,7 @@ export class TemplateManager {
             Retry
           </button>
         `;
-        noTemplatesEl.style.display = 'flex';
+        noTemplatesEl.style.display = "flex";
       }
     }
   }
@@ -162,15 +176,18 @@ export class TemplateManager {
    * Displays templates in the modal
    */
   static displayTemplatesInModal(templates: any[]): void {
-    const contentEl = document.getElementById('template-list-content');
+    const contentEl = document.getElementById("template-list-content");
     if (!contentEl) return;
 
-    const templatesHtml = templates.map(template => {
-      const createdDate = new Date(template.created_at).toLocaleDateString();
-      const templateName = template.template_data?.name || 'Untitled Template';
-      const description = template.template_description || 'No description provided';
-      
-      return `
+    const templatesHtml = templates
+      .map((template) => {
+        const createdDate = new Date(template.created_at).toLocaleDateString();
+        const templateName =
+          template.template_data?.name || "Untitled Template";
+        const description =
+          template.template_description || "No description provided";
+
+        return `
         <div class="template-card" data-template-id="${template.id}" onclick="TemplateManager.selectTemplate('${template.id}')">
           <div class="template-card__header">
             <h4 class="template-card__title">${templateName}</h4>
@@ -192,7 +209,8 @@ export class TemplateManager {
           </div>
         </div>
       `;
-    }).join('');
+      })
+      .join("");
 
     contentEl.innerHTML = templatesHtml;
   }
@@ -202,14 +220,16 @@ export class TemplateManager {
    */
   static selectTemplate(templateId: string): void {
     // Remove previous selection
-    document.querySelectorAll('.template-card').forEach(card => {
-      card.classList.remove('template-card--selected');
+    document.querySelectorAll(".template-card").forEach((card) => {
+      card.classList.remove("template-card--selected");
     });
 
     // Add selection to current template
-    const selectedCard = document.querySelector(`[data-template-id="${templateId}"]`);
+    const selectedCard = document.querySelector(
+      `[data-template-id="${templateId}"]`,
+    );
     if (selectedCard) {
-      selectedCard.classList.add('template-card--selected');
+      selectedCard.classList.add("template-card--selected");
     }
 
     this.selectedTemplateId = templateId;
@@ -220,7 +240,9 @@ export class TemplateManager {
    * Updates the load button state
    */
   static updateLoadButtonState(): void {
-    const loadButton = document.getElementById('load-selected-template') as HTMLButtonElement;
+    const loadButton = document.getElementById(
+      "load-selected-template",
+    ) as HTMLButtonElement;
     if (loadButton) {
       loadButton.disabled = !this.selectedTemplateId;
     }
@@ -236,21 +258,32 @@ export class TemplateManager {
       await this.loadTemplate(this.selectedTemplateId);
       this.hideLoadTemplateModal();
       // The template is now loaded in the config and preview areas
-      console.log('Template loaded successfully for editing');
+      console.log("Template loaded successfully for editing");
     } catch (error) {
-      console.error('Failed to load selected template:', error);
-      alert('Failed to load template. Please try again.');
+      console.error("Failed to load selected template:", error);
+      alert("Failed to load template. Please try again.");
     }
   }
 
   /**
    * Updates a template field and auto-saves to database
    */
-  static async updateTemplateField(templateId: string, blockType: string, fieldName: string, isChecked: boolean): Promise<void> {
+  static async updateTemplateField(
+    templateId: string,
+    blockType: string,
+    fieldName: string,
+    isChecked: boolean,
+  ): Promise<void> {
     try {
       // Update the currently loaded template data
-      if (this.currentlyLoadedTemplateData && this.currentlyLoadedTemplateData.id === templateId) {
-        const block = this.currentlyLoadedTemplateData.template_data.blocks.find((b: any) => b.type === blockType);
+      if (
+        this.currentlyLoadedTemplateData &&
+        this.currentlyLoadedTemplateData.id === templateId
+      ) {
+        const block =
+          this.currentlyLoadedTemplateData.template_data.blocks.find(
+            (b: any) => b.type === blockType,
+          );
         if (block) {
           if (isChecked) {
             block.config[fieldName] = true;
@@ -258,29 +291,32 @@ export class TemplateManager {
             delete block.config[fieldName];
           }
         }
-        
+
         // Data is automatically persisted to database via auto-save
       }
-      
+
       // Show saving status
-      const statusEl = document.getElementById('template-save-status');
+      const statusEl = document.getElementById("template-save-status");
       if (statusEl) {
-        statusEl.innerHTML = '<span class="save-indicator__text save-indicator__text--saving">Saving...</span>';
+        statusEl.innerHTML =
+          '<span class="save-indicator__text save-indicator__text--saving">Saving...</span>';
       }
-      
+
       // Get current template data from database
       const { data: currentTemplate, error: fetchError } = await supabase
-        .from('templates')
-        .select('template_data')
-        .eq('id', templateId)
+        .from("templates")
+        .select("template_data")
+        .eq("id", templateId)
         .single();
-      
+
       if (fetchError) throw fetchError;
-      
+
       // Update the specific block's config
       const updatedTemplateData = { ...currentTemplate.template_data };
-      const blockToUpdate = updatedTemplateData.blocks.find((block: any) => block.type === blockType);
-      
+      const blockToUpdate = updatedTemplateData.blocks.find(
+        (block: any) => block.type === blockType,
+      );
+
       if (blockToUpdate) {
         if (isChecked) {
           blockToUpdate.config[fieldName] = true;
@@ -288,38 +324,41 @@ export class TemplateManager {
           delete blockToUpdate.config[fieldName];
         }
       }
-      
+
       // Save to database
       const { error: updateError } = await supabase
-        .from('templates')
-        .update({ 
+        .from("templates")
+        .update({
           template_data: updatedTemplateData,
-          updated_at: new Date().toISOString()
+          updated_at: new Date().toISOString(),
         })
-        .eq('id', templateId);
-      
+        .eq("id", templateId);
+
       if (updateError) throw updateError;
-      
+
       // Show success status
       if (statusEl) {
-        statusEl.innerHTML = '<span class="save-indicator__text save-indicator__text--saved">Saved</span>';
+        statusEl.innerHTML =
+          '<span class="save-indicator__text save-indicator__text--saved">Saved</span>';
         setTimeout(() => {
-          statusEl.innerHTML = '<span class="save-indicator__text">Changes saved automatically</span>';
+          statusEl.innerHTML =
+            '<span class="save-indicator__text">Changes saved automatically</span>';
         }, 2000);
       }
-      
+
       // Update the preview
       this.updateTemplatePreview();
-      
     } catch (error) {
-      console.error('Failed to update template field:', error);
-      
+      console.error("Failed to update template field:", error);
+
       // Show error status
-      const statusEl = document.getElementById('template-save-status');
+      const statusEl = document.getElementById("template-save-status");
       if (statusEl) {
-        statusEl.innerHTML = '<span class="save-indicator__text save-indicator__text--error">Error saving</span>';
+        statusEl.innerHTML =
+          '<span class="save-indicator__text save-indicator__text--error">Error saving</span>';
         setTimeout(() => {
-          statusEl.innerHTML = '<span class="save-indicator__text">Changes saved automatically</span>';
+          statusEl.innerHTML =
+            '<span class="save-indicator__text">Changes saved automatically</span>';
         }, 3000);
       }
     }
@@ -332,11 +371,11 @@ export class TemplateManager {
     try {
       // This would typically gather data from the configuration forms
       // For now, just show a success message
-      console.log('Saving template changes for:', templateId);
-      alert('Template changes saved successfully!');
+      console.log("Saving template changes for:", templateId);
+      alert("Template changes saved successfully!");
     } catch (error) {
-      console.error('Failed to save template changes:', error);
-      alert('Failed to save template changes. Please try again.');
+      console.error("Failed to save template changes:", error);
+      alert("Failed to save template changes. Please try again.");
     }
   }
 
@@ -346,9 +385,9 @@ export class TemplateManager {
   static async previewTemplateInModal(templateId: string): Promise<void> {
     try {
       const { data, error } = await supabase
-        .from('templates')
-        .select('*')
-        .eq('id', templateId)
+        .from("templates")
+        .select("*")
+        .eq("id", templateId)
         .single();
 
       if (error) throw error;
@@ -358,27 +397,33 @@ export class TemplateManager {
         <div class="template-preview-modal" onclick="this.remove()">
           <div class="template-preview-modal__content" onclick="event.stopPropagation()">
             <div class="template-preview-modal__header">
-              <h3>${data.template_data?.name || 'Template Preview'}</h3>
+              <h3>${data.template_data?.name || "Template Preview"}</h3>
               <button onclick="this.closest('.template-preview-modal').remove()">&times;</button>
             </div>
             <div class="template-preview-modal__body">
               <div class="template-blocks-preview">
-                ${data.template_data?.blocks?.map((block: any) => `
+                ${
+                  data.template_data?.blocks
+                    ?.map(
+                      (block: any) => `
                   <div class="preview-block preview-block--${block.type}">
                     <div class="preview-block__label">${block.type.charAt(0).toUpperCase() + block.type.slice(1)}</div>
-                    <div class="preview-block__content">${block.content || 'No content'}</div>
+                    <div class="preview-block__content">${block.content || "No content"}</div>
                   </div>
-                `).join('') || '<p>No blocks configured</p>'}
+                `,
+                    )
+                    .join("") || "<p>No blocks configured</p>"
+                }
               </div>
             </div>
           </div>
         </div>
       `;
 
-      document.body.insertAdjacentHTML('beforeend', previewHtml);
+      document.body.insertAdjacentHTML("beforeend", previewHtml);
     } catch (error) {
-      console.error('Failed to preview template:', error);
-      alert('Failed to load template preview.');
+      console.error("Failed to preview template:", error);
+      alert("Failed to load template preview.");
     }
   }
 
@@ -386,24 +431,26 @@ export class TemplateManager {
    * Deletes a template
    */
   static async deleteTemplate(templateId: string): Promise<void> {
-    const confirmation = confirm('Are you sure you want to delete this template? This action cannot be undone.');
+    const confirmation = confirm(
+      "Are you sure you want to delete this template? This action cannot be undone.",
+    );
     if (!confirmation) return;
 
     try {
       const { error } = await supabase
-        .from('templates')
+        .from("templates")
         .delete()
-        .eq('id', templateId);
+        .eq("id", templateId);
 
       if (error) throw error;
 
       // Reload templates in modal
       await this.loadTemplatesForModal();
-      
-      console.log('Template deleted successfully');
+
+      console.log("Template deleted successfully");
     } catch (error) {
-      console.error('Failed to delete template:', error);
-      alert('Failed to delete template. Please try again.');
+      console.error("Failed to delete template:", error);
+      alert("Failed to delete template. Please try again.");
     }
   }
 
@@ -411,18 +458,28 @@ export class TemplateManager {
    * Filters templates based on search term
    */
   static filterTemplates(searchTerm: string): void {
-    const templateCards = document.querySelectorAll('.template-card');
-    
-    templateCards.forEach(card => {
-      const title = card.querySelector('.template-card__title')?.textContent?.toLowerCase() || '';
-      const description = card.querySelector('.template-card__description')?.textContent?.toLowerCase() || '';
-      const type = card.querySelector('.template-card__type')?.textContent?.toLowerCase() || '';
-      
-      const matchesSearch = title.includes(searchTerm) || 
-                           description.includes(searchTerm) || 
-                           type.includes(searchTerm);
-      
-      (card as HTMLElement).style.display = matchesSearch ? 'block' : 'none';
+    const templateCards = document.querySelectorAll(".template-card");
+
+    templateCards.forEach((card) => {
+      const title =
+        card
+          .querySelector(".template-card__title")
+          ?.textContent?.toLowerCase() || "";
+      const description =
+        card
+          .querySelector(".template-card__description")
+          ?.textContent?.toLowerCase() || "";
+      const type =
+        card
+          .querySelector(".template-card__type")
+          ?.textContent?.toLowerCase() || "";
+
+      const matchesSearch =
+        title.includes(searchTerm) ||
+        description.includes(searchTerm) ||
+        type.includes(searchTerm);
+
+      (card as HTMLElement).style.display = matchesSearch ? "block" : "none";
     });
   }
 
@@ -430,50 +487,72 @@ export class TemplateManager {
    * Applies filters and sorting to templates
    */
   static applyFiltersAndSort(): void {
-    const typeFilter = document.getElementById('template-type-filter') as HTMLSelectElement;
-    const sortFilter = document.getElementById('template-sort') as HTMLSelectElement;
-    const searchInput = document.getElementById('template-search') as HTMLInputElement;
-    
+    const typeFilter = document.getElementById(
+      "template-type-filter",
+    ) as HTMLSelectElement;
+    const sortFilter = document.getElementById(
+      "template-sort",
+    ) as HTMLSelectElement;
+    const searchInput = document.getElementById(
+      "template-search",
+    ) as HTMLInputElement;
+
     if (!typeFilter || !sortFilter) return;
 
     const selectedType = typeFilter.value;
     const sortBy = sortFilter.value;
-    const searchTerm = searchInput?.value?.toLowerCase() || '';
+    const searchTerm = searchInput?.value?.toLowerCase() || "";
 
-    const container = document.getElementById('template-list-content');
+    const container = document.getElementById("template-list-content");
     if (!container) return;
 
-    const templateCards = Array.from(container.querySelectorAll('.template-card')) as HTMLElement[];
-    
+    const templateCards = Array.from(
+      container.querySelectorAll(".template-card"),
+    ) as HTMLElement[];
+
     // Filter by type and search
-    templateCards.forEach(card => {
-      const cardType = card.querySelector('.template-card__type')?.textContent?.toLowerCase() || '';
-      const title = card.querySelector('.template-card__title')?.textContent?.toLowerCase() || '';
-      const description = card.querySelector('.template-card__description')?.textContent?.toLowerCase() || '';
-      
+    templateCards.forEach((card) => {
+      const cardType =
+        card
+          .querySelector(".template-card__type")
+          ?.textContent?.toLowerCase() || "";
+      const title =
+        card
+          .querySelector(".template-card__title")
+          ?.textContent?.toLowerCase() || "";
+      const description =
+        card
+          .querySelector(".template-card__description")
+          ?.textContent?.toLowerCase() || "";
+
       const matchesType = !selectedType || cardType === selectedType;
-      const matchesSearch = !searchTerm || 
-                           title.includes(searchTerm) || 
-                           description.includes(searchTerm) || 
-                           cardType.includes(searchTerm);
-      
-      card.style.display = (matchesType && matchesSearch) ? 'block' : 'none';
+      const matchesSearch =
+        !searchTerm ||
+        title.includes(searchTerm) ||
+        description.includes(searchTerm) ||
+        cardType.includes(searchTerm);
+
+      card.style.display = matchesType && matchesSearch ? "block" : "none";
     });
 
     // Sort visible cards
-    const visibleCards = templateCards.filter(card => card.style.display !== 'none');
-    
+    const visibleCards = templateCards.filter(
+      (card) => card.style.display !== "none",
+    );
+
     visibleCards.sort((a, b) => {
       switch (sortBy) {
-        case 'name':
-          const nameA = a.querySelector('.template-card__title')?.textContent || '';
-          const nameB = b.querySelector('.template-card__title')?.textContent || '';
+        case "name":
+          const nameA =
+            a.querySelector(".template-card__title")?.textContent || "";
+          const nameB =
+            b.querySelector(".template-card__title")?.textContent || "";
           return nameA.localeCompare(nameB);
-        case 'created_at':
+        case "created_at":
           // For created_at, we assume newer templates are shown first by default
           // This would require storing the actual date in a data attribute for proper sorting
           return 0; // Keep original order for now
-        case 'modified_at':
+        case "modified_at":
           // Similar to created_at - would need modification date stored
           return 0; // Keep original order for now
         default:
@@ -482,7 +561,7 @@ export class TemplateManager {
     });
 
     // Re-append sorted cards
-    visibleCards.forEach(card => {
+    visibleCards.forEach((card) => {
       container.appendChild(card);
     });
   }
@@ -490,11 +569,17 @@ export class TemplateManager {
   /**
    * Creates a new template with default blocks
    */
-  static async createTemplate(formData: { name: string; type: 'lesson'; description?: string }): Promise<string | null> {
+  static async createTemplate(formData: {
+    name: string;
+    type: "lesson";
+    description?: string;
+  }): Promise<string | null> {
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) {
-        throw new Error('User not authenticated');
+        throw new Error("User not authenticated");
       }
 
       // Generate a unique template ID
@@ -503,79 +588,79 @@ export class TemplateManager {
       // Create default blocks for the template
       const defaultBlocks: TemplateBlock[] = [
         {
-          id: 'header-1',
-          type: 'header',
+          id: "header-1",
+          type: "header",
           order: 1,
-          config: { 
+          config: {
             lesson_number: true,
             lesson_title: true,
             module_title: true,
             course_title: true,
-            institution_name: true
+            institution_name: true,
           },
-          content: '<div class="header-section">{{header}}</div>'
+          content: '<div class="header-section">{{header}}</div>',
         },
         {
-          id: 'program-1',
-          type: 'program',
+          id: "program-1",
+          type: "program",
           order: 2,
-          config: { 
+          config: {
             competence: true,
             topic: true,
             objective: true,
-            task: true
+            task: true,
           },
-          content: '<div class="program-section">{{program}}</div>'
+          content: '<div class="program-section">{{program}}</div>',
         },
         {
-          id: 'resources-1',
-          type: 'resources',
+          id: "resources-1",
+          type: "resources",
           order: 3,
-          config: { 
+          config: {
             task: true,
             type: true,
-            origin: true
+            origin: true,
           },
-          content: '<div class="resources-section">{{resources}}</div>'
+          content: '<div class="resources-section">{{resources}}</div>',
         },
         {
-          id: 'content-1',
-          type: 'content',
+          id: "content-1",
+          type: "content",
           order: 4,
-          config: { 
+          config: {
             instruction_title: true,
             instruction_area: true,
             student_title: true,
             student_area: true,
             teacher_title: true,
-            teacher_area: true
+            teacher_area: true,
           },
-          content: '<div class="content-section">{{content}}</div>'
+          content: '<div class="content-section">{{content}}</div>',
         },
         {
-          id: 'assignment-1',
-          type: 'assignment',
+          id: "assignment-1",
+          type: "assignment",
           order: 5,
-          config: { 
+          config: {
             instruction_title: true,
             instruction_area: true,
             student_title: true,
             student_area: true,
             teacher_title: true,
-            teacher_area: true
+            teacher_area: true,
           },
-          content: '<div class="assignment-section">{{assignment}}</div>'
+          content: '<div class="assignment-section">{{assignment}}</div>',
         },
         {
-          id: 'footer-1',
-          type: 'footer',
+          id: "footer-1",
+          type: "footer",
           order: 6,
-          config: { 
+          config: {
             copyright: true,
-            page_number: true
+            page_number: true,
           },
-          content: '<footer class="template-footer">{{footer}}</footer>'
-        }
+          content: '<footer class="template-footer">{{footer}}</footer>',
+        },
       ];
 
       const templateData: TemplateData = {
@@ -586,34 +671,36 @@ export class TemplateManager {
           name: formData.name,
           blocks: defaultBlocks,
           settings: {
-            version: '1.0',
-            created_at: new Date().toISOString()
-          }
-        }
+            version: "1.0",
+            created_at: new Date().toISOString(),
+          },
+        },
       };
 
       const { data, error } = await supabase
-        .from('templates')
-        .insert([{
-          template_id: templateData.template_id,
-          template_type: templateData.template_type,
-          template_description: templateData.template_description,
-          template_data: templateData.template_data,
-          created_by: user.id,
-          created_at: new Date().toISOString()
-        }])
-        .select('id')
+        .from("templates")
+        .insert([
+          {
+            template_id: templateData.template_id,
+            template_type: templateData.template_type,
+            template_description: templateData.template_description,
+            template_data: templateData.template_data,
+            created_by: user.id,
+            created_at: new Date().toISOString(),
+          },
+        ])
+        .select("id")
         .single();
 
       if (error) {
-        console.error('Error creating template:', error);
+        console.error("Error creating template:", error);
         throw error;
       }
 
-      console.log('Template created successfully:', data.id);
+      console.log("Template created successfully:", data.id);
       return data.id;
     } catch (error) {
-      console.error('Failed to create template:', error);
+      console.error("Failed to create template:", error);
       return null;
     }
   }
@@ -622,32 +709,36 @@ export class TemplateManager {
    * Shows the template configuration and preview areas
    */
   static showTemplateBuilder(templateId?: string): void {
-    const templateLayout = document.querySelector('.template-layout') as HTMLElement;
-    
+    const templateLayout = document.querySelector(
+      ".template-layout",
+    ) as HTMLElement;
+
     if (templateLayout) {
       // Template layout is now always visible, no need to change display
-      
+
       // Wait a bit for the layout to be visible, then initialize
       setTimeout(() => {
         // Initialize the configuration handler if available
         if (window.templateConfigHandler) {
           window.templateConfigHandler.init();
         } else {
-          console.warn('Template config handler not available, showing basic interface');
+          console.warn(
+            "Template config handler not available, showing basic interface",
+          );
           this.initializeBasicInterface();
         }
-        
+
         // If templateId is provided, load the template
         if (templateId) {
-          console.log('Loading template with ID:', templateId);
+          console.log("Loading template with ID:", templateId);
           this.loadTemplate(templateId);
         } else {
-          console.log('Initializing empty template');
+          console.log("Initializing empty template");
           this.initializeEmptyTemplate();
         }
       }, 100);
     } else {
-      console.error('Template layout not found');
+      console.error("Template layout not found");
     }
   }
 
@@ -658,31 +749,38 @@ export class TemplateManager {
     try {
       // If we have a currently loaded template, display it instead of the placeholder
       if (this.currentlyLoadedTemplateData) {
-        console.log('Displaying currently loaded template:', this.currentlyLoadedTemplateData);
+        console.log(
+          "Displaying currently loaded template:",
+          this.currentlyLoadedTemplateData,
+        );
         this.displayTemplateBlocks(this.currentlyLoadedTemplateData);
         this.updateTemplatePreview(this.currentlyLoadedTemplateData);
         return;
       }
 
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) {
-        throw new Error('User not authenticated');
+        throw new Error("User not authenticated");
       }
 
       const { data, error } = await supabase
-        .from('templates')
-        .select('id, template_id, template_type, template_description, created_at, template_data')
-        .eq('created_by', user.id)
-        .order('created_at', { ascending: false });
+        .from("templates")
+        .select(
+          "id, template_id, template_type, template_description, created_at, template_data",
+        )
+        .eq("created_by", user.id)
+        .order("created_at", { ascending: false });
 
       if (error) {
         throw error;
       }
 
-      console.log('Loaded templates:', data);
+      console.log("Loaded templates:", data);
       this.displayTemplateList(data || []);
     } catch (error) {
-      console.error('Failed to load templates:', error);
+      console.error("Failed to load templates:", error);
     }
   }
 
@@ -690,7 +788,7 @@ export class TemplateManager {
    * Displays the list of available templates
    */
   static displayTemplateList(templates: any[]): void {
-    const configArea = document.querySelector('.template-config');
+    const configArea = document.querySelector(".template-config");
     if (!configArea) return;
 
     if (templates.length === 0) {
@@ -724,19 +822,19 @@ export class TemplateManager {
   static async previewTemplate(templateId: string): Promise<void> {
     try {
       const { data, error } = await supabase
-        .from('templates')
-        .select('*')
-        .eq('id', templateId)
+        .from("templates")
+        .select("*")
+        .eq("id", templateId)
         .single();
 
       if (error) {
         throw error;
       }
 
-      console.log('Previewing template:', data);
+      console.log("Previewing template:", data);
       this.updateTemplatePreview(data);
     } catch (error) {
-      console.error('Failed to preview template:', error);
+      console.error("Failed to preview template:", error);
     }
   }
 
@@ -744,12 +842,14 @@ export class TemplateManager {
    * Initializes a basic interface when the config handler is not available
    */
   static initializeBasicInterface(): void {
-    const configArea = document.querySelector('.template-config');
-    const previewArea = document.querySelector('.template-preview');
-    
+    const configArea = document.querySelector(".template-config");
+    const previewArea = document.querySelector(".template-preview");
+
     if (configArea) {
       // Use the existing placeholder structure from HTML instead of generating new HTML
-      const placeholder = configArea.querySelector('.template-config-placeholder');
+      const placeholder = configArea.querySelector(
+        ".template-config-placeholder",
+      );
       if (placeholder) {
         placeholder.innerHTML = `
           <h3 class="heading heading--tertiary">Template Configuration</h3>
@@ -757,9 +857,9 @@ export class TemplateManager {
         `;
       }
     }
-    
+
     if (previewArea) {
-      const previewContainer = previewArea.querySelector('.preview-container');
+      const previewContainer = previewArea.querySelector(".preview-container");
       if (previewContainer) {
         previewContainer.innerHTML = `
           <div class="preview-placeholder">
@@ -788,13 +888,15 @@ export class TemplateManager {
   static clearTemplateState(): void {
     this.currentlyLoadedTemplateId = null;
     this.currentlyLoadedTemplateData = null;
-    
+
     // Template state is now managed via database
-    
+
     // Reset the template areas to placeholder state
-    const templateConfig = document.querySelector('.template-config');
+    const templateConfig = document.querySelector(".template-config");
     if (templateConfig) {
-      const placeholder = templateConfig.querySelector('.template-config-placeholder');
+      const placeholder = templateConfig.querySelector(
+        ".template-config-placeholder",
+      );
       if (placeholder) {
         placeholder.innerHTML = `
           <h3 class="heading heading--tertiary">Template Configuration</h3>
@@ -803,7 +905,7 @@ export class TemplateManager {
       }
     }
 
-    const previewContainer = document.querySelector('.preview-container');
+    const previewContainer = document.querySelector(".preview-container");
     if (previewContainer) {
       previewContainer.innerHTML = `
         <div class="template-preview-placeholder">
@@ -817,46 +919,49 @@ export class TemplateManager {
   static async loadTemplate(templateId: string): Promise<void> {
     try {
       const { data, error } = await supabase
-        .from('templates')
-        .select('*')
-        .eq('id', templateId)
+        .from("templates")
+        .select("*")
+        .eq("id", templateId)
         .single();
 
       if (error) {
         throw error;
       }
 
-      console.log('Loaded template:', data);
+      console.log("Loaded template:", data);
 
       // Get current course ID and associate template with it
-      const courseId = sessionStorage.getItem('currentCourseId');
+      const courseId = sessionStorage.getItem("currentCourseId");
       if (courseId && data.course_id !== courseId) {
-        console.log('Associating template with current course:', courseId);
-        
+        console.log("Associating template with current course:", courseId);
+
         // Update the template to be associated with current course
         const { error: updateError } = await supabase
-          .from('templates')
+          .from("templates")
           .update({ course_id: courseId })
-          .eq('id', templateId);
-          
+          .eq("id", templateId);
+
         if (updateError) {
-          console.error('Failed to associate template with course:', updateError);
+          console.error(
+            "Failed to associate template with course:",
+            updateError,
+          );
         } else {
-          console.log('Template successfully associated with course');
+          console.log("Template successfully associated with course");
         }
       }
 
-      // Store the loaded template data  
+      // Store the loaded template data
       this.currentlyLoadedTemplateId = data.id; // Store UUID for database operations
       this.currentlyLoadedTemplateData = data;
 
       // Populate the template configuration area with blocks
       this.displayTemplateBlocks(data);
-      
+
       // Update the preview area with template content
       this.updateTemplatePreview(data.template_data);
     } catch (error) {
-      console.error('Failed to load template:', error);
+      console.error("Failed to load template:", error);
     }
   }
 
@@ -865,63 +970,67 @@ export class TemplateManager {
    */
   static async loadCourseTemplate(): Promise<void> {
     try {
-      const courseId = sessionStorage.getItem('currentCourseId');
-      console.log('Attempting to load template for course ID:', courseId);
-      
+      const courseId = sessionStorage.getItem("currentCourseId");
+      console.log("Attempting to load template for course ID:", courseId);
+
       if (!courseId) {
-        console.log('No current course ID found in sessionStorage');
+        console.log("No current course ID found in sessionStorage");
         // Try to get the most recent course if no courseId is set
         const { data: recentCourse, error: courseError } = await supabase
-          .from('courses')
-          .select('id')
-          .order('created_at', { ascending: false })
+          .from("courses")
+          .select("id")
+          .order("created_at", { ascending: false })
           .limit(1)
           .single();
-          
+
         if (!courseError && recentCourse) {
-          console.log('Using most recent course:', recentCourse.id);
-          sessionStorage.setItem('currentCourseId', recentCourse.id);
+          console.log("Using most recent course:", recentCourse.id);
+          sessionStorage.setItem("currentCourseId", recentCourse.id);
           return this.loadCourseTemplate(); // Recursive call with course ID now set
         } else {
-          console.log('No courses found, showing template selection');
+          console.log("No courses found, showing template selection");
           this.loadExistingTemplates();
           return;
         }
       }
 
-      console.log('Loading template for course:', courseId);
-      
+      console.log("Loading template for course:", courseId);
+
       // Query database for template associated with this course
       const { data: template, error } = await supabase
-        .from('templates')
-        .select('*')
-        .eq('course_id', courseId)
+        .from("templates")
+        .select("*")
+        .eq("course_id", courseId)
         .single();
 
-      if (error && error.code !== 'PGRST116') { // PGRST116 = no rows found
-        console.error('Error loading course template:', error);
+      if (error && error.code !== "PGRST116") {
+        // PGRST116 = no rows found
+        console.error("Error loading course template:", error);
         this.loadExistingTemplates();
         return;
       }
 
       if (template) {
-        console.log('Found existing template for course:', template.template_id);
-        
+        console.log(
+          "Found existing template for course:",
+          template.template_id,
+        );
+
         // Load the template
         this.currentlyLoadedTemplateId = template.id; // Store UUID for database operations
         this.currentlyLoadedTemplateData = template;
 
         // Populate the template configuration area with blocks
         this.displayTemplateBlocks(template);
-        
+
         // Update the preview area with template content
         this.updateTemplatePreview(template.template_data);
       } else {
-        console.log('No template found for course, showing template selection');
+        console.log("No template found for course, showing template selection");
         this.loadExistingTemplates();
       }
     } catch (error) {
-      console.error('Failed to load course template:', error);
+      console.error("Failed to load course template:", error);
       // Fallback to showing template list
       this.loadExistingTemplates();
     }
@@ -930,55 +1039,96 @@ export class TemplateManager {
   /**
    * Gets the field configuration for each block type
    */
-  static getBlockFieldConfiguration(): Record<string, Array<{name: string, label: string, mandatory: boolean, separator?: boolean}>> {
+  static getBlockFieldConfiguration(): Record<
+    string,
+    Array<{
+      name: string;
+      label: string;
+      mandatory: boolean;
+      separator?: boolean;
+    }>
+  > {
     return {
       header: [
-        { name: 'lesson_number', label: 'Lesson number (#)', mandatory: true },
-        { name: 'lesson_title', label: 'Lesson title', mandatory: true },
-        { name: 'module_title', label: 'Module title', mandatory: true },
-        { name: 'course_title', label: 'Course title', mandatory: true },
-        { name: 'institution_name', label: 'Institution name', mandatory: true },
-        { name: 'teacher_name', label: 'Teacher name', mandatory: false }
+        { name: "lesson_number", label: "Lesson number (#)", mandatory: true },
+        { name: "lesson_title", label: "Lesson title", mandatory: true },
+        { name: "module_title", label: "Module title", mandatory: true },
+        { name: "course_title", label: "Course title", mandatory: true },
+        {
+          name: "institution_name",
+          label: "Institution name",
+          mandatory: true,
+        },
+        { name: "teacher_name", label: "Teacher name", mandatory: false },
       ],
       program: [
-        { name: 'competence', label: 'Competence', mandatory: true },
-        { name: 'topic', label: 'Topic', mandatory: true },
-        { name: 'objective', label: 'Objective', mandatory: true },
-        { name: 'task', label: 'Task', mandatory: true }
+        { name: "competence", label: "Competence", mandatory: true },
+        { name: "topic", label: "Topic", mandatory: true },
+        { name: "objective", label: "Objective", mandatory: true },
+        { name: "task", label: "Task", mandatory: true },
       ],
       resources: [
-        { name: 'task', label: 'Task', mandatory: true },
-        { name: 'type', label: 'Type', mandatory: true },
-        { name: 'origin', label: 'Origin', mandatory: true },
-        { name: 'state', label: 'State', mandatory: false },
-        { name: 'quality', label: 'Quality', mandatory: false },
-        { name: 'include_glossary', label: 'Include Glossary', mandatory: false, separator: true },
-        { name: 'historical_figures', label: 'Historical figures', mandatory: false },
-        { name: 'terminology', label: 'Terminology', mandatory: false },
-        { name: 'concepts', label: 'Concepts', mandatory: false }
+        { name: "task", label: "Task", mandatory: true },
+        { name: "type", label: "Type", mandatory: true },
+        { name: "origin", label: "Origin", mandatory: true },
+        { name: "state", label: "State", mandatory: false },
+        { name: "quality", label: "Quality", mandatory: false },
+        {
+          name: "include_glossary",
+          label: "Include Glossary",
+          mandatory: false,
+          separator: true,
+        },
+        {
+          name: "historical_figures",
+          label: "Historical figures",
+          mandatory: false,
+        },
+        { name: "terminology", label: "Terminology", mandatory: false },
+        { name: "concepts", label: "Concepts", mandatory: false },
       ],
       content: [
-        { name: 'instruction_title', label: 'Instruction title', mandatory: true },
-        { name: 'instruction_area', label: 'Instruction area', mandatory: true },
-        { name: 'student_title', label: 'Student Title', mandatory: true },
-        { name: 'student_area', label: 'Student Area', mandatory: true },
-        { name: 'teacher_title', label: 'Teacher title', mandatory: true },
-        { name: 'teacher_area', label: 'Teacher area', mandatory: true }
+        {
+          name: "instruction_title",
+          label: "Instruction title",
+          mandatory: true,
+        },
+        {
+          name: "instruction_area",
+          label: "Instruction area",
+          mandatory: true,
+        },
+        { name: "student_title", label: "Student Title", mandatory: true },
+        { name: "student_area", label: "Student Area", mandatory: true },
+        { name: "teacher_title", label: "Teacher title", mandatory: true },
+        { name: "teacher_area", label: "Teacher area", mandatory: true },
       ],
       assignment: [
-        { name: 'instruction_title', label: 'Instruction title', mandatory: true },
-        { name: 'instruction_area', label: 'Instruction area', mandatory: true },
-        { name: 'student_title', label: 'Student Title', mandatory: true },
-        { name: 'student_area', label: 'Student Area', mandatory: true },
-        { name: 'teacher_title', label: 'Teacher title', mandatory: true },
-        { name: 'teacher_area', label: 'Teacher area', mandatory: true }
+        {
+          name: "instruction_title",
+          label: "Instruction title",
+          mandatory: true,
+        },
+        {
+          name: "instruction_area",
+          label: "Instruction area",
+          mandatory: true,
+        },
+        { name: "student_title", label: "Student Title", mandatory: true },
+        { name: "student_area", label: "Student Area", mandatory: true },
+        { name: "teacher_title", label: "Teacher title", mandatory: true },
+        { name: "teacher_area", label: "Teacher area", mandatory: true },
       ],
       footer: [
-        { name: 'copyright', label: 'Copyright', mandatory: true },
-        { name: 'teacher_name', label: 'Teacher name', mandatory: false },
-        { name: 'institution_name', label: 'Institution name', mandatory: false },
-        { name: 'page_number', label: 'Page number (#)', mandatory: true }
-      ]
+        { name: "copyright", label: "Copyright", mandatory: true },
+        { name: "teacher_name", label: "Teacher name", mandatory: false },
+        {
+          name: "institution_name",
+          label: "Institution name",
+          mandatory: false,
+        },
+        { name: "page_number", label: "Page number (#)", mandatory: true },
+      ],
     };
   }
 
@@ -986,7 +1136,7 @@ export class TemplateManager {
    * Displays the template blocks in the configuration area
    */
   static displayTemplateBlocks(templateData: any): void {
-    const configArea = document.querySelector('.template-config');
+    const configArea = document.querySelector(".template-config");
     if (!configArea) return;
 
     // Handle both full template object and just template_data
@@ -997,30 +1147,34 @@ export class TemplateManager {
 
     const blocksHtml = `
       <div class="template-blocks">
-        ${blocks.map((block: TemplateBlock) => {
-          const fields = fieldConfig[block.type] || [];
-          
-          return `
+        ${blocks
+          .map((block: TemplateBlock) => {
+            const fields = fieldConfig[block.type] || [];
+
+            return `
             <div class="template-block-config" data-block="${block.type}" data-template-id="${templateId}">
               <div class="template-block-config__header">
                 <div class="template-block-item__icon template-block-item__icon--${block.type}"></div>
                 <h4 class="template-block-config__title">${block.type.charAt(0).toUpperCase() + block.type.slice(1)}</h4>
               </div>
               <div class="template-block-config__fields" data-block="${block.type}">
-                ${fields.map(field => {
-                  // Check if field is enabled in template data
-                  const isChecked = field.mandatory || (block.config && block.config[field.name] === true);
-                  
-                  return `
-                  ${field.separator ? '<div class="template-field-separator"></div>' : ''}
-                  <div class="template-field ${field.separator ? 'template-field--separator' : ''}">
+                ${fields
+                  .map((field) => {
+                    // Check if field is enabled in template data
+                    const isChecked =
+                      field.mandatory ||
+                      (block.config && block.config[field.name] === true);
+
+                    return `
+                  ${field.separator ? '<div class="template-field-separator"></div>' : ""}
+                  <div class="template-field ${field.separator ? "template-field--separator" : ""}">
                     <label class="template-field__label">
                       <input 
                         type="checkbox" 
                         name="${field.name}" 
                         data-block="${block.type}"
                         data-template-id="${templateData.id}"
-                        ${field.mandatory ? 'checked disabled' : (isChecked ? 'checked' : '')}
+                        ${field.mandatory ? "checked disabled" : isChecked ? "checked" : ""}
                         onchange="TemplateManager.updateTemplateField('${templateId}', '${block.type}', '${field.name}', this.checked)"
                         class="template-field__checkbox"
                       >
@@ -1029,16 +1183,19 @@ export class TemplateManager {
                       </span>
                     </label>
                   </div>
-                `;}).join('')}
+                `;
+                  })
+                  .join("")}
               </div>
             </div>
           `;
-        }).join('')}
+          })
+          .join("")}
       </div>
     `;
 
     configArea.innerHTML = blocksHtml;
-    
+
     // Update template preview after displaying blocks
     this.updateTemplatePreview(templateData);
   }
@@ -1048,41 +1205,77 @@ export class TemplateManager {
    */
   static getBlockDescription(blockType: string): string {
     const descriptions: Record<string, string> = {
-      header: 'Title and introduction section',
-      program: 'Learning objectives and outcomes',
-      resources: 'Files, links, and materials',
-      content: 'Main lesson content and materials',
-      assignment: 'Tasks and submissions',
-      footer: 'Credits and additional information'
+      header: "Title and introduction section",
+      program: "Learning objectives and outcomes",
+      resources: "Files, links, and materials",
+      content: "Main lesson content and materials",
+      assignment: "Tasks and submissions",
+      footer: "Credits and additional information",
     };
-    return descriptions[blockType] || 'Block configuration';
+    return descriptions[blockType] || "Block configuration";
   }
 
   /**
    * Initializes an empty template configuration
    */
   static initializeEmptyTemplate(): void {
-    console.log('Initializing empty template interface');
-    
+    console.log("Initializing empty template interface");
+
     // Clear any existing configuration forms
-    const forms = document.querySelectorAll('.template-config form');
-    forms.forEach(form => {
+    const forms = document.querySelectorAll(".template-config form");
+    forms.forEach((form) => {
       (form as HTMLFormElement).reset();
     });
 
     // Create a basic template structure to display
     const basicTemplate = {
       template_data: {
-        name: 'New Template',
+        name: "New Template",
         blocks: [
-          { id: 'header-1', type: 'header', order: 1, config: {}, content: 'Header content will appear here' },
-          { id: 'program-1', type: 'program', order: 2, config: {}, content: 'Learning objectives will appear here' },
-          { id: 'resources-1', type: 'resources', order: 3, config: {}, content: 'Resources will appear here' },
-          { id: 'content-1', type: 'content', order: 4, config: {}, content: 'Main content will appear here' },
-          { id: 'assignment-1', type: 'assignment', order: 5, config: {}, content: 'Assignment details will appear here' },
-          { id: 'footer-1', type: 'footer', order: 6, config: {}, content: 'Footer content will appear here' }
-        ]
-      }
+          {
+            id: "header-1",
+            type: "header",
+            order: 1,
+            config: {},
+            content: "Header content will appear here",
+          },
+          {
+            id: "program-1",
+            type: "program",
+            order: 2,
+            config: {},
+            content: "Learning objectives will appear here",
+          },
+          {
+            id: "resources-1",
+            type: "resources",
+            order: 3,
+            config: {},
+            content: "Resources will appear here",
+          },
+          {
+            id: "content-1",
+            type: "content",
+            order: 4,
+            config: {},
+            content: "Main content will appear here",
+          },
+          {
+            id: "assignment-1",
+            type: "assignment",
+            order: 5,
+            config: {},
+            content: "Assignment details will appear here",
+          },
+          {
+            id: "footer-1",
+            type: "footer",
+            order: 6,
+            config: {},
+            content: "Footer content will appear here",
+          },
+        ],
+      },
     };
 
     // Display the template blocks and preview
@@ -1095,22 +1288,22 @@ export class TemplateManager {
    */
   static populateTemplateConfig(templateData: any): void {
     // Implementation will be added in template configuration handler
-    console.log('Populating template config:', templateData);
+    console.log("Populating template config:", templateData);
   }
 
   /**
    * Updates the template preview
    */
   static updateTemplatePreview(templateData?: any): void {
-    const previewContainer = document.querySelector('.preview-container');
+    const previewContainer = document.querySelector(".preview-container");
     if (!previewContainer) return;
 
     // Use current template data if none provided
     const data = templateData || this.currentlyLoadedTemplateData;
-    
+
     // Handle both full template object and just template_data
     const actualData = data?.template_data || data;
-    
+
     if (!actualData || !actualData.blocks) {
       previewContainer.innerHTML = `
         <div class="preview-placeholder">
@@ -1122,15 +1315,18 @@ export class TemplateManager {
     }
 
     const blocks = actualData.blocks || [];
-    const templateName = actualData.name || 'Untitled Template';
-    
+    const templateName = actualData.name || "Untitled Template";
+
     // Sort blocks by order and render them
-    const sortedBlocks = blocks.sort((a: TemplateBlock, b: TemplateBlock) => a.order - b.order);
-    
-    const blocksHtml = sortedBlocks.map((block: TemplateBlock) => {
-      const checkedFields = this.getCheckedFields(block.type);
-      
-      return `
+    const sortedBlocks = blocks.sort(
+      (a: TemplateBlock, b: TemplateBlock) => a.order - b.order,
+    );
+
+    const blocksHtml = sortedBlocks
+      .map((block: TemplateBlock) => {
+        const checkedFields = this.getCheckedFields(block.type);
+
+        return `
         <div class="template-preview-block template-preview-block--${block.type}">
           <div class="template-preview-block__header">
             <h4 class="template-preview-block__title">${block.type.charAt(0).toUpperCase() + block.type.slice(1)}</h4>
@@ -1140,7 +1336,8 @@ export class TemplateManager {
           </div>
         </div>
       `;
-    }).join('');
+      })
+      .join("");
 
     previewContainer.innerHTML = `
 
@@ -1153,53 +1350,69 @@ export class TemplateManager {
   /**
    * Gets the currently checked fields for a block type from template data
    */
-  static getCheckedFields(blockType: string): Array<{name: string, label: string}> {
+  static getCheckedFields(
+    blockType: string,
+  ): Array<{ name: string; label: string }> {
     const fieldConfig = this.getBlockFieldConfiguration();
     const blockFields = fieldConfig[blockType] || [];
-    const checkedFields: Array<{name: string, label: string}> = [];
-    
-    blockFields.forEach(field => {
+    const checkedFields: Array<{ name: string; label: string }> = [];
+
+    blockFields.forEach((field) => {
       // Include mandatory fields (always checked)
       if (field.mandatory) {
         checkedFields.push({ name: field.name, label: field.label });
       } else {
         // Include optional fields that are checked in template data
         if (this.currentlyLoadedTemplateData) {
-          const block = this.currentlyLoadedTemplateData.template_data.blocks.find((b: any) => b.type === blockType);
+          const block =
+            this.currentlyLoadedTemplateData.template_data.blocks.find(
+              (b: any) => b.type === blockType,
+            );
           if (block && block.config && block.config[field.name] === true) {
             checkedFields.push({ name: field.name, label: field.label });
           }
         }
       }
     });
-    
+
     return checkedFields;
   }
 
   /**
    * Renders the content for a specific block type
    */
-  static renderBlockContent(blockType: string, checkedFields: Array<{name: string, label: string}>): string {
-    if (blockType === 'resources') {
+  static renderBlockContent(
+    blockType: string,
+    checkedFields: Array<{ name: string; label: string }>,
+  ): string {
+    if (blockType === "resources") {
       return this.renderResourcesBlockContent(checkedFields);
     }
-    
-    if (blockType === 'content' || blockType === 'assignment') {
+
+    if (blockType === "content" || blockType === "assignment") {
       return this.renderNestedBlockContent(blockType, checkedFields);
     }
-    
+
     // Default table rendering for other blocks
     return `
       <div class="template-preview-table">
         <div class="template-preview-table__header">
-          ${checkedFields.map(field => `
+          ${checkedFields
+            .map(
+              (field) => `
             <div class="template-preview-table__column-header">${field.label}</div>
-          `).join('')}
+          `,
+            )
+            .join("")}
         </div>
         <div class="template-preview-table__row">
-          ${checkedFields.map(field => `
+          ${checkedFields
+            .map(
+              (field) => `
             <div class="template-preview-table__cell">[${field.label}]</div>
-          `).join('')}
+          `,
+            )
+            .join("")}
         </div>
       </div>
     `;
@@ -1208,9 +1421,12 @@ export class TemplateManager {
   /**
    * Renders the nested hierarchical content for Content and Assignment blocks
    */
-  static renderNestedBlockContent(_blockType: string, checkedFields: Array<{name: string, label: string}>): string {
+  static renderNestedBlockContent(
+    _blockType: string,
+    checkedFields: Array<{ name: string; label: string }>,
+  ): string {
     let html = `<div class="template-nested-structure">`;
-    
+
     // Add the fixed hierarchy with proper nesting indentation
     html += `
       <div class="template-hierarchy">
@@ -1219,57 +1435,79 @@ export class TemplateManager {
         <div class="template-hierarchy-level template-hierarchy-level-3">Task</div>
         
         <div class="template-content-fields">
-          ${checkedFields.map(field => `
+          ${checkedFields
+            .map(
+              (field) => `
             <div class="template-content-field template-hierarchy-level-4">
               ${field.label}
             </div>
-          `).join('')}
+          `,
+            )
+            .join("")}
         </div>
       </div>
     `;
-    
+
     html += `</div>`;
-    
+
     return html;
   }
 
   /**
    * Renders the special Resources block content with optional glossary table
    */
-  static renderResourcesBlockContent(checkedFields: Array<{name: string, label: string}>): string {
+  static renderResourcesBlockContent(
+    checkedFields: Array<{ name: string; label: string }>,
+  ): string {
     // Get main resource fields (excluding glossary items)
-    const mainFields = checkedFields.filter(field => 
-      !['include_glossary', 'historical_figures', 'terminology', 'concepts'].includes(field.name)
+    const mainFields = checkedFields.filter(
+      (field) =>
+        ![
+          "include_glossary",
+          "historical_figures",
+          "terminology",
+          "concepts",
+        ].includes(field.name),
     );
-    
+
     // Check if glossary is included
-    const includeGlossary = checkedFields.some(field => field.name === 'include_glossary');
-    
-    // Get glossary items that are selected
-    const glossaryItems = checkedFields.filter(field => 
-      ['historical_figures', 'terminology', 'concepts'].includes(field.name)
+    const includeGlossary = checkedFields.some(
+      (field) => field.name === "include_glossary",
     );
-    
-    let html = '';
-    
+
+    // Get glossary items that are selected
+    const glossaryItems = checkedFields.filter((field) =>
+      ["historical_figures", "terminology", "concepts"].includes(field.name),
+    );
+
+    let html = "";
+
     // Main resources table
     if (mainFields.length > 0) {
       html += `
         <div class="template-preview-table">
           <div class="template-preview-table__header">
-            ${mainFields.map(field => `
+            ${mainFields
+              .map(
+                (field) => `
               <div class="template-preview-table__column-header">${field.label}</div>
-            `).join('')}
+            `,
+              )
+              .join("")}
           </div>
           <div class="template-preview-table__row">
-            ${mainFields.map(field => `
+            ${mainFields
+              .map(
+                (field) => `
               <div class="template-preview-table__cell">[${field.label}]</div>
-            `).join('')}
+            `,
+              )
+              .join("")}
           </div>
         </div>
       `;
     }
-    
+
     // Glossary table (only if glossary is included and items are selected)
     if (includeGlossary && glossaryItems.length > 0) {
       html += `
@@ -1280,17 +1518,21 @@ export class TemplateManager {
               <div class="template-preview-table__column-header">Type</div>
               <div class="template-preview-table__column-header">URL</div>
             </div>
-            ${glossaryItems.map(item => `
+            ${glossaryItems
+              .map(
+                (item) => `
               <div class="template-preview-table__row">
                 <div class="template-preview-table__cell">${item.label}</div>
                 <div class="template-preview-table__cell">[URL]</div>
               </div>
-            `).join('')}
+            `,
+              )
+              .join("")}
           </div>
         </div>
       `;
     }
-    
+
     return html;
   }
 
@@ -1299,13 +1541,16 @@ export class TemplateManager {
    */
   static getBlockPreviewContent(block: TemplateBlock): string {
     // If block has custom content, show it (removing HTML tags for preview)
-    if (block.content && block.content.trim() !== '') {
-      const tempDiv = document.createElement('div');
+    if (block.content && block.content.trim() !== "") {
+      const tempDiv = document.createElement("div");
       tempDiv.innerHTML = block.content;
-      const textContent = tempDiv.textContent || tempDiv.innerText || '';
-      return textContent.replace(/\{\{.*?\}\}/g, '[Dynamic Content]') || this.getDefaultBlockContent(block.type);
+      const textContent = tempDiv.textContent || tempDiv.innerText || "";
+      return (
+        textContent.replace(/\{\{.*?\}\}/g, "[Dynamic Content]") ||
+        this.getDefaultBlockContent(block.type)
+      );
     }
-    
+
     return this.getDefaultBlockContent(block.type);
   }
 
@@ -1314,20 +1559,22 @@ export class TemplateManager {
    */
   static getDefaultBlockContent(blockType: string): string {
     const defaultContent: Record<string, string> = {
-      header: 'Course title and introduction will appear here',
-      program: 'Learning objectives and outcomes will be displayed here',
-      resources: 'Files, links, and materials will be listed here',
-      content: 'Main lesson content and materials will appear here',
-      assignment: 'Tasks and submission instructions will be shown here',
-      footer: 'Credits and additional information will appear here'
+      header: "Course title and introduction will appear here",
+      program: "Learning objectives and outcomes will be displayed here",
+      resources: "Files, links, and materials will be listed here",
+      content: "Main lesson content and materials will appear here",
+      assignment: "Tasks and submission instructions will be shown here",
+      footer: "Credits and additional information will appear here",
     };
-    return defaultContent[blockType] || 'Block content will appear here';
-  }  /**
+    return defaultContent[blockType] || "Block content will appear here";
+  } /**
    * Show block configuration modal/interface
    */
   static showBlockConfiguration(blockType: string, templateId?: string): void {
-    console.log(`Showing configuration for ${blockType} block${templateId ? ` of template ${templateId}` : ''}`);
-    
+    console.log(
+      `Showing configuration for ${blockType} block${templateId ? ` of template ${templateId}` : ""}`,
+    );
+
     // Create an elegant modal for block configuration
     const modalHtml = `
       <div class="modal modal--active" id="block-config-modal">
@@ -1381,47 +1628,51 @@ export class TemplateManager {
         </div>
       </div>
     `;
-    
+
     // Add modal to page
-    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    document.body.insertAdjacentHTML("beforeend", modalHtml);
   }
-  
+
   /**
    * Hide block configuration modal
    */
   static hideBlockConfiguration(): void {
-    const modal = document.getElementById('block-config-modal');
+    const modal = document.getElementById("block-config-modal");
     if (modal) {
       modal.remove();
     }
   }
-  
+
   /**
    * Save block configuration
    */
   static saveBlockConfiguration(blockType: string): void {
-    const form = document.getElementById('block-config-form') as HTMLFormElement;
+    const form = document.getElementById(
+      "block-config-form",
+    ) as HTMLFormElement;
     if (form) {
       const formData = new FormData(form);
       const config = {
-        title: formData.get('block-title'),
-        content: formData.get('block-content'),
-        visible: formData.get('block-visible') === 'on',
-        required: formData.get('block-required') === 'on'
+        title: formData.get("block-title"),
+        content: formData.get("block-content"),
+        visible: formData.get("block-visible") === "on",
+        required: formData.get("block-required") === "on",
       };
-      
+
       console.log(`Saving ${blockType} block configuration:`, config);
-      
+
       // Here you would save the configuration to the template
       // For now, just show success and close modal
-      alert(`${blockType.charAt(0).toUpperCase() + blockType.slice(1)} block saved successfully!`);
+      alert(
+        `${blockType.charAt(0).toUpperCase() + blockType.slice(1)} block saved successfully!`,
+      );
       this.hideBlockConfiguration();
-      
+
       // Update the preview
       this.updateBlockPreview(blockType, config);
     }
   }
-  
+
   /**
    * Update block preview
    */
@@ -1443,35 +1694,43 @@ declare global {
 window.TemplateManager = TemplateManager;
 
 // Initialize template modal handlers when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   // Create template button handler
-  const createTemplateBtn = document.getElementById('create-template-btn');
+  const createTemplateBtn = document.getElementById("create-template-btn");
   if (createTemplateBtn) {
-    createTemplateBtn.addEventListener('click', () => {
+    createTemplateBtn.addEventListener("click", () => {
       TemplateManager.showCreateTemplateModal();
     });
   }
 
   // Load template button handler
-  const loadTemplateBtn = document.getElementById('load-template-btn');
+  const loadTemplateBtn = document.getElementById("load-template-btn");
   if (loadTemplateBtn) {
-    loadTemplateBtn.addEventListener('click', () => {
+    loadTemplateBtn.addEventListener("click", () => {
       TemplateManager.showLoadTemplateModal();
     });
   }
 
   // Load existing templates when the templates section is accessed
-  const templatesSection = document.getElementById('templates');
+  const templatesSection = document.getElementById("templates");
   if (templatesSection) {
     // Create a MutationObserver to watch for when the templates section becomes active
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
-        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName === "class"
+        ) {
           const target = mutation.target as HTMLElement;
-          if (target.classList.contains('article--active') && target.id === 'templates') {
+          if (
+            target.classList.contains("article--active") &&
+            target.id === "templates"
+          ) {
             // Templates section is now active, load existing templates
-            console.log('Templates section activated, loading existing templates');
-            
+            console.log(
+              "Templates section activated, loading existing templates",
+            );
+
             // Check if there's a template for the current course
             TemplateManager.loadCourseTemplate();
           }
@@ -1482,57 +1741,58 @@ document.addEventListener('DOMContentLoaded', () => {
     observer.observe(templatesSection, { attributes: true });
 
     // Also check if templates section is already active on page load
-    if (templatesSection.classList.contains('article--active')) {
-      console.log('Templates section already active on page load');
-      
+    if (templatesSection.classList.contains("article--active")) {
+      console.log("Templates section already active on page load");
+
       // Check if there's a template for the current course
       TemplateManager.loadCourseTemplate();
     }
   }
 
   // Search functionality for load template modal
-  const templateSearch = document.getElementById('template-search');
+  const templateSearch = document.getElementById("template-search");
   if (templateSearch) {
-    templateSearch.addEventListener('input', (e) => {
+    templateSearch.addEventListener("input", (e) => {
       const searchTerm = (e.target as HTMLInputElement).value.toLowerCase();
       TemplateManager.filterTemplates(searchTerm);
     });
   }
 
   // Filter functionality
-  const typeFilter = document.getElementById('template-type-filter');
-  const sortFilter = document.getElementById('template-sort');
-  
+  const typeFilter = document.getElementById("template-type-filter");
+  const sortFilter = document.getElementById("template-sort");
+
   if (typeFilter) {
-    typeFilter.addEventListener('change', () => {
+    typeFilter.addEventListener("change", () => {
       TemplateManager.applyFiltersAndSort();
     });
   }
-  
+
   if (sortFilter) {
-    sortFilter.addEventListener('change', () => {
+    sortFilter.addEventListener("change", () => {
       TemplateManager.applyFiltersAndSort();
     });
   }
 
   // Modal form submission handler
-  const createTemplateForm = document.getElementById('create-template-form');
+  const createTemplateForm = document.getElementById("create-template-form");
   if (createTemplateForm) {
-    createTemplateForm.addEventListener('submit', async (e) => {
+    createTemplateForm.addEventListener("submit", async (e) => {
       e.preventDefault();
-      
+
       const formData = new FormData(e.target as HTMLFormElement);
       const templateFormData = {
-        name: formData.get('template-name') as string,
-        type: formData.get('template-type') as 'lesson',
-        description: formData.get('template-description') as string || undefined
+        name: formData.get("template-name") as string,
+        type: formData.get("template-type") as "lesson",
+        description:
+          (formData.get("template-description") as string) || undefined,
       };
 
-      console.log('Creating template with data:', templateFormData);
-      
+      console.log("Creating template with data:", templateFormData);
+
       const templateId = await TemplateManager.createTemplate(templateFormData);
       if (templateId) {
-        console.log('Template created with ID:', templateId);
+        console.log("Template created with ID:", templateId);
         TemplateManager.hideCreateTemplateModal();
         TemplateManager.showTemplateBuilder(templateId);
         // Reload the template list to show the new template
@@ -1540,24 +1800,24 @@ document.addEventListener('DOMContentLoaded', () => {
           TemplateManager.loadExistingTemplates();
         }, 500);
       } else {
-        console.error('Failed to create template');
+        console.error("Failed to create template");
         // You could show an error message to the user here
       }
     });
   }
 
   // Modal close handlers
-  const modalCloseBtn = document.querySelector('.modal__close');
-  const modal = document.getElementById('create-template-modal');
-  
+  const modalCloseBtn = document.querySelector(".modal__close");
+  const modal = document.getElementById("create-template-modal");
+
   if (modalCloseBtn) {
-    modalCloseBtn.addEventListener('click', () => {
+    modalCloseBtn.addEventListener("click", () => {
       TemplateManager.hideCreateTemplateModal();
     });
   }
 
   if (modal) {
-    modal.addEventListener('click', (e) => {
+    modal.addEventListener("click", (e) => {
       if (e.target === modal) {
         TemplateManager.hideCreateTemplateModal();
       }

--- a/src/scripts/backend/courses/curriculumManager.ts
+++ b/src/scripts/backend/courses/curriculumManager.ts
@@ -1,189 +1,202 @@
-import { supabase } from '../../backend/supabase.js';
+import { supabase } from "../../backend/supabase.js";
 
 interface CurriculumLesson {
-    lessonNumber: number;
-    title: string;
-    topics: CurriculumTopic[];
+  lessonNumber: number;
+  title: string;
+  topics: CurriculumTopic[];
 }
 
 interface CurriculumTopic {
-    title: string;
-    objectives: string[];
-    tasks: string[];
+  title: string;
+  objectives: string[];
+  tasks: string[];
 }
 
 interface ContentLoadConfig {
-    type: 'mini' | 'regular' | 'double' | 'triple' | 'long';
-    duration: number; // in minutes
-    topicsPerLesson: number;
-    objectivesPerTopic: number;
-    tasksPerTopic: number;
+  type: "mini" | "regular" | "double" | "triple" | "long";
+  duration: number; // in minutes
+  topicsPerLesson: number;
+  objectivesPerTopic: number;
+  tasksPerTopic: number;
 }
 
-type PreviewMode = 'titles' | 'topics' | 'objectives';
+type PreviewMode = "titles" | "topics" | "objectives";
 
 export class CurriculumManager {
-    private courseId: string;
-    private curriculumConfigSection!: HTMLElement;
-    private curriculumPreviewSection!: HTMLElement;
-    private contentLoadDisplay!: HTMLElement;
-    private currentCurriculum: CurriculumLesson[] = [];
-    private contentLoadConfig: ContentLoadConfig | null = null;
-    private currentPreviewMode: PreviewMode = 'titles';
+  private courseId: string;
+  private curriculumConfigSection!: HTMLElement;
+  private curriculumPreviewSection!: HTMLElement;
+  private contentLoadDisplay!: HTMLElement;
+  private currentCurriculum: CurriculumLesson[] = [];
+  private contentLoadConfig: ContentLoadConfig | null = null;
+  private currentPreviewMode: PreviewMode = "titles";
 
-    constructor(courseId?: string) {
-        // Get course ID from parameter or session storage
-        this.courseId = courseId || sessionStorage.getItem('currentCourseId') || '';
-        
-        if (!this.courseId) {
-            console.error('No course ID available for curriculum management');
-            return;
-        }
-        
-        this.initializeElements();
-        this.bindEvents();
-        this.initializeCurriculum();
+  constructor(courseId?: string) {
+    // Get course ID from parameter or session storage
+    this.courseId = courseId || sessionStorage.getItem("currentCourseId") || "";
+
+    if (!this.courseId) {
+      console.error("No course ID available for curriculum management");
+      return;
     }
 
-    private async initializeCurriculum(): Promise<void> {
-        try {
-            // Load schedule data first
-            await this.loadScheduleData();
-            
-            // Load existing curriculum
-            await this.loadExistingCurriculum();
-            
-            // Auto-generate curriculum if we have schedule data but no curriculum
-            if (!this.currentCurriculum.length && this.contentLoadConfig) {
-                console.log('Auto-generating curriculum based on schedule data');
-                await this.generateCurriculum();
-            }
-            
-            // Always show preview if we have curriculum data
-            if (this.currentCurriculum.length > 0) {
-                this.showPreview();
-            }
-            
-        } catch (error) {
-            console.error('Error initializing curriculum:', error);
-        }
+    this.initializeElements();
+    this.bindEvents();
+    this.initializeCurriculum();
+  }
+
+  private async initializeCurriculum(): Promise<void> {
+    try {
+      // Load schedule data first
+      await this.loadScheduleData();
+
+      // Load existing curriculum
+      await this.loadExistingCurriculum();
+
+      // Auto-generate curriculum if we have schedule data but no curriculum
+      if (!this.currentCurriculum.length && this.contentLoadConfig) {
+        console.log("Auto-generating curriculum based on schedule data");
+        await this.generateCurriculum();
+      }
+
+      // Always show preview if we have curriculum data
+      if (this.currentCurriculum.length > 0) {
+        this.showPreview();
+      }
+    } catch (error) {
+      console.error("Error initializing curriculum:", error);
+    }
+  }
+
+  private initializeElements(): void {
+    this.curriculumConfigSection = document.getElementById(
+      "curriculum-config",
+    ) as HTMLElement;
+    this.curriculumPreviewSection = document.getElementById(
+      "curriculum-preview",
+    ) as HTMLElement;
+    this.contentLoadDisplay = document.getElementById(
+      "content-load-display",
+    ) as HTMLElement;
+
+    // Check if all elements were found
+    if (!this.curriculumConfigSection) {
+      console.error("curriculum-config element not found");
+      return;
+    }
+    if (!this.curriculumPreviewSection) {
+      console.error("curriculum-preview element not found");
+      return;
     }
 
-    private initializeElements(): void {
-        this.curriculumConfigSection = document.getElementById('curriculum-config') as HTMLElement;
-        this.curriculumPreviewSection = document.getElementById('curriculum-preview') as HTMLElement;
-        this.contentLoadDisplay = document.getElementById('content-load-display') as HTMLElement;
+    console.log("All curriculum elements found successfully");
+  }
 
-        // Check if all elements were found
-        if (!this.curriculumConfigSection) {
-            console.error('curriculum-config element not found');
-            return;
-        }
-        if (!this.curriculumPreviewSection) {
-            console.error('curriculum-preview element not found');
-            return;
-        }
-
-        console.log('All curriculum elements found successfully');
+  private bindEvents(): void {
+    if (!this.curriculumConfigSection) {
+      console.error("Cannot bind events: required elements not found");
+      return;
     }
 
-    private bindEvents(): void {
-        if (!this.curriculumConfigSection) {
-            console.error('Cannot bind events: required elements not found');
-            return;
-        }
+    // Preview mode buttons
+    const previewModeButtons =
+      this.curriculumPreviewSection?.querySelectorAll(".preview-mode-btn");
+    previewModeButtons?.forEach((button) => {
+      button.addEventListener("click", (e) => {
+        const mode = (e.target as HTMLElement).dataset.mode as PreviewMode;
+        this.setPreviewMode(mode);
+      });
+    });
 
-        // Preview mode buttons
-        const previewModeButtons = this.curriculumPreviewSection?.querySelectorAll('.preview-mode-btn');
-        previewModeButtons?.forEach(button => {
-            button.addEventListener('click', (e) => {
-                const mode = (e.target as HTMLElement).dataset.mode as PreviewMode;
-                this.setPreviewMode(mode);
-            });
-        });
+    console.log("Curriculum events bound successfully");
+  }
 
-        console.log('Curriculum events bound successfully');
+  private async loadScheduleData(): Promise<void> {
+    try {
+      const { data, error } = await supabase
+        .from("courses")
+        .select("schedule_settings")
+        .eq("id", this.courseId)
+        .single();
+
+      if (error) throw error;
+
+      if (
+        data?.schedule_settings &&
+        Array.isArray(data.schedule_settings) &&
+        data.schedule_settings.length > 0
+      ) {
+        // Get the first lesson to determine duration
+        const firstLesson = data.schedule_settings[0];
+        const duration = this.calculateLessonDuration(
+          firstLesson.startTime,
+          firstLesson.endTime,
+        );
+        this.contentLoadConfig = this.determineContentLoad(duration);
+        this.displayContentLoad();
+      } else {
+        this.displayNoScheduleWarning();
+      }
+    } catch (error) {
+      console.error("Error loading schedule data:", error);
+      this.displayNoScheduleWarning();
     }
+  }
 
-    private async loadScheduleData(): Promise<void> {
-        try {
-            const { data, error } = await supabase
-                .from('courses')
-                .select('schedule_settings')
-                .eq('id', this.courseId)
-                .single();
+  private calculateLessonDuration(startTime: string, endTime: string): number {
+    const start = new Date(`2000-01-01T${startTime}`);
+    const end = new Date(`2000-01-01T${endTime}`);
+    return Math.abs(end.getTime() - start.getTime()) / (1000 * 60); // Convert to minutes
+  }
 
-            if (error) throw error;
-
-            if (data?.schedule_settings && Array.isArray(data.schedule_settings) && data.schedule_settings.length > 0) {
-                // Get the first lesson to determine duration
-                const firstLesson = data.schedule_settings[0];
-                const duration = this.calculateLessonDuration(firstLesson.startTime, firstLesson.endTime);
-                this.contentLoadConfig = this.determineContentLoad(duration);
-                this.displayContentLoad();
-            } else {
-                this.displayNoScheduleWarning();
-            }
-        } catch (error) {
-            console.error('Error loading schedule data:', error);
-            this.displayNoScheduleWarning();
-        }
+  private determineContentLoad(duration: number): ContentLoadConfig {
+    if (duration <= 30) {
+      return {
+        type: "mini",
+        duration,
+        topicsPerLesson: 1,
+        objectivesPerTopic: 1,
+        tasksPerTopic: 2,
+      };
+    } else if (duration <= 60) {
+      return {
+        type: "regular",
+        duration,
+        topicsPerLesson: 2,
+        objectivesPerTopic: 2,
+        tasksPerTopic: 2,
+      };
+    } else if (duration <= 120) {
+      return {
+        type: "double",
+        duration,
+        topicsPerLesson: 3,
+        objectivesPerTopic: 2,
+        tasksPerTopic: 3,
+      };
+    } else if (duration <= 180) {
+      return {
+        type: "triple",
+        duration,
+        topicsPerLesson: 4,
+        objectivesPerTopic: 3,
+        tasksPerTopic: 3,
+      };
+    } else {
+      return {
+        type: "long",
+        duration,
+        topicsPerLesson: 5,
+        objectivesPerTopic: 3,
+        tasksPerTopic: 4,
+      };
     }
+  }
 
-    private calculateLessonDuration(startTime: string, endTime: string): number {
-        const start = new Date(`2000-01-01T${startTime}`);
-        const end = new Date(`2000-01-01T${endTime}`);
-        return Math.abs(end.getTime() - start.getTime()) / (1000 * 60); // Convert to minutes
-    }
+  private displayContentLoad(): void {
+    if (!this.contentLoadDisplay || !this.contentLoadConfig) return;
 
-    private determineContentLoad(duration: number): ContentLoadConfig {
-        if (duration <= 30) {
-            return {
-                type: 'mini',
-                duration,
-                topicsPerLesson: 1,
-                objectivesPerTopic: 1,
-                tasksPerTopic: 2
-            };
-        } else if (duration <= 60) {
-            return {
-                type: 'regular',
-                duration,
-                topicsPerLesson: 2,
-                objectivesPerTopic: 2,
-                tasksPerTopic: 2
-            };
-        } else if (duration <= 120) {
-            return {
-                type: 'double',
-                duration,
-                topicsPerLesson: 3,
-                objectivesPerTopic: 2,
-                tasksPerTopic: 3
-            };
-        } else if (duration <= 180) {
-            return {
-                type: 'triple',
-                duration,
-                topicsPerLesson: 4,
-                objectivesPerTopic: 3,
-                tasksPerTopic: 3
-            };
-        } else {
-            return {
-                type: 'long',
-                duration,
-                topicsPerLesson: 5,
-                objectivesPerTopic: 3,
-                tasksPerTopic: 4
-            };
-        }
-    }
-
-    private displayContentLoad(): void {
-        if (!this.contentLoadDisplay || !this.contentLoadConfig) return;
-
-        this.contentLoadDisplay.innerHTML = `
+    this.contentLoadDisplay.innerHTML = `
             <div class="content-load-info">
                 <div class="content-load-badge content-load-badge--${this.contentLoadConfig.type}">
                     ${this.contentLoadConfig.type.toUpperCase()}
@@ -198,12 +211,12 @@ export class CurriculumManager {
                 </div>
             </div>
         `;
-    }
+  }
 
-    private displayNoScheduleWarning(): void {
-        if (!this.contentLoadDisplay) return;
+  private displayNoScheduleWarning(): void {
+    if (!this.contentLoadDisplay) return;
 
-        this.contentLoadDisplay.innerHTML = `
+    this.contentLoadDisplay.innerHTML = `
             <div class="content-load-warning">
                 <div class="warning-icon">⚠️</div>
                 <div class="warning-text">
@@ -212,210 +225,233 @@ export class CurriculumManager {
                 </div>
             </div>
         `;
+  }
+
+  private async generateCurriculum(): Promise<void> {
+    if (!this.contentLoadConfig) {
+      console.warn(
+        "Content load configuration not available. Please ensure you have a schedule.",
+      );
+      return;
     }
 
-    private async generateCurriculum(): Promise<void> {
-        if (!this.contentLoadConfig) {
-            console.warn('Content load configuration not available. Please ensure you have a schedule.');
-            return;
+    console.log("Generating curriculum with config:", this.contentLoadConfig);
+
+    try {
+      // Get the number of lessons from schedule
+      const { data: scheduleData } = await supabase
+        .from("courses")
+        .select("schedule_settings, course_days")
+        .eq("id", this.courseId)
+        .single();
+
+      const numLessons = scheduleData?.course_days || 1;
+      const curriculum = this.createCurriculumStructure(numLessons);
+
+      await this.saveCurriculumToDatabase(curriculum);
+      this.currentCurriculum = curriculum;
+      this.renderCurriculumPreview();
+
+      console.log("Curriculum generated successfully");
+    } catch (error) {
+      console.error("Error generating curriculum:", error);
+      alert("Failed to generate curriculum. Please try again.");
+    }
+  }
+
+  private createCurriculumStructure(numLessons: number): CurriculumLesson[] {
+    if (!this.contentLoadConfig) return [];
+
+    const curriculum: CurriculumLesson[] = [];
+
+    for (let i = 1; i <= numLessons; i++) {
+      const lesson: CurriculumLesson = {
+        lessonNumber: i,
+        title: `Lesson ${i}`,
+        topics: [],
+      };
+
+      for (let j = 1; j <= this.contentLoadConfig.topicsPerLesson; j++) {
+        const topic: CurriculumTopic = {
+          title: `Topic ${j}`,
+          objectives: [],
+          tasks: [],
+        };
+
+        // Add objectives
+        for (let k = 1; k <= this.contentLoadConfig.objectivesPerTopic; k++) {
+          topic.objectives.push(`Objective ${k}`);
         }
 
-        console.log('Generating curriculum with config:', this.contentLoadConfig);
-
-        try {
-            // Get the number of lessons from schedule
-            const { data: scheduleData } = await supabase
-                .from('courses')
-                .select('schedule_settings, course_days')
-                .eq('id', this.courseId)
-                .single();
-
-            const numLessons = scheduleData?.course_days || 1;
-            const curriculum = this.createCurriculumStructure(numLessons);
-
-            await this.saveCurriculumToDatabase(curriculum);
-            this.currentCurriculum = curriculum;
-            this.renderCurriculumPreview();
-
-            console.log('Curriculum generated successfully');
-        } catch (error) {
-            console.error('Error generating curriculum:', error);
-            alert('Failed to generate curriculum. Please try again.');
+        // Add tasks
+        for (let l = 1; l <= this.contentLoadConfig.tasksPerTopic; l++) {
+          topic.tasks.push(`Task ${l}`);
         }
+
+        lesson.topics.push(topic);
+      }
+
+      curriculum.push(lesson);
     }
 
-    private createCurriculumStructure(numLessons: number): CurriculumLesson[] {
-        if (!this.contentLoadConfig) return [];
+    return curriculum;
+  }
 
-        const curriculum: CurriculumLesson[] = [];
+  private async saveCurriculumToDatabase(
+    curriculum: CurriculumLesson[],
+  ): Promise<void> {
+    const { error } = await supabase
+      .from("courses")
+      .update({
+        curriculum_data: curriculum,
+      })
+      .eq("id", this.courseId);
 
-        for (let i = 1; i <= numLessons; i++) {
-            const lesson: CurriculumLesson = {
-                lessonNumber: i,
-                title: `Lesson ${i}`,
-                topics: []
-            };
-
-            for (let j = 1; j <= this.contentLoadConfig.topicsPerLesson; j++) {
-                const topic: CurriculumTopic = {
-                    title: `Topic ${j}`,
-                    objectives: [],
-                    tasks: []
-                };
-
-                // Add objectives
-                for (let k = 1; k <= this.contentLoadConfig.objectivesPerTopic; k++) {
-                    topic.objectives.push(`Objective ${k}`);
-                }
-
-                // Add tasks
-                for (let l = 1; l <= this.contentLoadConfig.tasksPerTopic; l++) {
-                    topic.tasks.push(`Task ${l}`);
-                }
-
-                lesson.topics.push(topic);
-            }
-
-            curriculum.push(lesson);
-        }
-
-        return curriculum;
+    if (error) {
+      throw error;
     }
+  }
 
-    private async saveCurriculumToDatabase(curriculum: CurriculumLesson[]): Promise<void> {
-        const { error } = await supabase
-            .from('courses')
-            .update({
-                curriculum_data: curriculum
-            })
-            .eq('id', this.courseId);
+  private setPreviewMode(mode: PreviewMode): void {
+    this.currentPreviewMode = mode;
 
-        if (error) {
-            throw error;
-        }
-    }
+    // Update active button
+    const previewModeButtons =
+      this.curriculumPreviewSection.querySelectorAll(".preview-mode-btn");
+    previewModeButtons.forEach((btn) => {
+      btn.classList.toggle(
+        "active",
+        (btn as HTMLElement).dataset.mode === mode,
+      );
+    });
 
-    private setPreviewMode(mode: PreviewMode): void {
-        this.currentPreviewMode = mode;
-        
-        // Update active button
-        const previewModeButtons = this.curriculumPreviewSection.querySelectorAll('.preview-mode-btn');
-        previewModeButtons.forEach(btn => {
-            btn.classList.toggle('active', (btn as HTMLElement).dataset.mode === mode);
+    // Re-render preview with new mode
+    this.renderCurriculumPreview();
+  }
+
+  private renderCurriculumPreview(): void {
+    const previewContainer = this.curriculumPreviewSection.querySelector(
+      ".curriculum-preview-content",
+    );
+    if (!previewContainer || !Array.isArray(this.currentCurriculum)) return;
+
+    let html = "";
+
+    this.currentCurriculum.forEach((lesson) => {
+      html += `<div class="curriculum-lesson">`;
+
+      // Always show lesson title
+      html += `<div class="lesson-title" contenteditable="true" data-lesson="${lesson.lessonNumber}" data-field="title">${lesson.title}</div>`;
+
+      if (
+        this.currentPreviewMode === "topics" ||
+        this.currentPreviewMode === "objectives"
+      ) {
+        lesson.topics.forEach((topic, topicIndex) => {
+          html += `<div class="lesson-topic">`;
+          html += `<div class="topic-title" contenteditable="true" data-lesson="${lesson.lessonNumber}" data-topic="${topicIndex}" data-field="title">${topic.title}</div>`;
+
+          if (this.currentPreviewMode === "objectives") {
+            topic.objectives.forEach((objective, objIndex) => {
+              html += `<div class="topic-objective" contenteditable="true" data-lesson="${lesson.lessonNumber}" data-topic="${topicIndex}" data-objective="${objIndex}">${objective}</div>`;
+            });
+          }
+
+          html += `</div>`;
         });
+      }
 
-        // Re-render preview with new mode
+      html += `</div>`;
+    });
+
+    previewContainer.innerHTML = html;
+    this.bindEditableEvents();
+    this.curriculumPreviewSection.classList.remove("hidden");
+  }
+
+  private bindEditableEvents(): void {
+    const editableElements = this.curriculumPreviewSection.querySelectorAll(
+      '[contenteditable="true"]',
+    );
+    editableElements.forEach((element) => {
+      element.addEventListener("blur", (e) =>
+        this.updateCurriculumData(e.target as HTMLElement),
+      );
+    });
+  }
+
+  private updateCurriculumData(element: HTMLElement): void {
+    const lessonNum = parseInt(element.dataset.lesson || "0");
+    const topicIndex = element.dataset.topic
+      ? parseInt(element.dataset.topic)
+      : null;
+    const objectiveIndex = element.dataset.objective
+      ? parseInt(element.dataset.objective)
+      : null;
+    const field = element.dataset.field;
+    const newValue = element.textContent || "";
+
+    const lesson = this.currentCurriculum.find(
+      (l) => l.lessonNumber === lessonNum,
+    );
+    if (!lesson) return;
+
+    if (field === "title" && topicIndex === null) {
+      // Lesson title
+      lesson.title = newValue;
+    } else if (topicIndex !== null && lesson.topics[topicIndex]) {
+      if (field === "title") {
+        // Topic title
+        lesson.topics[topicIndex].title = newValue;
+      } else if (objectiveIndex !== null) {
+        // Objective
+        lesson.topics[topicIndex].objectives[objectiveIndex] = newValue;
+      }
+    }
+
+    // Auto-save to database
+    this.saveCurriculumToDatabase(this.currentCurriculum);
+  }
+
+  private async loadExistingCurriculum(): Promise<void> {
+    try {
+      const { data, error } = await supabase
+        .from("courses")
+        .select("curriculum_data")
+        .eq("id", this.courseId)
+        .single();
+
+      if (error) throw error;
+
+      if (data?.curriculum_data && Array.isArray(data.curriculum_data)) {
+        this.currentCurriculum = data.curriculum_data;
         this.renderCurriculumPreview();
+      } else {
+        this.hideCurriculumPreview();
+      }
+    } catch (error) {
+      console.error("Error loading existing curriculum:", error);
+      this.hideCurriculumPreview();
     }
+  }
 
-    private renderCurriculumPreview(): void {
-        const previewContainer = this.curriculumPreviewSection.querySelector('.curriculum-preview-content');
-        if (!previewContainer || !Array.isArray(this.currentCurriculum)) return;
+  private showPreview(): void {
+    this.curriculumPreviewSection.classList.remove("hidden");
+    this.renderCurriculumPreview();
+  }
 
-        let html = '';
-
-        this.currentCurriculum.forEach(lesson => {
-            html += `<div class="curriculum-lesson">`;
-            
-            // Always show lesson title
-            html += `<div class="lesson-title" contenteditable="true" data-lesson="${lesson.lessonNumber}" data-field="title">${lesson.title}</div>`;
-            
-            if (this.currentPreviewMode === 'topics' || this.currentPreviewMode === 'objectives') {
-                lesson.topics.forEach((topic, topicIndex) => {
-                    html += `<div class="lesson-topic">`;
-                    html += `<div class="topic-title" contenteditable="true" data-lesson="${lesson.lessonNumber}" data-topic="${topicIndex}" data-field="title">${topic.title}</div>`;
-                    
-                    if (this.currentPreviewMode === 'objectives') {
-                        topic.objectives.forEach((objective, objIndex) => {
-                            html += `<div class="topic-objective" contenteditable="true" data-lesson="${lesson.lessonNumber}" data-topic="${topicIndex}" data-objective="${objIndex}">${objective}</div>`;
-                        });
-                    }
-                    
-                    html += `</div>`;
-                });
-            }
-            
-            html += `</div>`;
-        });
-
-        previewContainer.innerHTML = html;
-        this.bindEditableEvents();
-        this.curriculumPreviewSection.classList.remove('hidden');
-    }
-
-    private bindEditableEvents(): void {
-        const editableElements = this.curriculumPreviewSection.querySelectorAll('[contenteditable="true"]');
-        editableElements.forEach(element => {
-            element.addEventListener('blur', (e) => this.updateCurriculumData(e.target as HTMLElement));
-        });
-    }
-
-    private updateCurriculumData(element: HTMLElement): void {
-        const lessonNum = parseInt(element.dataset.lesson || '0');
-        const topicIndex = element.dataset.topic ? parseInt(element.dataset.topic) : null;
-        const objectiveIndex = element.dataset.objective ? parseInt(element.dataset.objective) : null;
-        const field = element.dataset.field;
-        const newValue = element.textContent || '';
-
-        const lesson = this.currentCurriculum.find(l => l.lessonNumber === lessonNum);
-        if (!lesson) return;
-
-        if (field === 'title' && topicIndex === null) {
-            // Lesson title
-            lesson.title = newValue;
-        } else if (topicIndex !== null && lesson.topics[topicIndex]) {
-            if (field === 'title') {
-                // Topic title
-                lesson.topics[topicIndex].title = newValue;
-            } else if (objectiveIndex !== null) {
-                // Objective
-                lesson.topics[topicIndex].objectives[objectiveIndex] = newValue;
-            }
-        }
-
-        // Auto-save to database
-        this.saveCurriculumToDatabase(this.currentCurriculum);
-    }
-
-    private async loadExistingCurriculum(): Promise<void> {
-        try {
-            const { data, error } = await supabase
-                .from('courses')
-                .select('curriculum_data')
-                .eq('id', this.courseId)
-                .single();
-
-            if (error) throw error;
-
-            if (data?.curriculum_data && Array.isArray(data.curriculum_data)) {
-                this.currentCurriculum = data.curriculum_data;
-                this.renderCurriculumPreview();
-            } else {
-                this.hideCurriculumPreview();
-            }
-        } catch (error) {
-            console.error('Error loading existing curriculum:', error);
-            this.hideCurriculumPreview();
-        }
-    }
-
-    private showPreview(): void {
-        this.curriculumPreviewSection.classList.remove('hidden');
-        this.renderCurriculumPreview();
-    }
-
-    private hideCurriculumPreview(): void {
-        this.curriculumPreviewSection.classList.add('hidden');
-    }
+  private hideCurriculumPreview(): void {
+    this.curriculumPreviewSection.classList.add("hidden");
+  }
 }
 
 // Make CurriculumManager available globally for testing/debugging
 declare global {
-    interface Window {
-        CurriculumManager: typeof CurriculumManager;
-    }
+  interface Window {
+    CurriculumManager: typeof CurriculumManager;
+  }
 }
 
-if (typeof window !== 'undefined') {
-    window.CurriculumManager = CurriculumManager;
+if (typeof window !== "undefined") {
+  window.CurriculumManager = CurriculumManager;
 }

--- a/src/scripts/backend/courses/index.ts
+++ b/src/scripts/backend/courses/index.ts
@@ -2,13 +2,13 @@
 // COURSE BUILDER MAIN CONTROLLER - Uses Generic Form Handler
 // ==========================================================================
 
-import { CourseFormHandler } from './courseFormHandler';
-import { ScheduleCourseManager } from './scheduleCourse';
-import { CurriculumManager } from './curriculumManager';
+import { CourseFormHandler } from "./courseFormHandler";
+import { ScheduleCourseManager } from "./scheduleCourse";
+import { CurriculumManager } from "./curriculumManager";
 
 // Re-export course creation and classification functions
-export * from './createCourse';
-export * from './classifyCourse';
+export * from "./createCourse";
+export * from "./classifyCourse";
 
 // ==========================================================================
 // COURSE BUILDER CLASS
@@ -18,7 +18,7 @@ export class CourseBuilder {
   private currentFormHandler: CourseFormHandler | null = null;
   private scheduleManager: ScheduleCourseManager | null = null;
   private curriculumManager: CurriculumManager | null = null;
-  private currentSection: string = 'essentials';
+  private currentSection: string = "essentials";
 
   constructor() {
     this.initialize();
@@ -31,12 +31,12 @@ export class CourseBuilder {
   private initialize(): void {
     this.initializeCurrentSection();
     this.setupSectionNavigation();
-    console.log('Course Builder initialized with generic form handler');
+    console.log("Course Builder initialized with generic form handler");
   }
 
   private initializeCurrentSection(): void {
     // Initialize the currently active section
-    const activeSection = document.querySelector('.article--active');
+    const activeSection = document.querySelector(".article--active");
     if (activeSection) {
       const sectionId = activeSection.id;
       this.loadSection(sectionId);
@@ -45,11 +45,11 @@ export class CourseBuilder {
 
   private setupSectionNavigation(): void {
     // Listen for aside navigation clicks
-    const asideLinks = document.querySelectorAll('.aside__link[data-section]');
-    asideLinks.forEach(link => {
-      link.addEventListener('click', (e) => {
+    const asideLinks = document.querySelectorAll(".aside__link[data-section]");
+    asideLinks.forEach((link) => {
+      link.addEventListener("click", (e) => {
         e.preventDefault();
-        const section = (e.target as HTMLElement).getAttribute('data-section');
+        const section = (e.target as HTMLElement).getAttribute("data-section");
         if (section) {
           this.navigateToSection(section);
         }
@@ -63,15 +63,15 @@ export class CourseBuilder {
 
   private navigateToSection(sectionId: string): void {
     // Hide all articles
-    const articles = document.querySelectorAll('.article');
-    articles.forEach(article => {
-      article.classList.remove('article--active');
+    const articles = document.querySelectorAll(".article");
+    articles.forEach((article) => {
+      article.classList.remove("article--active");
     });
 
     // Show target article
     const targetArticle = document.getElementById(sectionId);
     if (targetArticle) {
-      targetArticle.classList.add('article--active');
+      targetArticle.classList.add("article--active");
       this.currentSection = sectionId;
       this.loadSection(sectionId);
     }
@@ -86,12 +86,12 @@ export class CourseBuilder {
       this.currentFormHandler = null;
       this.scheduleManager = null;
       this.curriculumManager = null;
-      
+
       // Initialize appropriate handler based on section
-      if (sectionId === 'schedule') {
+      if (sectionId === "schedule") {
         // Initialize schedule manager - it will auto-detect course ID from session storage
         this.scheduleManager = new ScheduleCourseManager();
-      } else if (sectionId === 'curriculum') {
+      } else if (sectionId === "curriculum") {
         // Initialize curriculum manager - it will auto-detect course ID from session storage
         this.curriculumManager = new CurriculumManager();
       } else {
@@ -105,15 +105,17 @@ export class CourseBuilder {
 
   private updateAsideNavigation(activeSectionId: string): void {
     // Remove active class from all links
-    const asideLinks = document.querySelectorAll('.aside__link');
-    asideLinks.forEach(link => {
-      link.classList.remove('aside__link--active');
+    const asideLinks = document.querySelectorAll(".aside__link");
+    asideLinks.forEach((link) => {
+      link.classList.remove("aside__link--active");
     });
 
     // Add active class to current link
-    const activeLink = document.querySelector(`[data-section="${activeSectionId}"]`);
+    const activeLink = document.querySelector(
+      `[data-section="${activeSectionId}"]`,
+    );
     if (activeLink) {
-      activeLink.classList.add('aside__link--active');
+      activeLink.classList.add("aside__link--active");
     }
   }
 
@@ -137,26 +139,34 @@ export class CourseBuilder {
 // Initialize when DOM is ready - but only once
 let courseBuilderInitialized = false;
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   // Only initialize if we're on the coursebuilder page, in the setup section, and not already initialized
-  const isInSetupSection = document.querySelector('.section#setup.section--active') || window.location.hash === '#setup' || window.location.hash === '';
-  const hasSetupSection = document.querySelector('.section#setup');
-  
+  const isInSetupSection =
+    document.querySelector(".section#setup.section--active") ||
+    window.location.hash === "#setup" ||
+    window.location.hash === "";
+  const hasSetupSection = document.querySelector(".section#setup");
+
   if (hasSetupSection && isInSetupSection && !courseBuilderInitialized) {
     courseBuilderInitialized = true;
     new CourseBuilder();
-    console.log('CourseBuilder (form handler) initialized from courses/index.ts');
+    console.log(
+      "CourseBuilder (form handler) initialized from courses/index.ts",
+    );
   }
 });
 
 // Also listen for hash changes to initialize when entering setup
-window.addEventListener('hashchange', () => {
-  const isInSetupSection = window.location.hash === '#setup' || window.location.hash === '';
-  const hasSetupSection = document.querySelector('.section#setup');
-  
+window.addEventListener("hashchange", () => {
+  const isInSetupSection =
+    window.location.hash === "#setup" || window.location.hash === "";
+  const hasSetupSection = document.querySelector(".section#setup");
+
   if (hasSetupSection && isInSetupSection && !courseBuilderInitialized) {
     courseBuilderInitialized = true;
     new CourseBuilder();
-    console.log('CourseBuilder (form handler) initialized on hash change to setup');
+    console.log(
+      "CourseBuilder (form handler) initialized on hash change to setup",
+    );
   }
 });

--- a/src/scripts/backend/courses/marginSettings.ts
+++ b/src/scripts/backend/courses/marginSettings.ts
@@ -3,14 +3,14 @@
  * Handles margin settings UI and database persistence for course canvas
  */
 
-import { supabase } from '../../backend/supabase';
+import { supabase } from "../../backend/supabase";
 
 export interface MarginSettings {
   top: number;
   bottom: number;
   left: number;
   right: number;
-  unit: 'inches' | 'centimeters';
+  unit: "inches" | "centimeters";
 }
 
 export class MarginSettingsHandler {
@@ -26,7 +26,7 @@ export class MarginSettingsHandler {
       bottom: 2.54,
       left: 2.54,
       right: 2.54,
-      unit: 'centimeters'
+      unit: "centimeters",
     };
 
     // Load from local storage if available
@@ -37,30 +37,33 @@ export class MarginSettingsHandler {
     this.bindEvents();
     this.updateUnitDisplays();
     this.updateInputValues(); // Ensure UI shows default values
-    console.log('📏 Margin Settings Handler initialized with defaults:', this.currentSettings);
+    console.log(
+      "📏 Margin Settings Handler initialized with defaults:",
+      this.currentSettings,
+    );
   }
 
   private bindEvents(): void {
     // Unit toggle events
     const unitInputs = document.querySelectorAll('input[name="margin-unit"]');
-    unitInputs.forEach(input => {
-      input.addEventListener('change', (e) => this.handleUnitChange(e));
+    unitInputs.forEach((input) => {
+      input.addEventListener("change", (e) => this.handleUnitChange(e));
     });
 
     // Margin input events
-    const marginInputs = document.querySelectorAll('.margin-input');
-    marginInputs.forEach(input => {
-      input.addEventListener('input', (e) => this.handleMarginChange(e));
-      input.addEventListener('change', (e) => this.handleMarginChange(e)); // For when user leaves field
+    const marginInputs = document.querySelectorAll(".margin-input");
+    marginInputs.forEach((input) => {
+      input.addEventListener("input", (e) => this.handleMarginChange(e));
+      input.addEventListener("change", (e) => this.handleMarginChange(e)); // For when user leaves field
     });
   }
 
   private handleUnitChange(event: Event): void {
     const input = event.target as HTMLInputElement;
-    const newUnit = input.value as 'inches' | 'centimeters';
-    
+    const newUnit = input.value as "inches" | "centimeters";
+
     console.log(`📏 Unit changed to: ${newUnit}`);
-    
+
     // Convert current values to new unit
     if (newUnit !== this.currentSettings.unit) {
       this.convertMarginUnits(this.currentSettings.unit, newUnit);
@@ -74,47 +77,72 @@ export class MarginSettingsHandler {
 
   private handleMarginChange(event: Event): void {
     const input = event.target as HTMLInputElement;
-    const marginType = input.name.replace('margin_', '') as keyof Omit<MarginSettings, 'unit'>;
+    const marginType = input.name.replace("margin_", "") as keyof Omit<
+      MarginSettings,
+      "unit"
+    >;
     const value = parseFloat(input.value) || 0;
-    
-    console.log(`📏 Margin ${marginType} changed to: ${value} ${this.currentSettings.unit}`);
-    
+
+    console.log(
+      `📏 Margin ${marginType} changed to: ${value} ${this.currentSettings.unit}`,
+    );
+
     // Update current settings
     this.currentSettings[marginType] = value;
-    
+
     // Show saving status
-    this.showSaveStatus('saving');
-    
+    this.showSaveStatus("saving");
+
     // Debounce saving to database
     if (this.saveTimeout) {
       clearTimeout(this.saveTimeout);
     }
-    
+
     this.saveTimeout = setTimeout(() => {
       this.saveSettingsToDatabase();
       this.updateCanvasMargins();
     }, 500); // Save after 500ms of no changes
   }
 
-  private convertMarginUnits(fromUnit: 'inches' | 'centimeters', toUnit: 'inches' | 'centimeters'): void {
+  private convertMarginUnits(
+    fromUnit: "inches" | "centimeters",
+    toUnit: "inches" | "centimeters",
+  ): void {
     if (fromUnit === toUnit) return;
-    
-    const conversionFactor = fromUnit === 'inches' ? 2.54 : 1 / 2.54; // inches to cm or cm to inches
-    
-    this.currentSettings.top = parseFloat((this.currentSettings.top * conversionFactor).toFixed(2));
-    this.currentSettings.bottom = parseFloat((this.currentSettings.bottom * conversionFactor).toFixed(2));
-    this.currentSettings.left = parseFloat((this.currentSettings.left * conversionFactor).toFixed(2));
-    this.currentSettings.right = parseFloat((this.currentSettings.right * conversionFactor).toFixed(2));
-    
-    console.log(`📏 Converted margins from ${fromUnit} to ${toUnit}:`, this.currentSettings);
+
+    const conversionFactor = fromUnit === "inches" ? 2.54 : 1 / 2.54; // inches to cm or cm to inches
+
+    this.currentSettings.top = parseFloat(
+      (this.currentSettings.top * conversionFactor).toFixed(2),
+    );
+    this.currentSettings.bottom = parseFloat(
+      (this.currentSettings.bottom * conversionFactor).toFixed(2),
+    );
+    this.currentSettings.left = parseFloat(
+      (this.currentSettings.left * conversionFactor).toFixed(2),
+    );
+    this.currentSettings.right = parseFloat(
+      (this.currentSettings.right * conversionFactor).toFixed(2),
+    );
+
+    console.log(
+      `📏 Converted margins from ${fromUnit} to ${toUnit}:`,
+      this.currentSettings,
+    );
   }
 
   private updateInputValues(): void {
-    const topInput = document.getElementById('margin-top') as HTMLInputElement;
-    const bottomInput = document.getElementById('margin-bottom') as HTMLInputElement;
-    const leftInput = document.getElementById('margin-left') as HTMLInputElement;
-    const rightInput = document.getElementById('margin-right') as HTMLInputElement;
-    
+    const topInput = document.getElementById("margin-top") as HTMLInputElement;
+    const bottomInput = document.getElementById(
+      "margin-bottom",
+    ) as HTMLInputElement;
+    const leftInput = document.getElementById(
+      "margin-left",
+    ) as HTMLInputElement;
+    const rightInput = document.getElementById(
+      "margin-right",
+    ) as HTMLInputElement;
+
     if (topInput) topInput.value = this.currentSettings.top.toString();
     if (bottomInput) bottomInput.value = this.currentSettings.bottom.toString();
     if (leftInput) leftInput.value = this.currentSettings.left.toString();
@@ -122,28 +150,33 @@ export class MarginSettingsHandler {
   }
 
   private updateUnitDisplays(): void {
-    const unitDisplays = document.querySelectorAll('.margin-unit-display');
-    const displayUnit = this.currentSettings.unit === 'inches' ? 'in' : 'cm';
-    
-    unitDisplays.forEach(display => {
+    const unitDisplays = document.querySelectorAll(".margin-unit-display");
+    const displayUnit = this.currentSettings.unit === "inches" ? "in" : "cm";
+
+    unitDisplays.forEach((display) => {
       display.textContent = displayUnit;
     });
   }
 
   private async saveSettingsToDatabase(): Promise<void> {
     if (!this.courseId) {
-      console.error('📏 ERROR: No course ID available, cannot save margin settings');
+      console.error(
+        "📏 ERROR: No course ID available, cannot save margin settings",
+      );
       return;
     }
 
     try {
-      console.log('📏 Saving margin settings to database...', this.currentSettings);
-      
+      console.log(
+        "📏 Saving margin settings to database...",
+        this.currentSettings,
+      );
+
       // Get current course settings
       const { data: course, error: fetchError } = await supabase
-        .from('courses')
-        .select('course_settings')
-        .eq('id', this.courseId)
+        .from("courses")
+        .select("course_settings")
+        .eq("id", this.courseId)
         .single();
 
       if (fetchError) {
@@ -154,56 +187,57 @@ export class MarginSettingsHandler {
       const existingSettings = course?.course_settings || {};
       const updatedSettings = {
         ...existingSettings,
-        margins: this.currentSettings
+        margins: this.currentSettings,
       };
 
       // Save to database
       const { error } = await supabase
-        .from('courses')
+        .from("courses")
         .update({ course_settings: updatedSettings })
-        .eq('id', this.courseId);
+        .eq("id", this.courseId);
 
       if (error) {
         throw error;
       }
 
-      console.log('📏 Margin settings saved successfully');
-      this.showSaveStatus('saved');
-      
+      console.log("📏 Margin settings saved successfully");
+      this.showSaveStatus("saved");
     } catch (error) {
-      console.error('📏 Failed to save margin settings:', error);
-      this.showSaveStatus('error');
+      console.error("📏 Failed to save margin settings:", error);
+      this.showSaveStatus("error");
     }
   }
 
-  private showSaveStatus(status: 'saving' | 'saved' | 'error'): void {
-    const statusElement = document.querySelector('#margins-save-status .save-indicator__text') as HTMLElement;
+  private showSaveStatus(status: "saving" | "saved" | "error"): void {
+    const statusElement = document.querySelector(
+      "#margins-save-status .save-indicator__text",
+    ) as HTMLElement;
     if (!statusElement) return;
 
     // Remove existing status classes
-    statusElement.classList.remove('saved', 'saving', 'error');
-    
+    statusElement.classList.remove("saved", "saving", "error");
+
     switch (status) {
-      case 'saving':
-        statusElement.textContent = 'Saving margins...';
-        statusElement.classList.add('saving');
+      case "saving":
+        statusElement.textContent = "Saving margins...";
+        statusElement.classList.add("saving");
         break;
-      case 'saved':
-        statusElement.textContent = 'Margins saved successfully';
-        statusElement.classList.add('saved');
+      case "saved":
+        statusElement.textContent = "Margins saved successfully";
+        statusElement.classList.add("saved");
         // Reset to default message after 3 seconds
         setTimeout(() => {
-          statusElement.textContent = 'Margins will be saved automatically';
-          statusElement.classList.remove('saved');
+          statusElement.textContent = "Margins will be saved automatically";
+          statusElement.classList.remove("saved");
         }, 3000);
         break;
-      case 'error':
-        statusElement.textContent = 'Failed to save margins';
-        statusElement.classList.add('error');
+      case "error":
+        statusElement.textContent = "Failed to save margins";
+        statusElement.classList.add("error");
         // Reset to default message after 5 seconds
         setTimeout(() => {
-          statusElement.textContent = 'Margins will be saved automatically';
-          statusElement.classList.remove('error');
+          statusElement.textContent = "Margins will be saved automatically";
+          statusElement.classList.remove("error");
         }, 5000);
         break;
     }
@@ -211,18 +245,18 @@ export class MarginSettingsHandler {
 
   public async loadSettingsFromDatabase(courseId: string): Promise<void> {
     this.courseId = courseId;
-    
+
     try {
       console.log(`📏 Loading margin settings for course: ${courseId}`);
-      
+
       const { data: course, error } = await supabase
-        .from('courses')
-        .select('course_settings')
-        .eq('id', courseId)
+        .from("courses")
+        .select("course_settings")
+        .eq("id", courseId)
         .single();
 
       if (error) {
-        console.error('📏 Error loading course settings:', error);
+        console.error("📏 Error loading course settings:", error);
         // Use defaults if loading fails
         this.updateInputValues();
         this.updateUnitDisplays();
@@ -233,18 +267,20 @@ export class MarginSettingsHandler {
       if (course?.course_settings?.margins) {
         const margins = course.course_settings.margins;
         this.currentSettings = { ...this.currentSettings, ...margins };
-        console.log('📏 Loaded margin settings from database:', this.currentSettings);
+        console.log(
+          "📏 Loaded margin settings from database:",
+          this.currentSettings,
+        );
       } else {
-        console.log('📏 No margin settings found in database, using defaults');
+        console.log("📏 No margin settings found in database, using defaults");
       }
 
       // Update UI and canvas
       this.updateInputValues();
       this.updateUnitDisplays();
       this.updateCanvasMargins();
-
     } catch (error) {
-      console.error('📏 Error loading margin settings:', error);
+      console.error("📏 Error loading margin settings:", error);
       // Use defaults if loading fails
       this.updateInputValues();
       this.updateUnitDisplays();
@@ -254,34 +290,43 @@ export class MarginSettingsHandler {
 
   private updateCanvasMargins(): void {
     // This will communicate with the course builder to update canvas margins
-    if (this.courseBuilder && typeof this.courseBuilder.updateCanvasMargins === 'function') {
+    if (
+      this.courseBuilder &&
+      typeof this.courseBuilder.updateCanvasMargins === "function"
+    ) {
       // Convert to pixels (assuming 96 DPI)
       const dpi = 96;
       const marginsInPixels = {
-        top: this.currentSettings.unit === 'inches' 
-          ? this.currentSettings.top * dpi 
-          : (this.currentSettings.top / 2.54) * dpi,
-        bottom: this.currentSettings.unit === 'inches' 
-          ? this.currentSettings.bottom * dpi 
-          : (this.currentSettings.bottom / 2.54) * dpi,
-        left: this.currentSettings.unit === 'inches' 
-          ? this.currentSettings.left * dpi 
-          : (this.currentSettings.left / 2.54) * dpi,
-        right: this.currentSettings.unit === 'inches' 
-          ? this.currentSettings.right * dpi 
-          : (this.currentSettings.right / 2.54) * dpi,
+        top:
+          this.currentSettings.unit === "inches"
+            ? this.currentSettings.top * dpi
+            : (this.currentSettings.top / 2.54) * dpi,
+        bottom:
+          this.currentSettings.unit === "inches"
+            ? this.currentSettings.bottom * dpi
+            : (this.currentSettings.bottom / 2.54) * dpi,
+        left:
+          this.currentSettings.unit === "inches"
+            ? this.currentSettings.left * dpi
+            : (this.currentSettings.left / 2.54) * dpi,
+        right:
+          this.currentSettings.unit === "inches"
+            ? this.currentSettings.right * dpi
+            : (this.currentSettings.right / 2.54) * dpi,
       };
-      
-      console.log('📏 Updating canvas margins:', marginsInPixels);
+
+      console.log("📏 Updating canvas margins:", marginsInPixels);
       this.courseBuilder.updateCanvasMargins(marginsInPixels);
     } else {
-      console.log('📏 Course builder not available yet, margins will be applied when canvas is ready');
+      console.log(
+        "📏 Course builder not available yet, margins will be applied when canvas is ready",
+      );
     }
   }
 
   public setCourseBuilder(courseBuilder: any): void {
     this.courseBuilder = courseBuilder;
-    console.log('📏 Course builder reference set');
+    console.log("📏 Course builder reference set");
     // Apply current margins immediately
     this.updateCanvasMargins();
   }
@@ -304,21 +349,30 @@ export class MarginSettingsHandler {
     }
   }
 
-  public getMarginPixels(): { top: number; bottom: number; left: number; right: number } {
+  public getMarginPixels(): {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  } {
     const dpi = 96;
     return {
-      top: this.currentSettings.unit === 'inches' 
-        ? this.currentSettings.top * dpi 
-        : (this.currentSettings.top / 2.54) * dpi,
-      bottom: this.currentSettings.unit === 'inches' 
-        ? this.currentSettings.bottom * dpi 
-        : (this.currentSettings.bottom / 2.54) * dpi,
-      left: this.currentSettings.unit === 'inches' 
-        ? this.currentSettings.left * dpi 
-        : (this.currentSettings.left / 2.54) * dpi,
-      right: this.currentSettings.unit === 'inches' 
-        ? this.currentSettings.right * dpi 
-        : (this.currentSettings.right / 2.54) * dpi,
+      top:
+        this.currentSettings.unit === "inches"
+          ? this.currentSettings.top * dpi
+          : (this.currentSettings.top / 2.54) * dpi,
+      bottom:
+        this.currentSettings.unit === "inches"
+          ? this.currentSettings.bottom * dpi
+          : (this.currentSettings.bottom / 2.54) * dpi,
+      left:
+        this.currentSettings.unit === "inches"
+          ? this.currentSettings.left * dpi
+          : (this.currentSettings.left / 2.54) * dpi,
+      right:
+        this.currentSettings.unit === "inches"
+          ? this.currentSettings.right * dpi
+          : (this.currentSettings.right / 2.54) * dpi,
     };
   }
 

--- a/src/scripts/backend/courses/scheduleCourse.ts
+++ b/src/scripts/backend/courses/scheduleCourse.ts
@@ -1,243 +1,290 @@
-import { supabase } from '../../backend/supabase.js';
+import { supabase } from "../../backend/supabase.js";
 
 interface ScheduleSession {
-    lessonNumber: number;
-    day: string;
-    date: string;
-    startTime: string;
-    endTime: string;
+  lessonNumber: number;
+  day: string;
+  date: string;
+  startTime: string;
+  endTime: string;
 }
 
 interface ScheduleConfig {
-    startDate: string;
-    endDate: string;
-    selectedDays: string[];
-    startTime: string;
-    endTime: string;
+  startDate: string;
+  endDate: string;
+  selectedDays: string[];
+  startTime: string;
+  endTime: string;
 }
 
 export class ScheduleCourseManager {
-    private courseId: string;
-    private scheduleConfigSection!: HTMLElement;
-    private schedulePreviewSection!: HTMLElement;
-    private scheduleButton!: HTMLButtonElement;
-    private deleteScheduleButton!: HTMLButtonElement;
-    private currentSchedule: ScheduleSession[] = [];
+  private courseId: string;
+  private scheduleConfigSection!: HTMLElement;
+  private schedulePreviewSection!: HTMLElement;
+  private scheduleButton!: HTMLButtonElement;
+  private deleteScheduleButton!: HTMLButtonElement;
+  private currentSchedule: ScheduleSession[] = [];
 
-    constructor(courseId?: string) {
-        // Get course ID from parameter or session storage
-        this.courseId = courseId || sessionStorage.getItem('currentCourseId') || '';
-        
-        if (!this.courseId) {
-            console.error('No course ID available for schedule management');
-            return;
-        }
-        
-        this.initializeElements();
-        this.bindEvents();
-        this.loadExistingSchedule();
-        
-        // Run initial validation to set proper button state
-        this.validateScheduleForm();
+  constructor(courseId?: string) {
+    // Get course ID from parameter or session storage
+    this.courseId = courseId || sessionStorage.getItem("currentCourseId") || "";
+
+    if (!this.courseId) {
+      console.error("No course ID available for schedule management");
+      return;
     }
 
-    private initializeElements(): void {
-        this.scheduleConfigSection = document.getElementById('schedule-config') as HTMLElement;
-        this.schedulePreviewSection = document.getElementById('schedule-preview') as HTMLElement;
-        this.scheduleButton = document.getElementById('schedule-course-btn') as HTMLButtonElement;
-        this.deleteScheduleButton = document.getElementById('delete-schedule-btn') as HTMLButtonElement;
+    this.initializeElements();
+    this.bindEvents();
+    this.loadExistingSchedule();
 
-        // Check if all elements were found
-        if (!this.scheduleConfigSection) {
-            console.error('schedule-config element not found');
-            return;
-        }
-        if (!this.schedulePreviewSection) {
-            console.error('schedule-preview element not found');
-            return;
-        }
-        if (!this.scheduleButton) {
-            console.error('schedule-course-btn element not found');
-            return;
-        }
-        if (!this.deleteScheduleButton) {
-            console.error('delete-schedule-btn element not found');
-            return;
-        }
+    // Run initial validation to set proper button state
+    this.validateScheduleForm();
+  }
 
-        console.log('All schedule elements found successfully');
+  private initializeElements(): void {
+    this.scheduleConfigSection = document.getElementById(
+      "schedule-config",
+    ) as HTMLElement;
+    this.schedulePreviewSection = document.getElementById(
+      "schedule-preview",
+    ) as HTMLElement;
+    this.scheduleButton = document.getElementById(
+      "schedule-course-btn",
+    ) as HTMLButtonElement;
+    this.deleteScheduleButton = document.getElementById(
+      "delete-schedule-btn",
+    ) as HTMLButtonElement;
+
+    // Check if all elements were found
+    if (!this.scheduleConfigSection) {
+      console.error("schedule-config element not found");
+      return;
+    }
+    if (!this.schedulePreviewSection) {
+      console.error("schedule-preview element not found");
+      return;
+    }
+    if (!this.scheduleButton) {
+      console.error("schedule-course-btn element not found");
+      return;
+    }
+    if (!this.deleteScheduleButton) {
+      console.error("delete-schedule-btn element not found");
+      return;
     }
 
-    private bindEvents(): void {
-        if (!this.scheduleConfigSection || !this.scheduleButton || !this.deleteScheduleButton) {
-            console.error('Cannot bind events: required elements not found');
-            return;
-        }
+    console.log("All schedule elements found successfully");
+  }
 
-        // Form input validation
-        this.scheduleConfigSection.addEventListener('input', () => this.validateScheduleForm());
-        this.scheduleConfigSection.addEventListener('change', () => this.validateScheduleForm());
-        
-        // Day selection buttons
-        const dayButtons = this.scheduleConfigSection.querySelectorAll('.day-button');
-        dayButtons.forEach(button => {
-            button.addEventListener('click', (e) => this.toggleDaySelection(e.target as HTMLButtonElement));
+  private bindEvents(): void {
+    if (
+      !this.scheduleConfigSection ||
+      !this.scheduleButton ||
+      !this.deleteScheduleButton
+    ) {
+      console.error("Cannot bind events: required elements not found");
+      return;
+    }
+
+    // Form input validation
+    this.scheduleConfigSection.addEventListener("input", () =>
+      this.validateScheduleForm(),
+    );
+    this.scheduleConfigSection.addEventListener("change", () =>
+      this.validateScheduleForm(),
+    );
+
+    // Day selection buttons
+    const dayButtons =
+      this.scheduleConfigSection.querySelectorAll(".day-button");
+    dayButtons.forEach((button) => {
+      button.addEventListener("click", (e) =>
+        this.toggleDaySelection(e.target as HTMLButtonElement),
+      );
+    });
+
+    // Schedule generation
+    this.scheduleButton.addEventListener("click", (e) => {
+      console.log("Button clicked!", {
+        disabled: this.scheduleButton.disabled,
+        classes: this.scheduleButton.className,
+        event: e,
+      });
+      this.generateSchedule();
+    });
+
+    // Delete schedule
+    this.deleteScheduleButton.addEventListener("click", (e) => {
+      console.log("Delete button clicked!", {
+        disabled: this.deleteScheduleButton.disabled,
+        classes: this.deleteScheduleButton.className,
+        event: e,
+      });
+      this.deleteSchedule();
+    });
+
+    console.log("Schedule events bound successfully");
+  }
+
+  private validateScheduleForm(): void {
+    const startDate = (
+      document.getElementById("start-date") as HTMLInputElement
+    )?.value;
+    const endDate = (document.getElementById("end-date") as HTMLInputElement)
+      ?.value;
+    const startTime = (
+      document.getElementById("start-time") as HTMLInputElement
+    )?.value;
+    const endTime = (document.getElementById("end-time") as HTMLInputElement)
+      ?.value;
+    const selectedDays = this.getSelectedDays();
+
+    const isValid =
+      startDate && endDate && startTime && endTime && selectedDays.length > 0;
+
+    console.log("Form validation:", {
+      startDate,
+      endDate,
+      startTime,
+      endTime,
+      selectedDays,
+      isValid,
+    });
+
+    if (isValid) {
+      this.scheduleButton.classList.add("active");
+      this.scheduleButton.classList.remove("button--disabled");
+      this.scheduleButton.disabled = false;
+    } else {
+      this.scheduleButton.classList.remove("active");
+      this.scheduleButton.classList.add("button--disabled");
+      this.scheduleButton.disabled = true;
+    }
+  }
+
+  private toggleDaySelection(button: HTMLButtonElement): void {
+    button.classList.toggle("selected");
+    this.validateScheduleForm();
+  }
+
+  private getSelectedDays(): string[] {
+    const selectedButtons = this.scheduleConfigSection.querySelectorAll(
+      ".day-button.selected",
+    );
+    return Array.from(selectedButtons).map(
+      (btn) => (btn as HTMLElement).dataset.day || "",
+    );
+  }
+
+  private getScheduleConfig(): ScheduleConfig {
+    return {
+      startDate: (document.getElementById("start-date") as HTMLInputElement)
+        .value,
+      endDate: (document.getElementById("end-date") as HTMLInputElement).value,
+      selectedDays: this.getSelectedDays(),
+      startTime: (document.getElementById("start-time") as HTMLInputElement)
+        .value,
+      endTime: (document.getElementById("end-time") as HTMLInputElement).value,
+    };
+  }
+
+  private async generateSchedule(): Promise<void> {
+    console.log("Generate schedule clicked");
+
+    const config = this.getScheduleConfig();
+    console.log("Schedule config:", config);
+
+    const sessions = this.calculateScheduleSessions(config);
+    console.log("Calculated sessions:", sessions);
+
+    try {
+      await this.saveScheduleToDatabase(sessions);
+      this.currentSchedule = sessions;
+      this.renderSchedulePreview();
+      this.lockScheduleConfig();
+      this.showDeleteScheduleButton();
+      console.log("Schedule generated successfully");
+    } catch (error) {
+      console.error("Error generating schedule:", error);
+      alert("Failed to generate schedule. Please try again.");
+    }
+  }
+
+  private calculateScheduleSessions(config: ScheduleConfig): ScheduleSession[] {
+    const sessions: ScheduleSession[] = [];
+    const startDate = new Date(config.startDate);
+    const endDate = new Date(config.endDate);
+
+    let lessonNumber = 1;
+    const currentDate = new Date(startDate);
+
+    while (currentDate <= endDate) {
+      const dayName = currentDate
+        .toLocaleDateString("en-US", { weekday: "long" })
+        .toLowerCase();
+
+      if (config.selectedDays.includes(dayName)) {
+        sessions.push({
+          lessonNumber: lessonNumber++,
+          day: dayName,
+          date: currentDate.toISOString().split("T")[0],
+          startTime: config.startTime,
+          endTime: config.endTime,
         });
+      }
 
-        // Schedule generation
-        this.scheduleButton.addEventListener('click', (e) => {
-            console.log('Button clicked!', {
-                disabled: this.scheduleButton.disabled,
-                classes: this.scheduleButton.className,
-                event: e
-            });
-            this.generateSchedule();
-        });
-        
-        // Delete schedule
-        this.deleteScheduleButton.addEventListener('click', (e) => {
-            console.log('Delete button clicked!', {
-                disabled: this.deleteScheduleButton.disabled,
-                classes: this.deleteScheduleButton.className,
-                event: e
-            });
-            this.deleteSchedule();
-        });
-
-        console.log('Schedule events bound successfully');
+      currentDate.setDate(currentDate.getDate() + 1);
     }
 
-    private validateScheduleForm(): void {
-        const startDate = (document.getElementById('start-date') as HTMLInputElement)?.value;
-        const endDate = (document.getElementById('end-date') as HTMLInputElement)?.value;
-        const startTime = (document.getElementById('start-time') as HTMLInputElement)?.value;
-        const endTime = (document.getElementById('end-time') as HTMLInputElement)?.value;
-        const selectedDays = this.getSelectedDays();
+    return sessions;
+  }
 
-        const isValid = startDate && endDate && startTime && endTime && selectedDays.length > 0;
-        
-        console.log('Form validation:', { startDate, endDate, startTime, endTime, selectedDays, isValid });
-        
-        if (isValid) {
-            this.scheduleButton.classList.add('active');
-            this.scheduleButton.classList.remove('button--disabled');
-            this.scheduleButton.disabled = false;
-        } else {
-            this.scheduleButton.classList.remove('active');
-            this.scheduleButton.classList.add('button--disabled');
-            this.scheduleButton.disabled = true;
-        }
+  private async saveScheduleToDatabase(
+    sessions: ScheduleSession[],
+  ): Promise<void> {
+    const { error } = await supabase
+      .from("courses")
+      .update({
+        schedule_settings: sessions,
+        course_days: sessions.length,
+      })
+      .eq("id", this.courseId);
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  private renderSchedulePreview(): void {
+    const previewContainer =
+      this.schedulePreviewSection.querySelector(".schedule-list");
+    if (!previewContainer) return;
+
+    previewContainer.innerHTML = "";
+
+    // Safety check: ensure currentSchedule is an array
+    if (!Array.isArray(this.currentSchedule)) {
+      console.warn("currentSchedule is not an array:", this.currentSchedule);
+      this.currentSchedule = [];
+      return;
     }
 
-    private toggleDaySelection(button: HTMLButtonElement): void {
-        button.classList.toggle('selected');
-        this.validateScheduleForm();
-    }
+    this.currentSchedule.forEach((session, index) => {
+      const row = this.createScheduleRow(session, index);
+      previewContainer.appendChild(row);
+    });
 
-    private getSelectedDays(): string[] {
-        const selectedButtons = this.scheduleConfigSection.querySelectorAll('.day-button.selected');
-        return Array.from(selectedButtons).map(btn => (btn as HTMLElement).dataset.day || '');
-    }
+    this.updateTotalLessonsDisplay();
+    this.schedulePreviewSection.classList.remove("hidden");
+  }
 
-    private getScheduleConfig(): ScheduleConfig {
-        return {
-            startDate: (document.getElementById('start-date') as HTMLInputElement).value,
-            endDate: (document.getElementById('end-date') as HTMLInputElement).value,
-            selectedDays: this.getSelectedDays(),
-            startTime: (document.getElementById('start-time') as HTMLInputElement).value,
-            endTime: (document.getElementById('end-time') as HTMLInputElement).value
-        };
-    }
-
-    private async generateSchedule(): Promise<void> {
-        console.log('Generate schedule clicked');
-        
-        const config = this.getScheduleConfig();
-        console.log('Schedule config:', config);
-        
-        const sessions = this.calculateScheduleSessions(config);
-        console.log('Calculated sessions:', sessions);
-        
-        try {
-            await this.saveScheduleToDatabase(sessions);
-            this.currentSchedule = sessions;
-            this.renderSchedulePreview();
-            this.lockScheduleConfig();
-            this.showDeleteScheduleButton();
-            console.log('Schedule generated successfully');
-        } catch (error) {
-            console.error('Error generating schedule:', error);
-            alert('Failed to generate schedule. Please try again.');
-        }
-    }
-
-    private calculateScheduleSessions(config: ScheduleConfig): ScheduleSession[] {
-        const sessions: ScheduleSession[] = [];
-        const startDate = new Date(config.startDate);
-        const endDate = new Date(config.endDate);
-
-        let lessonNumber = 1;
-        const currentDate = new Date(startDate);
-
-        while (currentDate <= endDate) {
-            const dayName = currentDate.toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
-            
-            if (config.selectedDays.includes(dayName)) {
-                sessions.push({
-                    lessonNumber: lessonNumber++,
-                    day: dayName,
-                    date: currentDate.toISOString().split('T')[0],
-                    startTime: config.startTime,
-                    endTime: config.endTime
-                });
-            }
-            
-            currentDate.setDate(currentDate.getDate() + 1);
-        }
-
-        return sessions;
-    }
-
-    private async saveScheduleToDatabase(sessions: ScheduleSession[]): Promise<void> {
-        const { error } = await supabase
-            .from('courses')
-            .update({
-                schedule_settings: sessions,
-                course_days: sessions.length
-            })
-            .eq('id', this.courseId);
-
-        if (error) {
-            throw error;
-        }
-    }
-
-    private renderSchedulePreview(): void {
-        const previewContainer = this.schedulePreviewSection.querySelector('.schedule-list');
-        if (!previewContainer) return;
-
-        previewContainer.innerHTML = '';
-
-        // Safety check: ensure currentSchedule is an array
-        if (!Array.isArray(this.currentSchedule)) {
-            console.warn('currentSchedule is not an array:', this.currentSchedule);
-            this.currentSchedule = [];
-            return;
-        }
-
-        this.currentSchedule.forEach((session, index) => {
-            const row = this.createScheduleRow(session, index);
-            previewContainer.appendChild(row);
-        });
-
-        this.updateTotalLessonsDisplay();
-        this.schedulePreviewSection.classList.remove('hidden');
-    }
-
-    private createScheduleRow(session: ScheduleSession, index: number): HTMLElement {
-        const row = document.createElement('div');
-        row.className = 'schedule-row';
-        row.innerHTML = `
+  private createScheduleRow(
+    session: ScheduleSession,
+    index: number,
+  ): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "schedule-row";
+    row.innerHTML = `
             <span class="lesson-number">${session.lessonNumber}</span>
             <span class="lesson-day">${this.formatDay(session.day)}</span>
             <input type="time" class="lesson-start-time" value="${session.startTime}" data-index="${index}">
@@ -245,155 +292,180 @@ export class ScheduleCourseManager {
             <button class="delete-lesson-btn" data-index="${index}">×</button>
         `;
 
-        // Bind events for time editing
-        const startTimeInput = row.querySelector('.lesson-start-time') as HTMLInputElement;
-        const endTimeInput = row.querySelector('.lesson-end-time') as HTMLInputElement;
-        const deleteButton = row.querySelector('.delete-lesson-btn') as HTMLButtonElement;
+    // Bind events for time editing
+    const startTimeInput = row.querySelector(
+      ".lesson-start-time",
+    ) as HTMLInputElement;
+    const endTimeInput = row.querySelector(
+      ".lesson-end-time",
+    ) as HTMLInputElement;
+    const deleteButton = row.querySelector(
+      ".delete-lesson-btn",
+    ) as HTMLButtonElement;
 
-        startTimeInput.addEventListener('change', (e) => this.updateLessonTime(index, 'startTime', (e.target as HTMLInputElement).value));
-        endTimeInput.addEventListener('change', (e) => this.updateLessonTime(index, 'endTime', (e.target as HTMLInputElement).value));
-        deleteButton.addEventListener('click', () => this.deleteLessonRow(index));
+    startTimeInput.addEventListener("change", (e) =>
+      this.updateLessonTime(
+        index,
+        "startTime",
+        (e.target as HTMLInputElement).value,
+      ),
+    );
+    endTimeInput.addEventListener("change", (e) =>
+      this.updateLessonTime(
+        index,
+        "endTime",
+        (e.target as HTMLInputElement).value,
+      ),
+    );
+    deleteButton.addEventListener("click", () => this.deleteLessonRow(index));
 
-        return row;
+    return row;
+  }
+
+  private async updateLessonTime(
+    index: number,
+    timeType: "startTime" | "endTime",
+    newTime: string,
+  ): Promise<void> {
+    this.currentSchedule[index][timeType] = newTime;
+
+    try {
+      await this.saveScheduleToDatabase(this.currentSchedule);
+    } catch (error) {
+      console.error("Error updating lesson time:", error);
+    }
+  }
+
+  private async deleteLessonRow(index: number): Promise<void> {
+    if (!confirm("Are you sure you want to delete this lesson?")) {
+      return;
     }
 
-    private async updateLessonTime(index: number, timeType: 'startTime' | 'endTime', newTime: string): Promise<void> {
-        this.currentSchedule[index][timeType] = newTime;
-        
-        try {
-            await this.saveScheduleToDatabase(this.currentSchedule);
-        } catch (error) {
-            console.error('Error updating lesson time:', error);
-        }
+    this.currentSchedule.splice(index, 1);
+
+    // Renumber lessons
+    this.currentSchedule.forEach((session, i) => {
+      session.lessonNumber = i + 1;
+    });
+
+    try {
+      await this.saveScheduleToDatabase(this.currentSchedule);
+      this.renderSchedulePreview();
+    } catch (error) {
+      console.error("Error deleting lesson:", error);
+    }
+  }
+
+  private async deleteSchedule(): Promise<void> {
+    if (!confirm("Are you sure you want to delete the entire schedule?")) {
+      return;
     }
 
-    private async deleteLessonRow(index: number): Promise<void> {
-        if (!confirm('Are you sure you want to delete this lesson?')) {
-            return;
-        }
+    try {
+      await supabase
+        .from("courses")
+        .update({
+          schedule_settings: null,
+          course_days: null,
+        })
+        .eq("id", this.courseId);
 
-        this.currentSchedule.splice(index, 1);
-        
-        // Renumber lessons
-        this.currentSchedule.forEach((session, i) => {
-            session.lessonNumber = i + 1;
-        });
-
-        try {
-            await this.saveScheduleToDatabase(this.currentSchedule);
-            this.renderSchedulePreview();
-        } catch (error) {
-            console.error('Error deleting lesson:', error);
-        }
+      this.currentSchedule = [];
+      this.unlockScheduleConfig();
+      this.hideSchedulePreview();
+      this.hideDeleteScheduleButton();
+    } catch (error) {
+      console.error("Error deleting schedule:", error);
     }
+  }
 
-    private async deleteSchedule(): Promise<void> {
-        if (!confirm('Are you sure you want to delete the entire schedule?')) {
-            return;
-        }
+  private async loadExistingSchedule(): Promise<void> {
+    try {
+      const { data, error } = await supabase
+        .from("courses")
+        .select("schedule_settings, course_days")
+        .eq("id", this.courseId)
+        .single();
 
-        try {
-            await supabase
-                .from('courses')
-                .update({
-                    schedule_settings: null,
-                    course_days: null
-                })
-                .eq('id', this.courseId);
+      if (error) throw error;
 
-            this.currentSchedule = [];
-            this.unlockScheduleConfig();
-            this.hideSchedulePreview();
-            this.hideDeleteScheduleButton();
-        } catch (error) {
-            console.error('Error deleting schedule:', error);
-        }
+      if (data?.schedule_settings && Array.isArray(data.schedule_settings)) {
+        this.currentSchedule = data.schedule_settings;
+        this.renderSchedulePreview();
+        this.lockScheduleConfig();
+        this.showDeleteScheduleButton();
+      } else {
+        // No existing schedule or invalid data - ensure currentSchedule is empty array
+        this.currentSchedule = [];
+        this.hideSchedulePreview();
+        this.unlockScheduleConfig();
+        this.hideDeleteScheduleButton();
+      }
+    } catch (error) {
+      console.error("Error loading existing schedule:", error);
+      // Ensure currentSchedule is always an array even on error
+      this.currentSchedule = [];
+      this.hideSchedulePreview();
+      this.unlockScheduleConfig();
+      this.hideDeleteScheduleButton();
     }
+  }
 
-    private async loadExistingSchedule(): Promise<void> {
-        try {
-            const { data, error } = await supabase
-                .from('courses')
-                .select('schedule_settings, course_days')
-                .eq('id', this.courseId)
-                .single();
+  private lockScheduleConfig(): void {
+    const inputs = this.scheduleConfigSection.querySelectorAll(
+      "input, button:not(#delete-schedule-btn)",
+    );
+    inputs.forEach((input) => {
+      (input as HTMLInputElement | HTMLButtonElement).disabled = true;
+    });
+    this.scheduleConfigSection.classList.add("locked");
+  }
 
-            if (error) throw error;
+  private unlockScheduleConfig(): void {
+    const inputs = this.scheduleConfigSection.querySelectorAll("input, button");
+    inputs.forEach((input) => {
+      (input as HTMLInputElement | HTMLButtonElement).disabled = false;
+    });
+    this.scheduleConfigSection.classList.remove("locked");
+    this.validateScheduleForm();
+  }
 
-            if (data?.schedule_settings && Array.isArray(data.schedule_settings)) {
-                this.currentSchedule = data.schedule_settings;
-                this.renderSchedulePreview();
-                this.lockScheduleConfig();
-                this.showDeleteScheduleButton();
-            } else {
-                // No existing schedule or invalid data - ensure currentSchedule is empty array
-                this.currentSchedule = [];
-                this.hideSchedulePreview();
-                this.unlockScheduleConfig();
-                this.hideDeleteScheduleButton();
-            }
-        } catch (error) {
-            console.error('Error loading existing schedule:', error);
-            // Ensure currentSchedule is always an array even on error
-            this.currentSchedule = [];
-            this.hideSchedulePreview();
-            this.unlockScheduleConfig();
-            this.hideDeleteScheduleButton();
-        }
+  private showDeleteScheduleButton(): void {
+    this.deleteScheduleButton.classList.remove("hidden");
+    this.deleteScheduleButton.disabled = false;
+    this.deleteScheduleButton.style.pointerEvents = "auto";
+    console.log("Delete button shown and enabled");
+  }
+
+  private hideDeleteScheduleButton(): void {
+    this.deleteScheduleButton.classList.add("hidden");
+    console.log("Delete button hidden");
+  }
+
+  private hideSchedulePreview(): void {
+    this.schedulePreviewSection.classList.add("hidden");
+  }
+
+  private updateTotalLessonsDisplay(): void {
+    const totalDisplay =
+      this.schedulePreviewSection.querySelector(".total-lessons");
+    if (totalDisplay) {
+      totalDisplay.textContent = `Total lessons: ${this.currentSchedule.length}`;
     }
+  }
 
-    private lockScheduleConfig(): void {
-        const inputs = this.scheduleConfigSection.querySelectorAll('input, button:not(#delete-schedule-btn)');
-        inputs.forEach(input => {
-            (input as HTMLInputElement | HTMLButtonElement).disabled = true;
-        });
-        this.scheduleConfigSection.classList.add('locked');
-    }
-
-    private unlockScheduleConfig(): void {
-        const inputs = this.scheduleConfigSection.querySelectorAll('input, button');
-        inputs.forEach(input => {
-            (input as HTMLInputElement | HTMLButtonElement).disabled = false;
-        });
-        this.scheduleConfigSection.classList.remove('locked');
-        this.validateScheduleForm();
-    }
-
-    private showDeleteScheduleButton(): void {
-        this.deleteScheduleButton.classList.remove('hidden');
-        this.deleteScheduleButton.disabled = false;
-        this.deleteScheduleButton.style.pointerEvents = 'auto';
-        console.log('Delete button shown and enabled');
-    }
-
-    private hideDeleteScheduleButton(): void {
-        this.deleteScheduleButton.classList.add('hidden');
-        console.log('Delete button hidden');
-    }
-
-    private hideSchedulePreview(): void {
-        this.schedulePreviewSection.classList.add('hidden');
-    }
-
-    private updateTotalLessonsDisplay(): void {
-        const totalDisplay = this.schedulePreviewSection.querySelector('.total-lessons');
-        if (totalDisplay) {
-            totalDisplay.textContent = `Total lessons: ${this.currentSchedule.length}`;
-        }
-    }
-
-    private formatDay(day: string): string {
-        return day.charAt(0).toUpperCase() + day.slice(1);
-    }
+  private formatDay(day: string): string {
+    return day.charAt(0).toUpperCase() + day.slice(1);
+  }
 }
 
 // Make ScheduleCourseManager available globally for testing/debugging
 declare global {
-    interface Window {
-        ScheduleCourseManager: typeof ScheduleCourseManager;
-    }
+  interface Window {
+    ScheduleCourseManager: typeof ScheduleCourseManager;
+  }
 }
 
-if (typeof window !== 'undefined') {
-    window.ScheduleCourseManager = ScheduleCourseManager;
+if (typeof window !== "undefined") {
+  window.ScheduleCourseManager = ScheduleCourseManager;
 }

--- a/src/scripts/backend/courses/templates/templateBlocks.ts
+++ b/src/scripts/backend/courses/templates/templateBlocks.ts
@@ -1,6 +1,12 @@
 export interface TemplateBlockConfig {
   id: string;
-  type: 'header' | 'program' | 'resources' | 'content' | 'assignment' | 'footer';
+  type:
+    | "header"
+    | "program"
+    | "resources"
+    | "content"
+    | "assignment"
+    | "footer";
   label: string;
   icon: string;
   defaultConfig: Record<string, any>;
@@ -10,7 +16,7 @@ export interface TemplateBlockConfig {
 export interface TemplateConfigField {
   name: string;
   label: string;
-  type: 'text' | 'textarea' | 'select' | 'checkbox' | 'color' | 'number';
+  type: "text" | "textarea" | "select" | "checkbox" | "color" | "number";
   options?: { value: string; label: string }[];
   defaultValue?: any;
   required?: boolean;
@@ -18,215 +24,215 @@ export interface TemplateConfigField {
 
 export const TEMPLATE_BLOCKS: TemplateBlockConfig[] = [
   {
-    id: 'header',
-    type: 'header',
-    label: 'Header',
-    icon: 'header',
+    id: "header",
+    type: "header",
+    label: "Header",
+    icon: "header",
     defaultConfig: {
       showTitle: true,
       showSubtitle: true,
-      backgroundColor: '#ffffff',
-      textColor: '#333333'
+      backgroundColor: "#ffffff",
+      textColor: "#333333",
     },
     configFields: [
       {
-        name: 'showTitle',
-        label: 'Show Title',
-        type: 'checkbox',
-        defaultValue: true
+        name: "showTitle",
+        label: "Show Title",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'showSubtitle',
-        label: 'Show Subtitle',
-        type: 'checkbox',
-        defaultValue: true
+        name: "showSubtitle",
+        label: "Show Subtitle",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'backgroundColor',
-        label: 'Background Color',
-        type: 'color',
-        defaultValue: '#ffffff'
+        name: "backgroundColor",
+        label: "Background Color",
+        type: "color",
+        defaultValue: "#ffffff",
       },
       {
-        name: 'textColor',
-        label: 'Text Color',
-        type: 'color',
-        defaultValue: '#333333'
-      }
-    ]
+        name: "textColor",
+        label: "Text Color",
+        type: "color",
+        defaultValue: "#333333",
+      },
+    ],
   },
   {
-    id: 'program',
-    type: 'program',
-    label: 'Program',
-    icon: 'program',
+    id: "program",
+    type: "program",
+    label: "Program",
+    icon: "program",
     defaultConfig: {
       showObjectives: true,
       showOutcomes: true,
-      showPrerequisites: false
+      showPrerequisites: false,
     },
     configFields: [
       {
-        name: 'showObjectives',
-        label: 'Show Learning Objectives',
-        type: 'checkbox',
-        defaultValue: true
+        name: "showObjectives",
+        label: "Show Learning Objectives",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'showOutcomes',
-        label: 'Show Learning Outcomes',
-        type: 'checkbox',
-        defaultValue: true
+        name: "showOutcomes",
+        label: "Show Learning Outcomes",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'showPrerequisites',
-        label: 'Show Prerequisites',
-        type: 'checkbox',
-        defaultValue: false
-      }
-    ]
+        name: "showPrerequisites",
+        label: "Show Prerequisites",
+        type: "checkbox",
+        defaultValue: false,
+      },
+    ],
   },
   {
-    id: 'resources',
-    type: 'resources',
-    label: 'Resources',
-    icon: 'resources',
+    id: "resources",
+    type: "resources",
+    label: "Resources",
+    icon: "resources",
     defaultConfig: {
       allowFiles: true,
       allowLinks: true,
       allowVideos: true,
-      maxFiles: 10
+      maxFiles: 10,
     },
     configFields: [
       {
-        name: 'allowFiles',
-        label: 'Allow File Uploads',
-        type: 'checkbox',
-        defaultValue: true
+        name: "allowFiles",
+        label: "Allow File Uploads",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'allowLinks',
-        label: 'Allow External Links',
-        type: 'checkbox',
-        defaultValue: true
+        name: "allowLinks",
+        label: "Allow External Links",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'allowVideos',
-        label: 'Allow Video Embeds',
-        type: 'checkbox',
-        defaultValue: true
+        name: "allowVideos",
+        label: "Allow Video Embeds",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'maxFiles',
-        label: 'Maximum Files',
-        type: 'number',
-        defaultValue: 10
-      }
-    ]
+        name: "maxFiles",
+        label: "Maximum Files",
+        type: "number",
+        defaultValue: 10,
+      },
+    ],
   },
   {
-    id: 'content',
-    type: 'content',
-    label: 'Content',
-    icon: 'content',
+    id: "content",
+    type: "content",
+    label: "Content",
+    icon: "content",
     defaultConfig: {
-      editor: 'rich-text',
+      editor: "rich-text",
       allowMedia: true,
-      allowTables: true
+      allowTables: true,
     },
     configFields: [
       {
-        name: 'editor',
-        label: 'Editor Type',
-        type: 'select',
+        name: "editor",
+        label: "Editor Type",
+        type: "select",
         options: [
-          { value: 'rich-text', label: 'Rich Text Editor' },
-          { value: 'markdown', label: 'Markdown Editor' },
-          { value: 'plain-text', label: 'Plain Text' }
+          { value: "rich-text", label: "Rich Text Editor" },
+          { value: "markdown", label: "Markdown Editor" },
+          { value: "plain-text", label: "Plain Text" },
         ],
-        defaultValue: 'rich-text'
+        defaultValue: "rich-text",
       },
       {
-        name: 'allowMedia',
-        label: 'Allow Media Uploads',
-        type: 'checkbox',
-        defaultValue: true
+        name: "allowMedia",
+        label: "Allow Media Uploads",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'allowTables',
-        label: 'Allow Tables',
-        type: 'checkbox',
-        defaultValue: true
-      }
-    ]
+        name: "allowTables",
+        label: "Allow Tables",
+        type: "checkbox",
+        defaultValue: true,
+      },
+    ],
   },
   {
-    id: 'assignment',
-    type: 'assignment',
-    label: 'Assignment',
-    icon: 'assignment',
+    id: "assignment",
+    type: "assignment",
+    label: "Assignment",
+    icon: "assignment",
     defaultConfig: {
       allowSubmissions: true,
       requireDueDate: true,
       enableGrading: true,
-      maxSubmissions: 1
+      maxSubmissions: 1,
     },
     configFields: [
       {
-        name: 'allowSubmissions',
-        label: 'Allow Student Submissions',
-        type: 'checkbox',
-        defaultValue: true
+        name: "allowSubmissions",
+        label: "Allow Student Submissions",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'requireDueDate',
-        label: 'Require Due Date',
-        type: 'checkbox',
-        defaultValue: true
+        name: "requireDueDate",
+        label: "Require Due Date",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'enableGrading',
-        label: 'Enable Grading',
-        type: 'checkbox',
-        defaultValue: true
+        name: "enableGrading",
+        label: "Enable Grading",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'maxSubmissions',
-        label: 'Maximum Submissions',
-        type: 'number',
-        defaultValue: 1
-      }
-    ]
+        name: "maxSubmissions",
+        label: "Maximum Submissions",
+        type: "number",
+        defaultValue: 1,
+      },
+    ],
   },
   {
-    id: 'footer',
-    type: 'footer',
-    label: 'Footer',
-    icon: 'footer',
+    id: "footer",
+    type: "footer",
+    label: "Footer",
+    icon: "footer",
     defaultConfig: {
       showCredits: true,
       showDate: true,
-      showContact: false
+      showContact: false,
     },
     configFields: [
       {
-        name: 'showCredits',
-        label: 'Show Credits',
-        type: 'checkbox',
-        defaultValue: true
+        name: "showCredits",
+        label: "Show Credits",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'showDate',
-        label: 'Show Creation Date',
-        type: 'checkbox',
-        defaultValue: true
+        name: "showDate",
+        label: "Show Creation Date",
+        type: "checkbox",
+        defaultValue: true,
       },
       {
-        name: 'showContact',
-        label: 'Show Contact Information',
-        type: 'checkbox',
-        defaultValue: false
-      }
-    ]
-  }
+        name: "showContact",
+        label: "Show Contact Information",
+        type: "checkbox",
+        defaultValue: false,
+      },
+    ],
+  },
 ];

--- a/src/scripts/backend/courses/templates/templateConfigHandler.ts
+++ b/src/scripts/backend/courses/templates/templateConfigHandler.ts
@@ -1,4 +1,4 @@
-import { TEMPLATE_BLOCKS } from './templateBlocks.js';
+import { TEMPLATE_BLOCKS } from "./templateBlocks.js";
 
 export class TemplateConfigHandler {
   private currentTemplate: any = null;
@@ -16,14 +16,15 @@ export class TemplateConfigHandler {
    * Renders the block selector interface
    */
   private renderBlockSelector(): void {
-    const configContainer = document.querySelector('.template-config');
+    const configContainer = document.querySelector(".template-config");
     if (!configContainer) return;
 
     const blockSelectorHtml = `
       <div class="template-blocks-selector">
         <h3 class="heading heading--tertiary">Template Blocks</h3>
         <div class="blocks-grid">
-          ${TEMPLATE_BLOCKS.map(block => `
+          ${TEMPLATE_BLOCKS.map(
+            (block) => `
             <div class="block-option" data-block-type="${block.type}">
               <div class="block-option__icon">${block.icon}</div>
               <div class="block-option__label">${block.label}</div>
@@ -32,7 +33,8 @@ export class TemplateConfigHandler {
                 <label for="toggle-${block.type}"></label>
               </div>
             </div>
-          `).join('')}
+          `,
+          ).join("")}
         </div>
       </div>
       <div class="template-block-config">
@@ -51,20 +53,22 @@ export class TemplateConfigHandler {
    */
   private setupEventListeners(): void {
     // Block toggle listeners
-    document.querySelectorAll('.block-option input[type="checkbox"]').forEach(checkbox => {
-      checkbox.addEventListener('change', (e) => {
-        const target = e.target as HTMLInputElement;
-        const blockType = target.id.replace('toggle-', '');
-        this.toggleBlock(blockType, target.checked);
+    document
+      .querySelectorAll('.block-option input[type="checkbox"]')
+      .forEach((checkbox) => {
+        checkbox.addEventListener("change", (e) => {
+          const target = e.target as HTMLInputElement;
+          const blockType = target.id.replace("toggle-", "");
+          this.toggleBlock(blockType, target.checked);
+        });
       });
-    });
 
     // Block selection listeners
-    document.querySelectorAll('.block-option').forEach(option => {
-      option.addEventListener('click', (e) => {
+    document.querySelectorAll(".block-option").forEach((option) => {
+      option.addEventListener("click", (e) => {
         // Avoid triggering when clicking the checkbox
-        if ((e.target as HTMLElement).tagName !== 'INPUT') {
-          const blockType = option.getAttribute('data-block-type');
+        if ((e.target as HTMLElement).tagName !== "INPUT") {
+          const blockType = option.getAttribute("data-block-type");
           if (blockType) {
             this.selectBlock(blockType);
           }
@@ -82,7 +86,9 @@ export class TemplateConfigHandler {
         this.activeBlocks.push(blockType);
       }
     } else {
-      this.activeBlocks = this.activeBlocks.filter(type => type !== blockType);
+      this.activeBlocks = this.activeBlocks.filter(
+        (type) => type !== blockType,
+      );
     }
 
     this.updatePreview();
@@ -93,14 +99,16 @@ export class TemplateConfigHandler {
    */
   private selectBlock(blockType: string): void {
     // Remove previous selection
-    document.querySelectorAll('.block-option').forEach(option => {
-      option.classList.remove('block-option--selected');
+    document.querySelectorAll(".block-option").forEach((option) => {
+      option.classList.remove("block-option--selected");
     });
 
     // Add selection to current block
-    const selectedOption = document.querySelector(`[data-block-type="${blockType}"]`);
+    const selectedOption = document.querySelector(
+      `[data-block-type="${blockType}"]`,
+    );
     if (selectedOption) {
-      selectedOption.classList.add('block-option--selected');
+      selectedOption.classList.add("block-option--selected");
     }
 
     // Load block configuration
@@ -111,16 +119,18 @@ export class TemplateConfigHandler {
    * Loads configuration form for a specific block
    */
   private loadBlockConfig(blockType: string): void {
-    const blockConfig = TEMPLATE_BLOCKS.find(block => block.type === blockType);
+    const blockConfig = TEMPLATE_BLOCKS.find(
+      (block) => block.type === blockType,
+    );
     if (!blockConfig) return;
 
-    const configContent = document.querySelector('.block-config-content');
+    const configContent = document.querySelector(".block-config-content");
     if (!configContent) return;
 
     const configFormHtml = `
       <form class="form" data-block-type="${blockType}">
         <h4 class="heading heading--quaternary">${blockConfig.label} Settings</h4>
-        ${blockConfig.configFields.map(field => this.renderConfigField(field)).join('')}
+        ${blockConfig.configFields.map((field) => this.renderConfigField(field)).join("")}
         <div class="form__group">
           <button type="button" class="btn btn--secondary btn--small" onclick="templateConfigHandler.resetBlockConfig('${blockType}')">
             Reset to Default
@@ -132,11 +142,13 @@ export class TemplateConfigHandler {
     configContent.innerHTML = configFormHtml;
 
     // Setup field change listeners
-    configContent.querySelectorAll('input, select, textarea').forEach(input => {
-      input.addEventListener('change', () => {
-        this.updateBlockConfig(blockType);
+    configContent
+      .querySelectorAll("input, select, textarea")
+      .forEach((input) => {
+        input.addEventListener("change", () => {
+          this.updateBlockConfig(blockType);
+        });
       });
-    });
   }
 
   /**
@@ -144,52 +156,57 @@ export class TemplateConfigHandler {
    */
   private renderConfigField(field: any): string {
     switch (field.type) {
-      case 'checkbox':
+      case "checkbox":
         return `
           <div class="form__group">
             <label class="form__label form__label--checkbox">
-              <input type="checkbox" name="${field.name}" ${field.defaultValue ? 'checked' : ''}>
+              <input type="checkbox" name="${field.name}" ${field.defaultValue ? "checked" : ""}>
               ${field.label}
             </label>
           </div>
         `;
-      case 'select':
+      case "select":
         return `
           <div class="form__group">
             <label class="form__label" for="${field.name}">${field.label}</label>
             <select class="form__input" name="${field.name}">
-              ${field.options?.map((option: any) => 
-                `<option value="${option.value}" ${option.value === field.defaultValue ? 'selected' : ''}>${option.label}</option>`
-              ).join('') || ''}
+              ${
+                field.options
+                  ?.map(
+                    (option: any) =>
+                      `<option value="${option.value}" ${option.value === field.defaultValue ? "selected" : ""}>${option.label}</option>`,
+                  )
+                  .join("") || ""
+              }
             </select>
           </div>
         `;
-      case 'color':
+      case "color":
         return `
           <div class="form__group">
             <label class="form__label" for="${field.name}">${field.label}</label>
-            <input type="color" class="form__input form__input--color" name="${field.name}" value="${field.defaultValue || '#000000'}">
+            <input type="color" class="form__input form__input--color" name="${field.name}" value="${field.defaultValue || "#000000"}">
           </div>
         `;
-      case 'number':
+      case "number":
         return `
           <div class="form__group">
             <label class="form__label" for="${field.name}">${field.label}</label>
             <input type="number" class="form__input" name="${field.name}" value="${field.defaultValue || 0}">
           </div>
         `;
-      case 'textarea':
+      case "textarea":
         return `
           <div class="form__group">
             <label class="form__label" for="${field.name}">${field.label}</label>
-            <textarea class="form__input" name="${field.name}" rows="3">${field.defaultValue || ''}</textarea>
+            <textarea class="form__input" name="${field.name}" rows="3">${field.defaultValue || ""}</textarea>
           </div>
         `;
       default:
         return `
           <div class="form__group">
             <label class="form__label" for="${field.name}">${field.label}</label>
-            <input type="text" class="form__input" name="${field.name}" value="${field.defaultValue || ''}">
+            <input type="text" class="form__input" name="${field.name}" value="${field.defaultValue || ""}">
           </div>
         `;
     }
@@ -199,7 +216,9 @@ export class TemplateConfigHandler {
    * Updates block configuration based on form values
    */
   private updateBlockConfig(blockType: string): void {
-    const form = document.querySelector(`form[data-block-type="${blockType}"]`) as HTMLFormElement;
+    const form = document.querySelector(
+      `form[data-block-type="${blockType}"]`,
+    ) as HTMLFormElement;
     if (!form) return;
 
     const formData = new FormData(form);
@@ -211,7 +230,7 @@ export class TemplateConfigHandler {
     }
 
     // Handle checkboxes (they don't appear in FormData when unchecked)
-    form.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+    form.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
       const input = checkbox as HTMLInputElement;
       config[input.name] = input.checked;
     });
@@ -221,14 +240,16 @@ export class TemplateConfigHandler {
       this.currentTemplate = { blocks: [] };
     }
 
-    const blockIndex = this.currentTemplate.blocks.findIndex((block: any) => block.type === blockType);
+    const blockIndex = this.currentTemplate.blocks.findIndex(
+      (block: any) => block.type === blockType,
+    );
     if (blockIndex >= 0) {
       this.currentTemplate.blocks[blockIndex].config = config;
     } else {
       this.currentTemplate.blocks.push({
         type: blockType,
         config: config,
-        order: this.activeBlocks.indexOf(blockType) + 1
+        order: this.activeBlocks.indexOf(blockType) + 1,
       });
     }
 
@@ -239,19 +260,25 @@ export class TemplateConfigHandler {
    * Resets a block to its default configuration
    */
   resetBlockConfig(blockType: string): void {
-    const blockConfig = TEMPLATE_BLOCKS.find(block => block.type === blockType);
+    const blockConfig = TEMPLATE_BLOCKS.find(
+      (block) => block.type === blockType,
+    );
     if (!blockConfig) return;
 
     // Update form with default values
-    const form = document.querySelector(`form[data-block-type="${blockType}"]`) as HTMLFormElement;
+    const form = document.querySelector(
+      `form[data-block-type="${blockType}"]`,
+    ) as HTMLFormElement;
     if (form) {
-      blockConfig.configFields.forEach(field => {
-        const input = form.querySelector(`[name="${field.name}"]`) as HTMLInputElement;
+      blockConfig.configFields.forEach((field) => {
+        const input = form.querySelector(
+          `[name="${field.name}"]`,
+        ) as HTMLInputElement;
         if (input) {
-          if (input.type === 'checkbox') {
+          if (input.type === "checkbox") {
             input.checked = field.defaultValue || false;
           } else {
-            input.value = field.defaultValue || '';
+            input.value = field.defaultValue || "";
           }
         }
       });
@@ -266,11 +293,11 @@ export class TemplateConfigHandler {
    */
   private updatePreview(): void {
     // This will trigger the preview update in the main template manager
-    const event = new CustomEvent('templateConfigChanged', {
+    const event = new CustomEvent("templateConfigChanged", {
       detail: {
         template: this.currentTemplate,
-        activeBlocks: this.activeBlocks
-      }
+        activeBlocks: this.activeBlocks,
+      },
     });
     document.dispatchEvent(event);
   }

--- a/src/scripts/backend/courses/templates/templatePreviewHandler.ts
+++ b/src/scripts/backend/courses/templates/templatePreviewHandler.ts
@@ -2,7 +2,7 @@ export class TemplatePreviewHandler {
   private previewContainer: HTMLElement | null = null;
 
   constructor() {
-    this.previewContainer = document.querySelector('.preview-container');
+    this.previewContainer = document.querySelector(".preview-container");
     this.setupEventListeners();
   }
 
@@ -10,7 +10,7 @@ export class TemplatePreviewHandler {
    * Sets up event listeners for template preview updates
    */
   private setupEventListeners(): void {
-    document.addEventListener('templateConfigChanged', (e: any) => {
+    document.addEventListener("templateConfigChanged", (e: any) => {
       this.updatePreview(e.detail.template, e.detail.activeBlocks);
     });
   }
@@ -58,7 +58,9 @@ export class TemplatePreviewHandler {
         return aIndex - bIndex;
       });
 
-    const blocksHtml = sortedBlocks.map((block: any) => this.renderBlock(block)).join('');
+    const blocksHtml = sortedBlocks
+      .map((block: any) => this.renderBlock(block))
+      .join("");
 
     return `
       <div class="template-preview-content">
@@ -82,19 +84,19 @@ export class TemplatePreviewHandler {
    */
   private renderBlock(block: any): string {
     const config = block.config || {};
-    
+
     switch (block.type) {
-      case 'header':
+      case "header":
         return this.renderHeaderBlock(config);
-      case 'program':
+      case "program":
         return this.renderProgramBlock(config);
-      case 'resources':
+      case "resources":
         return this.renderResourcesBlock(config);
-      case 'content':
+      case "content":
         return this.renderContentBlock(config);
-      case 'assignment':
+      case "assignment":
         return this.renderAssignmentBlock(config);
-      case 'footer':
+      case "footer":
         return this.renderFooterBlock(config);
       default:
         return `<div class="preview-block preview-block--unknown">Unknown block type: ${block.type}</div>`;
@@ -105,8 +107,8 @@ export class TemplatePreviewHandler {
    * Renders header block preview
    */
   private renderHeaderBlock(config: any): string {
-    const backgroundColor = config.backgroundColor || '#ffffff';
-    const textColor = config.textColor || '#333333';
+    const backgroundColor = config.backgroundColor || "#ffffff";
+    const textColor = config.textColor || "#333333";
     const showTitle = config.showTitle !== false;
     const showSubtitle = config.showSubtitle !== false;
 
@@ -114,8 +116,8 @@ export class TemplatePreviewHandler {
       <div class="preview-block preview-block--header" style="background-color: ${backgroundColor}; color: ${textColor};">
         <div class="preview-block__label">📋 Header</div>
         <div class="preview-block__content">
-          ${showTitle ? '<h1 class="preview-title">Course Title</h1>' : ''}
-          ${showSubtitle ? '<h2 class="preview-subtitle">Course Subtitle</h2>' : ''}
+          ${showTitle ? '<h1 class="preview-title">Course Title</h1>' : ""}
+          ${showSubtitle ? '<h2 class="preview-subtitle">Course Subtitle</h2>' : ""}
         </div>
       </div>
     `;
@@ -133,9 +135,9 @@ export class TemplatePreviewHandler {
       <div class="preview-block preview-block--program">
         <div class="preview-block__label">🎯 Program</div>
         <div class="preview-block__content">
-          ${showObjectives ? '<div class="preview-section"><strong>Learning Objectives:</strong> <span class="preview-placeholder">Objectives will be displayed here</span></div>' : ''}
-          ${showOutcomes ? '<div class="preview-section"><strong>Learning Outcomes:</strong> <span class="preview-placeholder">Outcomes will be displayed here</span></div>' : ''}
-          ${showPrerequisites ? '<div class="preview-section"><strong>Prerequisites:</strong> <span class="preview-placeholder">Prerequisites will be displayed here</span></div>' : ''}
+          ${showObjectives ? '<div class="preview-section"><strong>Learning Objectives:</strong> <span class="preview-placeholder">Objectives will be displayed here</span></div>' : ""}
+          ${showOutcomes ? '<div class="preview-section"><strong>Learning Outcomes:</strong> <span class="preview-placeholder">Outcomes will be displayed here</span></div>' : ""}
+          ${showPrerequisites ? '<div class="preview-section"><strong>Prerequisites:</strong> <span class="preview-placeholder">Prerequisites will be displayed here</span></div>' : ""}
         </div>
       </div>
     `;
@@ -155,9 +157,9 @@ export class TemplatePreviewHandler {
         <div class="preview-block__label">📚 Resources</div>
         <div class="preview-block__content">
           <div class="preview-section">
-            ${allowFiles ? `<div class="preview-resource">📎 File uploads (max: ${maxFiles})</div>` : ''}
-            ${allowLinks ? '<div class="preview-resource">🔗 External links</div>' : ''}
-            ${allowVideos ? '<div class="preview-resource">🎥 Video embeds</div>' : ''}
+            ${allowFiles ? `<div class="preview-resource">📎 File uploads (max: ${maxFiles})</div>` : ""}
+            ${allowLinks ? '<div class="preview-resource">🔗 External links</div>' : ""}
+            ${allowVideos ? '<div class="preview-resource">🎥 Video embeds</div>' : ""}
           </div>
         </div>
       </div>
@@ -168,7 +170,7 @@ export class TemplatePreviewHandler {
    * Renders content block preview
    */
   private renderContentBlock(config: any): string {
-    const editor = config.editor || 'rich-text';
+    const editor = config.editor || "rich-text";
     const allowMedia = config.allowMedia !== false;
     const allowTables = config.allowTables !== false;
 
@@ -178,8 +180,8 @@ export class TemplatePreviewHandler {
         <div class="preview-block__content">
           <div class="preview-section">
             <div class="preview-editor">Editor: ${editor}</div>
-            ${allowMedia ? '<div class="preview-feature">✓ Media uploads enabled</div>' : ''}
-            ${allowTables ? '<div class="preview-feature">✓ Tables enabled</div>' : ''}
+            ${allowMedia ? '<div class="preview-feature">✓ Media uploads enabled</div>' : ""}
+            ${allowTables ? '<div class="preview-feature">✓ Tables enabled</div>' : ""}
             <div class="preview-placeholder">Course content will be displayed here...</div>
           </div>
         </div>
@@ -201,9 +203,9 @@ export class TemplatePreviewHandler {
         <div class="preview-block__label">✅ Assignment</div>
         <div class="preview-block__content">
           <div class="preview-section">
-            ${allowSubmissions ? `<div class="preview-feature">✓ Student submissions (max: ${maxSubmissions})</div>` : ''}
-            ${requireDueDate ? '<div class="preview-feature">✓ Due date required</div>' : ''}
-            ${enableGrading ? '<div class="preview-feature">✓ Grading enabled</div>' : ''}
+            ${allowSubmissions ? `<div class="preview-feature">✓ Student submissions (max: ${maxSubmissions})</div>` : ""}
+            ${requireDueDate ? '<div class="preview-feature">✓ Due date required</div>' : ""}
+            ${enableGrading ? '<div class="preview-feature">✓ Grading enabled</div>' : ""}
             <div class="preview-placeholder">Assignment details will be displayed here...</div>
           </div>
         </div>
@@ -224,9 +226,9 @@ export class TemplatePreviewHandler {
         <div class="preview-block__label">🔖 Footer</div>
         <div class="preview-block__content">
           <div class="preview-section">
-            ${showCredits ? '<div class="preview-feature">✓ Credits displayed</div>' : ''}
-            ${showDate ? '<div class="preview-feature">✓ Creation date displayed</div>' : ''}
-            ${showContact ? '<div class="preview-feature">✓ Contact information displayed</div>' : ''}
+            ${showCredits ? '<div class="preview-feature">✓ Credits displayed</div>' : ""}
+            ${showDate ? '<div class="preview-feature">✓ Creation date displayed</div>' : ""}
+            ${showContact ? '<div class="preview-feature">✓ Contact information displayed</div>' : ""}
           </div>
         </div>
       </div>
@@ -238,7 +240,7 @@ export class TemplatePreviewHandler {
    */
   exportTemplate(): void {
     // This would open an export modal or trigger a download
-    console.log('Exporting template...');
+    console.log("Exporting template...");
     // Implementation for template export functionality
   }
 }

--- a/src/scripts/backend/supabase.ts
+++ b/src/scripts/backend/supabase.ts
@@ -3,13 +3,15 @@
  * Backend configuration for database and authentication services
  */
 
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Missing Supabase environment variables. Please check your .env file.')
+  throw new Error(
+    "Missing Supabase environment variables. Please check your .env file.",
+  );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey)
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/src/scripts/coursebuilder/canvas/CanvasEventHandler.ts
+++ b/src/scripts/coursebuilder/canvas/CanvasEventHandler.ts
@@ -4,8 +4,8 @@
  * Single Responsibility: Event handling only
  */
 
-import { Application, Container, FederatedPointerEvent } from 'pixi.js';
-import { ToolManager } from '../tools/ToolManager';
+import { Application, Container, FederatedPointerEvent } from "pixi.js";
+import { ToolManager } from "../tools/ToolManager";
 
 export class CanvasEventHandler {
   private app: Application;
@@ -29,13 +29,13 @@ export class CanvasEventHandler {
    */
   public setupEvents(): void {
     // Make the stage interactive
-    this.app.stage.eventMode = 'static';
+    this.app.stage.eventMode = "static";
     this.app.stage.hitArea = this.app.screen;
 
     // Add pointer events
     this.setupPointerEvents();
 
-    console.log('🎯 Canvas events setup complete');
+    console.log("🎯 Canvas events setup complete");
   }
 
   /**
@@ -43,21 +43,21 @@ export class CanvasEventHandler {
    */
   private setupPointerEvents(): void {
     // Pointer down event
-    this.app.stage.on('pointerdown', (event: FederatedPointerEvent) => {
+    this.app.stage.on("pointerdown", (event: FederatedPointerEvent) => {
       this.handlePointerDown(event);
     });
 
     // Pointer move event
-    this.app.stage.on('pointermove', (event: FederatedPointerEvent) => {
+    this.app.stage.on("pointermove", (event: FederatedPointerEvent) => {
       this.handlePointerMove(event);
     });
 
     // Pointer up event
-    this.app.stage.on('pointerup', (event: FederatedPointerEvent) => {
+    this.app.stage.on("pointerup", (event: FederatedPointerEvent) => {
       this.handlePointerUp(event);
     });
 
-    console.log('🖱️ Pointer events attached');
+    console.log("🖱️ Pointer events attached");
   }
 
   /**
@@ -69,7 +69,7 @@ export class CanvasEventHandler {
       try {
         activeTool.onPointerDown(event, this.drawingContainer);
       } catch (error) {
-        console.error('❌ Error in tool pointer down:', error);
+        console.error("❌ Error in tool pointer down:", error);
       }
     }
   }
@@ -83,7 +83,7 @@ export class CanvasEventHandler {
       try {
         activeTool.onPointerMove(event, this.drawingContainer);
       } catch (error) {
-        console.error('❌ Error in tool pointer move:', error);
+        console.error("❌ Error in tool pointer move:", error);
       }
     }
   }
@@ -97,7 +97,7 @@ export class CanvasEventHandler {
       try {
         activeTool.onPointerUp(event, this.drawingContainer);
       } catch (error) {
-        console.error('❌ Error in tool pointer up:', error);
+        console.error("❌ Error in tool pointer up:", error);
       }
     }
   }
@@ -110,24 +110,30 @@ export class CanvasEventHandler {
     if (!canvas) return;
 
     // Remove all cursor classes
-    canvas.classList.remove('cursor-pen', 'cursor-eraser', 'cursor-text', 'cursor-highlighter', 'cursor-selection');
+    canvas.classList.remove(
+      "cursor-pen",
+      "cursor-eraser",
+      "cursor-text",
+      "cursor-highlighter",
+      "cursor-selection",
+    );
 
     // Add cursor class for current tool
     switch (toolName) {
-      case 'pen':
-        canvas.classList.add('cursor-pen');
+      case "pen":
+        canvas.classList.add("cursor-pen");
         break;
-      case 'eraser':
-        canvas.classList.add('cursor-eraser');
+      case "eraser":
+        canvas.classList.add("cursor-eraser");
         break;
-      case 'text':
-        canvas.classList.add('cursor-text');
+      case "text":
+        canvas.classList.add("cursor-text");
         break;
-      case 'highlighter':
-        canvas.classList.add('cursor-highlighter');
+      case "highlighter":
+        canvas.classList.add("cursor-highlighter");
         break;
       default:
-        canvas.classList.add('cursor-selection');
+        canvas.classList.add("cursor-selection");
     }
 
     console.log(`🖱️ Canvas cursor updated for tool: ${toolName}`);
@@ -137,8 +143,8 @@ export class CanvasEventHandler {
    * Enable/disable events
    */
   public setEventsEnabled(enabled: boolean): void {
-    this.app.stage.eventMode = enabled ? 'static' : 'none';
-    console.log(`🎯 Canvas events ${enabled ? 'enabled' : 'disabled'}`);
+    this.app.stage.eventMode = enabled ? "static" : "none";
+    console.log(`🎯 Canvas events ${enabled ? "enabled" : "disabled"}`);
   }
 
   /**
@@ -146,9 +152,9 @@ export class CanvasEventHandler {
    */
   public getEventInfo(): any {
     return {
-      stageInteractive: this.app.stage.eventMode === 'static',
+      stageInteractive: this.app.stage.eventMode === "static",
       hasHitArea: !!this.app.stage.hitArea,
-      eventMode: this.app.stage.eventMode
+      eventMode: this.app.stage.eventMode,
     };
   }
 
@@ -157,13 +163,13 @@ export class CanvasEventHandler {
    */
   public destroy(): void {
     // Remove all event listeners
-    this.app.stage.off('pointerdown');
-    this.app.stage.off('pointermove');
-    this.app.stage.off('pointerup');
-    
+    this.app.stage.off("pointerdown");
+    this.app.stage.off("pointermove");
+    this.app.stage.off("pointerup");
+
     // Disable events
-    this.app.stage.eventMode = 'none';
-    
-    console.log('🗑️ Canvas event handler destroyed');
+    this.app.stage.eventMode = "none";
+
+    console.log("🗑️ Canvas event handler destroyed");
   }
 }

--- a/src/scripts/coursebuilder/canvas/CanvasLayerManager.ts
+++ b/src/scripts/coursebuilder/canvas/CanvasLayerManager.ts
@@ -4,7 +4,7 @@
  * Single Responsibility: Layer creation and management only
  */
 
-import { Application, Container, Graphics } from 'pixi.js';
+import { Application, Container, Graphics } from "pixi.js";
 
 export class CanvasLayerManager {
   private app: Application;
@@ -23,22 +23,22 @@ export class CanvasLayerManager {
   public initializeLayers(): void {
     // Create layout container (bottom layer - protected)
     this.layoutContainer = new Container();
-    this.layoutContainer.label = 'layout-layer';
+    this.layoutContainer.label = "layout-layer";
     this.layoutContainer.zIndex = 0;
     this.app.stage.addChild(this.layoutContainer);
 
     // Create drawing container (top layer - user editable)
     this.drawingContainer = new Container();
-    this.drawingContainer.label = 'drawing-layer';
+    this.drawingContainer.label = "drawing-layer";
     this.drawingContainer.zIndex = 1;
     this.app.stage.addChild(this.drawingContainer);
 
     // Enable sorting by zIndex
     this.app.stage.sortableChildren = true;
 
-    console.log('🏗️ Canvas layers initialized');
-    console.log('📐 Layout container (protected) created');
-    console.log('✏️ Drawing container (editable) created');
+    console.log("🏗️ Canvas layers initialized");
+    console.log("📐 Layout container (protected) created");
+    console.log("✏️ Drawing container (editable) created");
   }
 
   /**
@@ -46,7 +46,7 @@ export class CanvasLayerManager {
    */
   public addBackgroundGrid(): void {
     if (!this.layoutContainer) {
-      console.warn('⚠️ Layout container not initialized');
+      console.warn("⚠️ Layout container not initialized");
       return;
     }
 
@@ -61,7 +61,7 @@ export class CanvasLayerManager {
 
     // Draw grid lines
     graphics.moveTo(0, 0);
-    
+
     // Draw vertical lines
     for (let x = 0; x <= canvasWidth; x += gridSize) {
       graphics.moveTo(x, 0);
@@ -76,19 +76,24 @@ export class CanvasLayerManager {
 
     graphics.stroke({ width: 1, color: 0xe0e0e0, alpha: 0.8 });
 
-    graphics.label = 'background-grid';
-    
+    graphics.label = "background-grid";
+
     this.layoutContainer.addChild(graphics);
 
-    console.log('🔲 Enhanced background grid added to layout layer');
+    console.log("🔲 Enhanced background grid added to layout layer");
   }
 
   /**
    * Add or update margin boundaries (blue borders)
    */
-  public updateMarginBoundaries(margins: { top: number; right: number; bottom: number; left: number }): void {
+  public updateMarginBoundaries(margins: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  }): void {
     if (!this.layoutContainer) {
-      console.warn('⚠️ Layout container not initialized');
+      console.warn("⚠️ Layout container not initialized");
       return;
     }
 
@@ -100,7 +105,7 @@ export class CanvasLayerManager {
 
     // Create new margin graphics
     this.marginGraphics = new Graphics();
-    this.marginGraphics.label = 'margin-boundaries';
+    this.marginGraphics.label = "margin-boundaries";
 
     const canvasWidth = this.app.screen.width;
     const canvasHeight = this.app.screen.height;
@@ -135,10 +140,10 @@ export class CanvasLayerManager {
     }
 
     // Style the margin lines
-    this.marginGraphics.stroke({ 
-      width: lineWidth, 
-      color: marginColor, 
-      alpha: marginAlpha 
+    this.marginGraphics.stroke({
+      width: lineWidth,
+      color: marginColor,
+      alpha: marginAlpha,
     });
 
     // Add margin area overlay (very subtle fill)
@@ -150,7 +155,12 @@ export class CanvasLayerManager {
 
     // Bottom margin area
     if (margins.bottom > 0) {
-      this.marginGraphics.rect(0, canvasHeight - margins.bottom, canvasWidth, margins.bottom);
+      this.marginGraphics.rect(
+        0,
+        canvasHeight - margins.bottom,
+        canvasWidth,
+        margins.bottom,
+      );
       this.marginGraphics.fill({ color: marginColor, alpha: 0.05 });
     }
 
@@ -162,13 +172,18 @@ export class CanvasLayerManager {
 
     // Right margin area
     if (margins.right > 0) {
-      this.marginGraphics.rect(canvasWidth - margins.right, 0, margins.right, canvasHeight);
+      this.marginGraphics.rect(
+        canvasWidth - margins.right,
+        0,
+        margins.right,
+        canvasHeight,
+      );
       this.marginGraphics.fill({ color: marginColor, alpha: 0.05 });
     }
 
     this.layoutContainer.addChild(this.marginGraphics);
 
-    console.log('📏 Margin boundaries updated:', margins);
+    console.log("📏 Margin boundaries updated:", margins);
   }
 
   /**
@@ -179,7 +194,7 @@ export class CanvasLayerManager {
       this.layoutContainer.removeChild(this.marginGraphics);
       this.marginGraphics.destroy();
       this.marginGraphics = null;
-      console.log('📏 Margin boundaries cleared');
+      console.log("📏 Margin boundaries cleared");
     }
   }
 
@@ -189,7 +204,7 @@ export class CanvasLayerManager {
   public clearDrawingLayer(): void {
     if (this.drawingContainer) {
       this.drawingContainer.removeChildren();
-      console.log('🗑️ Drawing layer cleared (layout protected)');
+      console.log("🗑️ Drawing layer cleared (layout protected)");
     }
   }
 
@@ -204,11 +219,11 @@ export class CanvasLayerManager {
       this.drawingContainer.removeChildren();
     }
     this.layoutBlocks = [];
-    
+
     // Restore background grid
     this.addBackgroundGrid();
-    
-    console.log('⚠️ All layers cleared and background grid restored');
+
+    console.log("⚠️ All layers cleared and background grid restored");
   }
 
   /**
@@ -230,15 +245,17 @@ export class CanvasLayerManager {
    */
   public addLayoutBlock(block: any): void {
     this.layoutBlocks.push(block);
-    console.log('📐 Layout block added:', block.name || 'unnamed');
+    console.log("📐 Layout block added:", block.name || "unnamed");
   }
 
   /**
    * Remove layout block
    */
   public removeLayoutBlock(blockId: string): void {
-    this.layoutBlocks = this.layoutBlocks.filter(block => block.id !== blockId);
-    console.log('📐 Layout block removed:', blockId);
+    this.layoutBlocks = this.layoutBlocks.filter(
+      (block) => block.id !== blockId,
+    );
+    console.log("📐 Layout block removed:", blockId);
   }
 
   /**
@@ -253,7 +270,7 @@ export class CanvasLayerManager {
    */
   public clearLayoutBlocks(): void {
     this.layoutBlocks = [];
-    console.log('📐 Layout blocks cleared');
+    console.log("📐 Layout blocks cleared");
   }
 
   /**
@@ -264,14 +281,14 @@ export class CanvasLayerManager {
       layoutContainer: {
         exists: !!this.layoutContainer,
         children: this.layoutContainer?.children.length || 0,
-        name: this.layoutContainer?.name || 'none'
+        name: this.layoutContainer?.name || "none",
       },
       drawingContainer: {
         exists: !!this.drawingContainer,
         children: this.drawingContainer?.children.length || 0,
-        name: this.drawingContainer?.name || 'none'
+        name: this.drawingContainer?.name || "none",
       },
-      layoutBlocks: this.layoutBlocks.length
+      layoutBlocks: this.layoutBlocks.length,
     };
   }
 
@@ -284,7 +301,7 @@ export class CanvasLayerManager {
       this.marginGraphics.destroy();
       this.marginGraphics = null;
     }
-    
+
     if (this.layoutContainer) {
       this.layoutContainer.destroy({ children: true });
       this.layoutContainer = null;
@@ -294,6 +311,6 @@ export class CanvasLayerManager {
       this.drawingContainer = null;
     }
     this.layoutBlocks = [];
-    console.log('🗑️ Canvas layers destroyed');
+    console.log("🗑️ Canvas layers destroyed");
   }
 }

--- a/src/scripts/coursebuilder/canvas/CanvasManager.ts
+++ b/src/scripts/coursebuilder/canvas/CanvasManager.ts
@@ -4,8 +4,8 @@
  * Single Responsibility: Canvas lifecycle and state management only
  */
 
-import * as PIXI from 'pixi.js';
-import { LayoutRenderer } from '../layout/LayoutRenderer';
+import * as PIXI from "pixi.js";
+import { LayoutRenderer } from "../layout/LayoutRenderer";
 
 export class CanvasManager {
   private canvas: HTMLCanvasElement;
@@ -15,13 +15,13 @@ export class CanvasManager {
   private currentTemplate: any = null;
   private isLayoutVisible: boolean = true;
 
-  constructor(canvasId: string = 'canvas') {
+  constructor(canvasId: string = "canvas") {
     this.canvas = document.getElementById(canvasId) as HTMLCanvasElement;
     if (!this.canvas) {
       throw new Error(`Canvas element with id '${canvasId}' not found`);
     }
 
-    this.ctx = this.canvas.getContext('2d')!;
+    this.ctx = this.canvas.getContext("2d")!;
     this.initializeCanvas();
   }
 
@@ -31,14 +31,14 @@ export class CanvasManager {
   private initializeCanvas(): void {
     // Set canvas size
     this.resizeCanvas();
-    
+
     // Initialize PIXI if available
-    if (typeof PIXI !== 'undefined') {
+    if (typeof PIXI !== "undefined") {
       this.initializePixi();
     }
 
     // Bind resize events
-    window.addEventListener('resize', this.resizeCanvas.bind(this));
+    window.addEventListener("resize", this.resizeCanvas.bind(this));
   }
 
   /**
@@ -49,11 +49,11 @@ export class CanvasManager {
       view: this.canvas,
       width: this.canvas.width,
       height: this.canvas.height,
-      backgroundColor: 0xFFFFFF,
-      antialias: true
+      backgroundColor: 0xffffff,
+      antialias: true,
     });
 
-    console.log('📱 PIXI application initialized');
+    console.log("📱 PIXI application initialized");
   }
 
   /**
@@ -89,11 +89,11 @@ export class CanvasManager {
    */
   async loadTemplate(template: any): Promise<void> {
     this.currentTemplate = template;
-    
+
     if (this.layoutRenderer) {
       // Note: LayoutRenderer doesn't have renderTemplate method
       // Template data should be processed before calling renderLayoutStructure
-      console.log('📋 Template loaded:', template.name);
+      console.log("📋 Template loaded:", template.name);
       this.renderLayout();
     }
   }
@@ -105,7 +105,7 @@ export class CanvasManager {
     if (!this.layoutRenderer || !this.currentTemplate) return;
 
     this.clearCanvas();
-    
+
     if (this.isLayoutVisible) {
       // Use renderLayoutStructure with blocks from template
       const blocks = this.currentTemplate.blocks || [];
@@ -119,8 +119,8 @@ export class CanvasManager {
   toggleLayoutVisibility(): void {
     this.isLayoutVisible = !this.isLayoutVisible;
     this.renderLayout();
-    
-    console.log(`👁️ Layout visibility: ${this.isLayoutVisible ? 'ON' : 'OFF'}`);
+
+    console.log(`👁️ Layout visibility: ${this.isLayoutVisible ? "ON" : "OFF"}`);
   }
 
   /**
@@ -128,7 +128,7 @@ export class CanvasManager {
    */
   clearCanvas(): void {
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    
+
     if (this.pixiApp) {
       this.pixiApp.stage.removeChildren();
     }
@@ -140,12 +140,12 @@ export class CanvasManager {
   clearAll(): void {
     this.clearCanvas();
     this.currentTemplate = null;
-    
+
     if (this.layoutRenderer) {
       this.layoutRenderer.clear();
     }
-    
-    console.log('🧹 Canvas and layout cleared');
+
+    console.log("🧹 Canvas and layout cleared");
   }
 
   /**
@@ -153,13 +153,13 @@ export class CanvasManager {
    */
   addPage(): void {
     if (!this.currentTemplate) {
-      console.warn('No template loaded - cannot add page');
+      console.warn("No template loaded - cannot add page");
       return;
     }
 
     // Logic for adding new page
-    console.log('📄 Adding new page');
-    
+    console.log("📄 Adding new page");
+
     // Trigger re-render with new page
     this.renderLayout();
   }
@@ -170,7 +170,7 @@ export class CanvasManager {
   getDimensions(): { width: number; height: number } {
     return {
       width: this.canvas.width,
-      height: this.canvas.height
+      height: this.canvas.height,
     };
   }
 
@@ -216,7 +216,7 @@ export class CanvasManager {
     const rect = this.canvas.getBoundingClientRect();
     return {
       x: screenX - rect.left,
-      y: screenY - rect.top
+      y: screenY - rect.top,
     };
   }
 
@@ -227,7 +227,7 @@ export class CanvasManager {
     const rect = this.canvas.getBoundingClientRect();
     return {
       x: canvasX + rect.left,
-      y: canvasY + rect.top
+      y: canvasY + rect.top,
     };
   }
 
@@ -235,12 +235,12 @@ export class CanvasManager {
    * Cleanup resources
    */
   destroy(): void {
-    window.removeEventListener('resize', this.resizeCanvas);
-    
+    window.removeEventListener("resize", this.resizeCanvas);
+
     if (this.pixiApp) {
       this.pixiApp.destroy();
     }
-    
+
     this.layoutRenderer = null;
     this.currentTemplate = null;
   }

--- a/src/scripts/coursebuilder/canvas/CanvasManagerSimplified.ts
+++ b/src/scripts/coursebuilder/canvas/CanvasManagerSimplified.ts
@@ -8,19 +8,19 @@ export class CanvasManager {
   private currentTemplate: any = null;
   private isLayoutVisible: boolean = true;
 
-  constructor(canvasId: string = 'canvas') {
+  constructor(canvasId: string = "canvas") {
     this.canvas = document.getElementById(canvasId) as HTMLCanvasElement;
     if (!this.canvas) {
       throw new Error(`Canvas element with id '${canvasId}' not found`);
     }
-    this.ctx = this.canvas.getContext('2d')!;
+    this.ctx = this.canvas.getContext("2d")!;
     this.initializeCanvas();
   }
 
   private initializeCanvas(): void {
     this.canvas.width = 800;
     this.canvas.height = 600;
-    window.addEventListener('resize', () => this.resizeCanvas());
+    window.addEventListener("resize", () => this.resizeCanvas());
   }
 
   public resizeCanvas(): void {
@@ -50,7 +50,7 @@ export class CanvasManager {
   public renderCurrentState(): void {
     if (!this.isLayoutVisible) return;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.ctx.fillStyle = '#f0f0f0';
+    this.ctx.fillStyle = "#f0f0f0";
     this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
   }
 
@@ -88,7 +88,7 @@ export class CanvasManager {
     return { width: this.canvas.width, height: this.canvas.height };
   }
 
-  public exportAsDataURL(type: string = 'image/png'): string {
+  public exportAsDataURL(type: string = "image/png"): string {
     return this.canvas.toDataURL(type);
   }
 
@@ -96,7 +96,7 @@ export class CanvasManager {
     return {
       dimensions: this.getDimensions(),
       isLayoutVisible: this.isLayoutVisible,
-      hasTemplate: !!this.currentTemplate
+      hasTemplate: !!this.currentTemplate,
     };
   }
 
@@ -114,15 +114,15 @@ export class CanvasManager {
     const rect = this.canvas.getBoundingClientRect();
     const x = event.clientX - rect.left;
     const y = event.clientY - rect.top;
-    
-    const canvasClickEvent = new CustomEvent('canvasClick', {
-      detail: { x, y }
+
+    const canvasClickEvent = new CustomEvent("canvasClick", {
+      detail: { x, y },
     });
     this.canvas.dispatchEvent(canvasClickEvent);
   }
 
   public destroy(): void {
-    window.removeEventListener('resize', this.resizeCanvas);
+    window.removeEventListener("resize", this.resizeCanvas);
     this.clearAll();
   }
 }

--- a/src/scripts/coursebuilder/canvas/PixiApplicationManager.ts
+++ b/src/scripts/coursebuilder/canvas/PixiApplicationManager.ts
@@ -4,18 +4,18 @@
  * Single Responsibility: PIXI App creation and configuration only
  */
 
-import { Application } from 'pixi.js';
-import { initDevtools } from '@pixi/devtools';
+import { Application } from "pixi.js";
+import { initDevtools } from "@pixi/devtools";
 
 // Expose PIXI globally for devtools (PIXI v8.2+ requirement)
-import * as PIXI from 'pixi.js';
+import * as PIXI from "pixi.js";
 
 // Safely expose PIXI globally
 try {
   (window as any).PIXI = PIXI;
   (globalThis as any).PIXI = PIXI;
 } catch (error) {
-  console.warn('Could not expose PIXI globally:', error);
+  console.warn("Could not expose PIXI globally:", error);
 }
 
 export class PixiApplicationManager {
@@ -24,15 +24,20 @@ export class PixiApplicationManager {
 
   constructor(containerSelector: string) {
     // Handle both ID (#id) and class (.class) selectors
-    if (containerSelector.startsWith('#') || containerSelector.startsWith('.')) {
+    if (
+      containerSelector.startsWith("#") ||
+      containerSelector.startsWith(".")
+    ) {
       this.canvasElement = document.querySelector(containerSelector);
     } else {
       // Fallback for plain ID strings (legacy compatibility)
       this.canvasElement = document.getElementById(containerSelector);
     }
-    
+
     if (!this.canvasElement) {
-      throw new Error(`Canvas container with selector "${containerSelector}" not found`);
+      throw new Error(
+        `Canvas container with selector "${containerSelector}" not found`,
+      );
     }
   }
 
@@ -43,13 +48,15 @@ export class PixiApplicationManager {
     try {
       // Create PixiJS application
       this.app = new Application();
-      
+
       // Use fixed A4 dimensions since container is now properly sized in CSS
       const canvasWidth = 794;
       const canvasHeight = 1123;
       const a4AspectRatio = canvasWidth / canvasHeight;
 
-      console.log(`🎨 Using fixed A4 dimensions: ${canvasWidth}x${canvasHeight}`);
+      console.log(
+        `🎨 Using fixed A4 dimensions: ${canvasWidth}x${canvasHeight}`,
+      );
       console.log(`🎨 A4 aspect ratio: ${a4AspectRatio}`);
 
       // Initialize the application with A4 dimensions
@@ -63,42 +70,50 @@ export class PixiApplicationManager {
       });
 
       // Clear the canvas container and add PixiJS canvas
-      this.canvasElement!.innerHTML = '';
+      this.canvasElement!.innerHTML = "";
       this.canvasElement!.appendChild(this.app.canvas);
 
       // Expose app globally for PIXI devtools with multiple approaches
       (window as any).__PIXI_APP__ = this.app;
       (globalThis as any).__PIXI_APP__ = this.app;
-      
+
       // Safely expose on PIXI object for devtools detection
       try {
-        if ((window as any).PIXI && typeof (window as any).PIXI === 'object') {
+        if ((window as any).PIXI && typeof (window as any).PIXI === "object") {
           // Use getOwnPropertyDescriptor to check if property exists and is configurable
-          const appDescriptor = Object.getOwnPropertyDescriptor((window as any).PIXI, 'app');
-          
+          const appDescriptor = Object.getOwnPropertyDescriptor(
+            (window as any).PIXI,
+            "app",
+          );
+
           if (!appDescriptor) {
             // Property doesn't exist, create it
-            Object.defineProperty((window as any).PIXI, 'app', {
+            Object.defineProperty((window as any).PIXI, "app", {
               value: this.app,
               writable: true,
-              configurable: true
+              configurable: true,
             });
           } else if (appDescriptor.configurable || appDescriptor.writable) {
             // Property exists and can be modified
             (window as any).PIXI.app = this.app;
           } else {
             // Property exists but is sealed/frozen, skip modification
-            console.warn('PIXI.app property exists but is not configurable/writable, skipping modification');
+            console.warn(
+              "PIXI.app property exists but is not configurable/writable, skipping modification",
+            );
           }
-          
+
           // Handle apps array similarly
-          const appsDescriptor = Object.getOwnPropertyDescriptor((window as any).PIXI, 'apps');
-          
+          const appsDescriptor = Object.getOwnPropertyDescriptor(
+            (window as any).PIXI,
+            "apps",
+          );
+
           if (!appsDescriptor) {
-            Object.defineProperty((window as any).PIXI, 'apps', {
+            Object.defineProperty((window as any).PIXI, "apps", {
               value: [this.app],
               writable: true,
-              configurable: true
+              configurable: true,
             });
           } else if (Array.isArray((window as any).PIXI.apps)) {
             // Check if this app is already in the array to avoid duplicates
@@ -106,55 +121,65 @@ export class PixiApplicationManager {
               try {
                 (window as any).PIXI.apps.push(this.app);
               } catch (pushError) {
-                console.warn('Could not add to PIXI.apps array:', pushError);
+                console.warn("Could not add to PIXI.apps array:", pushError);
               }
             }
           }
         }
       } catch (error) {
-        console.warn('Could not extend PIXI object (it may be sealed):', error);
+        console.warn("Could not extend PIXI object (it may be sealed):", error);
         // Create alternative global references
         (window as any).PIXI_APP_INSTANCE = this.app;
-        (window as any).PIXI_APPS = [(window as any).PIXI_APPS || [], this.app].flat();
+        (window as any).PIXI_APPS = [
+          (window as any).PIXI_APPS || [],
+          this.app,
+        ].flat();
       }
-      
+
       // Initialize PIXI devtools - for v8.2+ use no-parameter call
       try {
-        console.log('🔧 Initializing PIXI devtools...');
-        console.log('🔧 Renderer available:', !!this.app.renderer);
-        console.log('🔧 Stage available:', !!this.app.stage);
-        console.log('🔧 PIXI globally available:', !!(window as any).PIXI);
-        console.log('🔧 PIXI version:', PIXI.VERSION);
-        
+        console.log("🔧 Initializing PIXI devtools...");
+        console.log("🔧 Renderer available:", !!this.app.renderer);
+        console.log("🔧 Stage available:", !!this.app.stage);
+        console.log("🔧 PIXI globally available:", !!(window as any).PIXI);
+        console.log("🔧 PIXI version:", PIXI.VERSION);
+
         // For PIXI v8.2+, try with app parameter first
         initDevtools({ app: this.app });
-        console.log('✅ PIXI devtools initialized with app parameter');
-        
+        console.log("✅ PIXI devtools initialized with app parameter");
+
         // Dispatch custom event for additional devtools support
-        window.dispatchEvent(new CustomEvent('pixi-app-ready', { detail: this.app }));
-        
+        window.dispatchEvent(
+          new CustomEvent("pixi-app-ready", { detail: this.app }),
+        );
       } catch (error) {
-        console.error('❌ Failed to initialize PIXI devtools with global hooks:', error);
-        
+        console.error(
+          "❌ Failed to initialize PIXI devtools with global hooks:",
+          error,
+        );
+
         // Fallback to explicit configuration
         try {
-          initDevtools({ 
-            app: this.app 
+          initDevtools({
+            app: this.app,
           });
-          console.log('✅ PIXI devtools initialized with explicit app');
+          console.log("✅ PIXI devtools initialized with explicit app");
         } catch (fallbackError) {
           try {
             initDevtools({
               renderer: this.app.renderer,
               stage: this.app.stage,
             });
-            console.log('✅ PIXI devtools initialized with renderer/stage');
+            console.log("✅ PIXI devtools initialized with renderer/stage");
           } catch (finalError) {
-            console.error('❌ All devtools initialization methods failed:', finalError);
+            console.error(
+              "❌ All devtools initialization methods failed:",
+              finalError,
+            );
           }
         }
       }
-      
+
       // Style the canvas to be centered in container
       this.styleCanvas();
 
@@ -163,25 +188,30 @@ export class PixiApplicationManager {
         width: 794 / canvasWidth,
         height: 1123 / canvasHeight,
         canvasWidth,
-        canvasHeight
+        canvasHeight,
       };
 
-      console.log('🎨 PixiJS Application initialized successfully');
-      console.log(`🎨 Canvas dimensions: ${canvasWidth}x${canvasHeight} (A4 dimensions)`);
+      console.log("🎨 PixiJS Application initialized successfully");
+      console.log(
+        `🎨 Canvas dimensions: ${canvasWidth}x${canvasHeight} (A4 dimensions)`,
+      );
       console.log(`🎨 Canvas screen bounds:`, this.app.screen);
-      console.log('🎨 PIXI.js version:', PIXI.VERSION);
-      console.log('🎨 PIXI.js globally available:', !!(window as any).PIXI);
-      console.log('🎨 PIXI Application exposed as window.__PIXI_APP__:', !!(window as any).__PIXI_APP__);
-      console.log('🎨 Renderer type:', this.app.renderer.type);
-      console.log('🎨 Renderer resolution:', this.app.renderer.resolution);
-      console.log('🎨 Stage children count:', this.app.stage.children.length);
-      
+      console.log("🎨 PIXI.js version:", PIXI.VERSION);
+      console.log("🎨 PIXI.js globally available:", !!(window as any).PIXI);
+      console.log(
+        "🎨 PIXI Application exposed as window.__PIXI_APP__:",
+        !!(window as any).__PIXI_APP__,
+      );
+      console.log("🎨 Renderer type:", this.app.renderer.type);
+      console.log("🎨 Renderer resolution:", this.app.renderer.resolution);
+      console.log("🎨 Stage children count:", this.app.stage.children.length);
+
       // Enhanced devtools compatibility
       this.enhanceDevtoolsCompatibility();
 
       return this.app;
     } catch (error) {
-      console.error('❌ Failed to initialize PixiJS Application:', error);
+      console.error("❌ Failed to initialize PixiJS Application:", error);
       throw error;
     }
   }
@@ -191,27 +221,27 @@ export class PixiApplicationManager {
    */
   private enhanceDevtoolsCompatibility(): void {
     if (!this.app) return;
-    
+
     // Register with global hook if available
     if ((window as any).__PIXI_DEVTOOLS_GLOBAL_HOOK__) {
       (window as any).__PIXI_DEVTOOLS_GLOBAL_HOOK__.register(this.app);
     }
-    
+
     // Make app detectable by various methods
     const globalTargets = [window, globalThis];
-    globalTargets.forEach(target => {
+    globalTargets.forEach((target) => {
       if (!(target as any).pixiApps) (target as any).pixiApps = [];
       if (!(target as any).pixiApps.includes(this.app)) {
         (target as any).pixiApps.push(this.app);
       }
     });
-    
+
     // Add event listeners for devtools frame detection
-    this.app.renderer.on('resize', () => {
+    this.app.renderer.on("resize", () => {
       // Silent hook for devtools detection
     });
-    
-    console.log('🔧 Enhanced devtools compatibility measures applied');
+
+    console.log("🔧 Enhanced devtools compatibility measures applied");
   }
 
   /**
@@ -220,11 +250,11 @@ export class PixiApplicationManager {
   private styleCanvas(): void {
     if (!this.app) return;
 
-    this.app.canvas.style.display = 'block';
-    this.app.canvas.style.margin = 'auto';
-    this.app.canvas.style.border = '2px solid #6495ed';
-    this.app.canvas.style.borderRadius = '8px';
-    this.app.canvas.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.1)';
+    this.app.canvas.style.display = "block";
+    this.app.canvas.style.margin = "auto";
+    this.app.canvas.style.border = "2px solid #6495ed";
+    this.app.canvas.style.borderRadius = "8px";
+    this.app.canvas.style.boxShadow = "0 4px 12px rgba(0, 0, 0, 0.1)";
   }
 
   /**
@@ -251,10 +281,10 @@ export class PixiApplicationManager {
     if (!this.app) {
       return { width: 0, height: 0 };
     }
-    
+
     return {
       width: this.app.screen.width,
-      height: this.app.screen.height
+      height: this.app.screen.height,
     };
   }
 
@@ -268,13 +298,13 @@ export class PixiApplicationManager {
       dimensions: this.getDimensions(),
       renderer: {
         type: this.app.renderer.type,
-        resolution: this.app.renderer.resolution
+        resolution: this.app.renderer.resolution,
       },
       stage: {
         children: this.app.stage.children.length,
-        interactive: this.app.stage.eventMode === 'static'
+        interactive: this.app.stage.eventMode === "static",
       },
-      scaleToA4: (this.app as any).scaleToA4
+      scaleToA4: (this.app as any).scaleToA4,
     };
   }
 
@@ -283,16 +313,16 @@ export class PixiApplicationManager {
    */
   public async exportAsImage(): Promise<string> {
     if (!this.app) {
-      throw new Error('PixiJS application not initialized');
+      throw new Error("PixiJS application not initialized");
     }
 
     try {
       // Extract the canvas as base64
       const base64 = await this.app.renderer.extract.base64(this.app.stage);
-      console.log('📸 Canvas exported as image');
+      console.log("📸 Canvas exported as image");
       return base64;
     } catch (error) {
-      console.error('❌ Failed to export canvas as image:', error);
+      console.error("❌ Failed to export canvas as image:", error);
       throw error;
     }
   }
@@ -304,7 +334,7 @@ export class PixiApplicationManager {
     if (this.app) {
       this.app.destroy(true, { children: true, texture: true });
       this.app = null;
-      console.log('🗑️ PixiJS Application destroyed');
+      console.log("🗑️ PixiJS Application destroyed");
     }
   }
 }

--- a/src/scripts/coursebuilder/canvas/PixiCanvas.ts
+++ b/src/scripts/coursebuilder/canvas/PixiCanvas.ts
@@ -4,11 +4,11 @@
  * Single Responsibility: High-level canvas coordination only (under 250 lines)
  */
 
-import { Application, Container } from 'pixi.js';
-import { ToolManager } from '../tools/ToolManager';
-import { PixiApplicationManager } from './PixiApplicationManager';
-import { CanvasLayerManager } from './CanvasLayerManager';
-import { CanvasEventHandler } from './CanvasEventHandler';
+import { Application, Container } from "pixi.js";
+import { ToolManager } from "../tools/ToolManager";
+import { PixiApplicationManager } from "./PixiApplicationManager";
+import { CanvasLayerManager } from "./CanvasLayerManager";
+import { CanvasEventHandler } from "./CanvasEventHandler";
 
 export class PixiCanvas {
   private appManager: PixiApplicationManager;
@@ -29,20 +29,22 @@ export class PixiCanvas {
     try {
       // Initialize PIXI application
       this.app = await this.appManager.initializeApplication();
-      
+
       // Initialize layer management
       this.layerManager = new CanvasLayerManager(this.app);
       this.layerManager.initializeLayers();
       this.layerManager.addBackgroundGrid();
-      
+
       // Initialize event handling
       this.eventHandler = new CanvasEventHandler(this.app, this.toolManager);
-      this.eventHandler.setDrawingContainer(this.layerManager.getDrawingContainer()!);
+      this.eventHandler.setDrawingContainer(
+        this.layerManager.getDrawingContainer()!,
+      );
       this.eventHandler.setupEvents();
-      
-      console.log('🎨 PixiCanvas system fully initialized');
+
+      console.log("🎨 PixiCanvas system fully initialized");
     } catch (error) {
-      console.error('❌ Failed to initialize PixiCanvas system:', error);
+      console.error("❌ Failed to initialize PixiCanvas system:", error);
       throw error;
     }
   }
@@ -92,11 +94,16 @@ export class PixiCanvas {
   /**
    * Update canvas margins (visual boundaries)
    */
-  public updateMargins(margins: { top: number; right: number; bottom: number; left: number }): void {
+  public updateMargins(margins: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  }): void {
     if (this.layerManager) {
       this.layerManager.updateMarginBoundaries(margins);
     } else {
-      console.warn('⚠️ Layer manager not initialized');
+      console.warn("⚠️ Layer manager not initialized");
     }
   }
 
@@ -127,15 +134,15 @@ export class PixiCanvas {
     const appInfo = this.appManager.getCanvasInfo();
     const layerInfo = this.layerManager?.getLayerInfo();
     const eventInfo = this.eventHandler?.getEventInfo();
-    
+
     return {
       application: appInfo,
       layers: layerInfo,
       events: eventInfo,
       tools: {
         activeTool: this.toolManager.getActiveToolName(),
-        toolSettings: this.toolManager.getToolSettings()
-      }
+        toolSettings: this.toolManager.getToolSettings(),
+      },
     };
   }
 
@@ -183,16 +190,16 @@ export class PixiCanvas {
       this.eventHandler.destroy();
       this.eventHandler = null;
     }
-    
+
     if (this.layerManager) {
       this.layerManager.destroy();
       this.layerManager = null;
     }
-    
+
     this.toolManager.destroy();
     this.appManager.destroy();
     this.app = null;
-    
-    console.log('🗑️ PixiCanvas system destroyed');
+
+    console.log("🗑️ PixiCanvas system destroyed");
   }
 }

--- a/src/scripts/coursebuilder/canvas/PixiCanvasRefactored.ts
+++ b/src/scripts/coursebuilder/canvas/PixiCanvasRefactored.ts
@@ -4,11 +4,11 @@
  * Single Responsibility: High-level canvas coordination only (under 250 lines)
  */
 
-import { Application, Container } from 'pixi.js';
-import { ToolManager } from '../tools/ToolManager.js';
-import { PixiApplicationManager } from './PixiApplicationManager.js';
-import { CanvasLayerManager } from './CanvasLayerManager.js';
-import { CanvasEventHandler } from './CanvasEventHandler.js';
+import { Application, Container } from "pixi.js";
+import { ToolManager } from "../tools/ToolManager.js";
+import { PixiApplicationManager } from "./PixiApplicationManager.js";
+import { CanvasLayerManager } from "./CanvasLayerManager.js";
+import { CanvasEventHandler } from "./CanvasEventHandler.js";
 
 export class PixiCanvasRefactored {
   private appManager: PixiApplicationManager;
@@ -29,20 +29,22 @@ export class PixiCanvasRefactored {
     try {
       // Initialize PIXI application
       this.app = await this.appManager.initializeApplication();
-      
+
       // Initialize layer management
       this.layerManager = new CanvasLayerManager(this.app);
       this.layerManager.initializeLayers();
       this.layerManager.addBackgroundGrid();
-      
+
       // Initialize event handling
       this.eventHandler = new CanvasEventHandler(this.app, this.toolManager);
-      this.eventHandler.setDrawingContainer(this.layerManager.getDrawingContainer()!);
+      this.eventHandler.setDrawingContainer(
+        this.layerManager.getDrawingContainer()!,
+      );
       this.eventHandler.setupEvents();
-      
-      console.log('🎨 PixiCanvas system fully initialized');
+
+      console.log("🎨 PixiCanvas system fully initialized");
     } catch (error) {
-      console.error('❌ Failed to initialize PixiCanvas system:', error);
+      console.error("❌ Failed to initialize PixiCanvas system:", error);
       throw error;
     }
   }
@@ -116,15 +118,15 @@ export class PixiCanvasRefactored {
     const appInfo = this.appManager.getCanvasInfo();
     const layerInfo = this.layerManager?.getLayerInfo();
     const eventInfo = this.eventHandler?.getEventInfo();
-    
+
     return {
       application: appInfo,
       layers: layerInfo,
       events: eventInfo,
       tools: {
         activeTool: this.toolManager.getActiveToolName(),
-        toolSettings: this.toolManager.getToolSettings()
-      }
+        toolSettings: this.toolManager.getToolSettings(),
+      },
     };
   }
 
@@ -172,16 +174,16 @@ export class PixiCanvasRefactored {
       this.eventHandler.destroy();
       this.eventHandler = null;
     }
-    
+
     if (this.layerManager) {
       this.layerManager.destroy();
       this.layerManager = null;
     }
-    
+
     this.toolManager.destroy();
     this.appManager.destroy();
     this.app = null;
-    
-    console.log('🗑️ PixiCanvas system destroyed');
+
+    console.log("🗑️ PixiCanvas system destroyed");
   }
 }

--- a/src/scripts/coursebuilder/canvas/TemplateRenderer.ts
+++ b/src/scripts/coursebuilder/canvas/TemplateRenderer.ts
@@ -3,40 +3,46 @@
  * Handles loading and applying template configuration to layout blocks
  */
 
-import { supabase } from '../../backend/supabase';
-import type { RenderedBlock } from '../layout/LayoutTypes';
+import { supabase } from "../../backend/supabase";
+import type { RenderedBlock } from "../layout/LayoutTypes";
 
 export class TemplateRenderer {
   /**
    * Get layout blocks with template configuration applied as field labels
    * Fetches template data directly from Supabase
    */
-  static async getConfiguredLayoutBlocks(renderedBlocks: RenderedBlock[], courseId: string): Promise<RenderedBlock[]> {
+  static async getConfiguredLayoutBlocks(
+    renderedBlocks: RenderedBlock[],
+    courseId: string,
+  ): Promise<RenderedBlock[]> {
     try {
-      console.log('📄 Fetching template configuration for course:', courseId);
+      console.log("📄 Fetching template configuration for course:", courseId);
 
       const { data: template, error } = await supabase
-        .from('templates')
-        .select('template_data')
-        .eq('course_id', courseId)
+        .from("templates")
+        .select("template_data")
+        .eq("course_id", courseId)
         .single();
 
-      if (error && error.code !== 'PGRST116') { // PGRST116 = no rows found
-        console.error('Error loading course template:', error);
+      if (error && error.code !== "PGRST116") {
+        // PGRST116 = no rows found
+        console.error("Error loading course template:", error);
         return renderedBlocks; // Return original blocks if error
       }
 
       if (!template?.template_data) {
-        console.log('📄 No template found for course, returning default blocks');
+        console.log(
+          "📄 No template found for course, returning default blocks",
+        );
         return renderedBlocks;
       }
 
-      console.log('📄 Template data loaded:', template.template_data);
+      console.log("📄 Template data loaded:", template.template_data);
 
-      const configuredBlocks = renderedBlocks.map(renderedBlock => {
+      const configuredBlocks = renderedBlocks.map((renderedBlock) => {
         // Find matching template block
         const templateBlock = template.template_data.blocks.find(
-          (tb: any) => tb.type === renderedBlock.blockId
+          (tb: any) => tb.type === renderedBlock.blockId,
         );
 
         if (!templateBlock) {
@@ -45,34 +51,39 @@ export class TemplateRenderer {
 
         // Generate input field definitions based on configuration
         const inputFields = this.generateInputFields(templateBlock);
-        
+
         // Update areas with input field information
         // Only assign to content areas (not instruction areas)
-        const updatedAreas = renderedBlock.areas.map(area => {
-          const shouldHaveContent = area.areaId === 'header-content-area' || 
-                                    area.areaId === 'footer-content-area' ||
-                                    area.areaId.includes('content-area');
-          
-          console.log(`📝 Area "${area.areaId}" in block "${renderedBlock.blockId}": shouldHaveContent=${shouldHaveContent}, inputFields=${inputFields.length}`);
-          
+        const updatedAreas = renderedBlock.areas.map((area) => {
+          const shouldHaveContent =
+            area.areaId === "header-content-area" ||
+            area.areaId === "footer-content-area" ||
+            area.areaId.includes("content-area");
+
+          console.log(
+            `📝 Area "${area.areaId}" in block "${renderedBlock.blockId}": shouldHaveContent=${shouldHaveContent}, inputFields=${inputFields.length}`,
+          );
+
           return {
             ...area,
-            content: shouldHaveContent && inputFields.length > 0 ? inputFields : area.content,
-            inputFields: shouldHaveContent ? inputFields : undefined
+            content:
+              shouldHaveContent && inputFields.length > 0
+                ? inputFields
+                : area.content,
+            inputFields: shouldHaveContent ? inputFields : undefined,
           };
         });
 
         return {
           ...renderedBlock,
-          areas: updatedAreas
+          areas: updatedAreas,
         };
       });
 
-      console.log('📄 Layout blocks configured with template fields');
+      console.log("📄 Layout blocks configured with template fields");
       return configuredBlocks;
-
     } catch (error) {
-      console.error('📄 Failed to fetch template configuration:', error);
+      console.error("📄 Failed to fetch template configuration:", error);
       return renderedBlocks; // Return original blocks on error
     }
   }
@@ -89,15 +100,15 @@ export class TemplateRenderer {
       if (enabled) {
         const inputType = this.getInputTypeForField(key);
         const label = key
-          .replace(/_/g, ' ')
-          .replace(/\b\w/g, l => l.toUpperCase());
-        
+          .replace(/_/g, " ")
+          .replace(/\b\w/g, (l) => l.toUpperCase());
+
         fields.push({
           key: key,
           label: label,
           inputType: inputType,
           placeholder: this.getPlaceholderForField(key),
-          required: this.isFieldRequired(key)
+          required: this.isFieldRequired(key),
         });
       }
     }
@@ -110,21 +121,21 @@ export class TemplateRenderer {
    */
   private static getPlaceholderForField(fieldKey: string): string {
     const placeholders: Record<string, string> = {
-      'course_title': 'Enter course name...',
-      'lesson_title': 'Enter lesson title...',
-      'module_title': 'Enter module name...',
-      'teacher_name': 'Enter teacher name...',
-      'lesson_number': 'Enter lesson number...',
-      'institution_name': 'Enter school/institution...',
-      'task': 'Describe the main task...',
-      'topic': 'Enter lesson topic...',
-      'objective': 'State learning objective...',
-      'competence': 'Define competence goals...',
-      'page_number': 'Page #',
-      'copyright': '© 2025 Institution Name'
+      course_title: "Enter course name...",
+      lesson_title: "Enter lesson title...",
+      module_title: "Enter module name...",
+      teacher_name: "Enter teacher name...",
+      lesson_number: "Enter lesson number...",
+      institution_name: "Enter school/institution...",
+      task: "Describe the main task...",
+      topic: "Enter lesson topic...",
+      objective: "State learning objective...",
+      competence: "Define competence goals...",
+      page_number: "Page #",
+      copyright: "© 2025 Institution Name",
     };
 
-    return placeholders[fieldKey] || `Enter ${fieldKey.replace(/_/g, ' ')}...`;
+    return placeholders[fieldKey] || `Enter ${fieldKey.replace(/_/g, " ")}...`;
   }
 
   /**
@@ -132,9 +143,12 @@ export class TemplateRenderer {
    */
   private static isFieldRequired(fieldKey: string): boolean {
     const requiredFields = [
-      'course_title', 'lesson_title', 'teacher_name', 'institution_name'
+      "course_title",
+      "lesson_title",
+      "teacher_name",
+      "institution_name",
     ];
-    
+
     return requiredFields.includes(fieldKey);
   }
 
@@ -144,41 +158,52 @@ export class TemplateRenderer {
   private static getInputTypeForField(fieldKey: string): string {
     // Text inputs
     const textFields = [
-      'course_title', 'lesson_title', 'module_title', 'teacher_name', 
-      'institution_name', 'task', 'topic', 'objective', 'competence',
-      'type', 'state', 'origin', 'quality', 'concepts', 'terminology',
-      'historical_figures', 'student_area', 'teacher_area', 
-      'student_title', 'teacher_title', 'instruction_area', 
-      'instruction_title', 'copyright'
+      "course_title",
+      "lesson_title",
+      "module_title",
+      "teacher_name",
+      "institution_name",
+      "task",
+      "topic",
+      "objective",
+      "competence",
+      "type",
+      "state",
+      "origin",
+      "quality",
+      "concepts",
+      "terminology",
+      "historical_figures",
+      "student_area",
+      "teacher_area",
+      "student_title",
+      "teacher_title",
+      "instruction_area",
+      "instruction_title",
+      "copyright",
     ];
 
     // Number inputs
-    const numberFields = [
-      'lesson_number', 'page_number'
-    ];
+    const numberFields = ["lesson_number", "page_number"];
 
     // Boolean/checkbox inputs
-    const booleanFields = [
-      'include_glossary'
-    ];
+    const booleanFields = ["include_glossary"];
 
     // Date inputs
-    const dateFields = [
-      'created_at', 'updated_at'
-    ];
+    const dateFields = ["created_at", "updated_at"];
 
     // Determine input type
     if (textFields.includes(fieldKey)) {
-      return 'text';
+      return "text";
     } else if (numberFields.includes(fieldKey)) {
-      return 'number';
+      return "number";
     } else if (booleanFields.includes(fieldKey)) {
-      return 'checkbox';
+      return "checkbox";
     } else if (dateFields.includes(fieldKey)) {
-      return 'date';
+      return "date";
     } else {
       // Default to text for unknown fields
-      return 'text';
+      return "text";
     }
   }
 }

--- a/src/scripts/coursebuilder/commands/AddObjectCommand.ts
+++ b/src/scripts/coursebuilder/commands/AddObjectCommand.ts
@@ -1,5 +1,5 @@
-import { Command } from './Command';
-import { Container, Graphics, Sprite, Text } from 'pixi.js';
+import { Command } from "./Command";
+import { Container, Graphics, Sprite, Text } from "pixi.js";
 
 // Union type for common PIXI display objects
 type DisplayObject = Container | Graphics | Sprite | Text;
@@ -25,7 +25,7 @@ export class AddObjectCommand implements Command {
    */
   public execute(): void {
     this.parentContainer.addChild(this.objectToAdd);
-    console.log('AddObjectCommand: executed');
+    console.log("AddObjectCommand: executed");
   }
 
   /**
@@ -33,6 +33,6 @@ export class AddObjectCommand implements Command {
    */
   public undo(): void {
     this.parentContainer.removeChild(this.objectToAdd);
-    console.log('AddObjectCommand: undone');
+    console.log("AddObjectCommand: undone");
   }
 }

--- a/src/scripts/coursebuilder/commands/CommandManager.ts
+++ b/src/scripts/coursebuilder/commands/CommandManager.ts
@@ -1,4 +1,4 @@
-import { Command } from './Command';
+import { Command } from "./Command";
 
 /**
  * Manages the execution, undoing, and redoing of commands.
@@ -27,9 +27,11 @@ export class CommandManager {
     if (command) {
       command.undo();
       this.redoStack.push(command);
-      console.log(`Command undone, undo stack size: ${this.undoStack.length}, redo stack size: ${this.redoStack.length}`);
+      console.log(
+        `Command undone, undo stack size: ${this.undoStack.length}, redo stack size: ${this.redoStack.length}`,
+      );
     } else {
-      console.log('Nothing to undo.');
+      console.log("Nothing to undo.");
     }
   }
 
@@ -41,9 +43,11 @@ export class CommandManager {
     if (command) {
       command.execute();
       this.undoStack.push(command);
-      console.log(`Command redone, undo stack size: ${this.undoStack.length}, redo stack size: ${this.redoStack.length}`);
+      console.log(
+        `Command redone, undo stack size: ${this.undoStack.length}, redo stack size: ${this.redoStack.length}`,
+      );
     } else {
-      console.log('Nothing to redo.');
+      console.log("Nothing to redo.");
     }
   }
 

--- a/src/scripts/coursebuilder/coursebuilder.ts
+++ b/src/scripts/coursebuilder/coursebuilder.ts
@@ -4,14 +4,14 @@
  * Single Responsibility: Component coordination and initialization only
  */
 
-import { PixiCanvas } from './canvas/PixiCanvas';
-import { ToolStateManager } from './ui/ToolStateManager';
-import { UIEventHandler } from './ui/UIEventHandler';
-import { MarginSettingsManager } from './managers/MarginSettingsManager';
-import { PageManager } from './managers/PageManager';
-import { MediaManagerRefactored as MediaManager } from './media/MediaManagerRefactored';
-import { FontManager } from './font/FontManager';
-import { CommandManager } from './commands/CommandManager';
+import { PixiCanvas } from "./canvas/PixiCanvas";
+import { ToolStateManager } from "./ui/ToolStateManager";
+import { UIEventHandler } from "./ui/UIEventHandler";
+import { MarginSettingsManager } from "./managers/MarginSettingsManager";
+import { PageManager } from "./managers/PageManager";
+import { MediaManagerRefactored as MediaManager } from "./media/MediaManagerRefactored";
+import { FontManager } from "./font/FontManager";
+import { CommandManager } from "./commands/CommandManager";
 
 export class CourseBuilder {
   private pixiCanvas: PixiCanvas | null = null;
@@ -26,8 +26,8 @@ export class CourseBuilder {
   private currentCourseId: string | null = null;
 
   constructor() {
-    this.canvasContainer = document.getElementById('canvas-container');
-    
+    this.canvasContainer = document.getElementById("canvas-container");
+
     // Initialize all managers
     this.commandManager = new CommandManager();
     this.toolStateManager = new ToolStateManager();
@@ -36,7 +36,7 @@ export class CourseBuilder {
     this.mediaManager = new MediaManager();
     this.fontManager = new FontManager();
     this.uiEventHandler = new UIEventHandler(this.toolStateManager);
-    
+
     this.init();
   }
 
@@ -44,13 +44,13 @@ export class CourseBuilder {
    * Initialize the coursebuilder
    */
   private async init(): Promise<void> {
-    console.log('🚀 Initializing CourseBuilder with modular architecture');
-    
+    console.log("🚀 Initializing CourseBuilder with modular architecture");
+
     await this.initializePixiCanvas();
     this.setupComponentCallbacks();
     this.bindGlobalEvents();
-    
-    console.log('✅ CourseBuilder initialization complete');
+
+    console.log("✅ CourseBuilder initialization complete");
   }
 
   /**
@@ -58,17 +58,17 @@ export class CourseBuilder {
    */
   private async initializePixiCanvas(): Promise<void> {
     if (!this.canvasContainer) {
-      console.error('❌ Canvas container not found');
+      console.error("❌ Canvas container not found");
       return;
     }
 
     try {
-      this.pixiCanvas = new PixiCanvas('canvas-container');
+      this.pixiCanvas = new PixiCanvas("canvas-container");
       await this.pixiCanvas.init();
-      
-      console.log('🎨 PIXI Canvas initialized');
+
+      console.log("🎨 PIXI Canvas initialized");
     } catch (error) {
-      console.error('❌ Failed to initialize PIXI Canvas:', error);
+      console.error("❌ Failed to initialize PIXI Canvas:", error);
     }
   }
 
@@ -92,25 +92,25 @@ export class CourseBuilder {
 
     // Page changes
     this.pageManager.setOnPageChange((page: any) => {
-      console.log('📄 Page changed:', page.name);
+      console.log("📄 Page changed:", page.name);
       // Handle page change logic here
     });
 
     // Margin changes
     this.marginSettings.setOnMarginChange((margins) => {
-      console.log('📐 Margins updated:', margins);
+      console.log("📐 Margins updated:", margins);
       // Handle margin changes here
     });
 
     // Font changes
     this.fontManager.setOnFontChange((fontFamily: string) => {
-      console.log('🔤 Font changed:', fontFamily);
+      console.log("🔤 Font changed:", fontFamily);
       // Handle font changes here
     });
 
     // Media selection
     this.mediaManager.setOnMediaSelection((mediaType: string) => {
-      console.log('🎬 Media type selected:', mediaType);
+      console.log("🎬 Media type selected:", mediaType);
       // Handle media selection here
     });
   }
@@ -120,21 +120,23 @@ export class CourseBuilder {
    */
   private bindGlobalEvents(): void {
     // Canvas actions
-    document.addEventListener('clearCanvas', () => this.clearCanvas());
-    document.addEventListener('clearAll', () => this.clearAll());
-    document.addEventListener('addPage', () => this.addNewPage());
-    document.addEventListener('toggleLayout', () => this.toggleLayout());
-    
+    document.addEventListener("clearCanvas", () => this.clearCanvas());
+    document.addEventListener("clearAll", () => this.clearAll());
+    document.addEventListener("addPage", () => this.addNewPage());
+    document.addEventListener("toggleLayout", () => this.toggleLayout());
+
     // Media integration
-    document.addEventListener('addMediaToCanvas', (event: any) => {
+    document.addEventListener("addMediaToCanvas", (event: any) => {
       this.addMediaToCanvas(event.detail.url, event.detail.type);
     });
 
     // Keyboard shortcuts for undo/redo
-    document.addEventListener('keydown', (event) => {
-      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-      const undoKeyPressed = (isMac ? event.metaKey : event.ctrlKey) && event.key === 'z';
-      const redoKeyPressed = (isMac ? event.metaKey : event.ctrlKey) && event.key === 'y';
+    document.addEventListener("keydown", (event) => {
+      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+      const undoKeyPressed =
+        (isMac ? event.metaKey : event.ctrlKey) && event.key === "z";
+      const redoKeyPressed =
+        (isMac ? event.metaKey : event.ctrlKey) && event.key === "y";
 
       if (undoKeyPressed) {
         event.preventDefault();
@@ -166,7 +168,7 @@ export class CourseBuilder {
   public setCourseId(courseId: string): void {
     this.currentCourseId = courseId;
     console.log(`📚 Course ID set to: ${courseId}`);
-    
+
     // Pass the course ID to margin settings so it can load/save to database
     this.marginSettings.setCourseId(courseId);
   }
@@ -184,7 +186,7 @@ export class CourseBuilder {
   public clearCanvas(): void {
     if (this.pixiCanvas) {
       this.pixiCanvas.clearCanvas();
-      console.log('🧹 Canvas cleared');
+      console.log("🧹 Canvas cleared");
     }
   }
 
@@ -195,7 +197,7 @@ export class CourseBuilder {
     if (this.pixiCanvas) {
       this.pixiCanvas.clearAll();
     }
-    console.log('🧹 All content cleared');
+    console.log("🧹 All content cleared");
   }
 
   /**
@@ -212,7 +214,7 @@ export class CourseBuilder {
     if (this.pixiCanvas) {
       // PIXI.js doesn't have the same layout visibility concept
       // This could be implemented as layer visibility in PIXI
-      console.log('🔄 Layout visibility toggle requested');
+      console.log("🔄 Layout visibility toggle requested");
     }
   }
 
@@ -283,12 +285,12 @@ export class CourseBuilder {
     this.pageManager.destroy();
     this.mediaManager.destroy();
     this.fontManager.destroy();
-    
+
     if (this.pixiCanvas) {
       this.pixiCanvas.destroy();
     }
-    
-    console.log('🗑️ CourseBuilder destroyed');
+
+    console.log("🗑️ CourseBuilder destroyed");
   }
 }
 
@@ -300,12 +302,12 @@ export class CourseBuilder {
   getState: () => {
     const instance = (window as any).courseBuilder;
     if (!instance) return null;
-    
+
     return {
       currentTool: instance.getCurrentTool(),
       toolSettings: instance.getToolSettings(),
       pageCount: instance.getPageManager().getPageCount(),
-      currentPage: instance.getPageManager().getCurrentPageIndex()
+      currentPage: instance.getPageManager().getCurrentPageIndex(),
     };
-  }
+  },
 };

--- a/src/scripts/coursebuilder/devtools-setup.ts
+++ b/src/scripts/coursebuilder/devtools-setup.ts
@@ -3,175 +3,193 @@
  * Ensures proper devtools initialization and global exposure
  */
 
-import * as PIXI from 'pixi.js';
-import { initDevtools } from '@pixi/devtools';
-import PixiSceneInspector from './devtools/PixiSceneInspector';
+import * as PIXI from "pixi.js";
+import { initDevtools } from "@pixi/devtools";
+import PixiSceneInspector from "./devtools/PixiSceneInspector";
 
 // Global exposure for devtools compatibility
 try {
   (window as any).PIXI = PIXI;
   (globalThis as any).PIXI = PIXI;
 } catch (error) {
-  console.warn('Could not expose PIXI globally in devtools setup:', error);
+  console.warn("Could not expose PIXI globally in devtools setup:", error);
 }
 
 // Enhanced devtools setup function
 export function setupPixiDevtools() {
-  console.log('🔧 Setting up PixiJS devtools environment...');
-  console.log('🔧 PIXI version:', PIXI.VERSION);
-  console.log('🔧 PIXI globally available:', !!(window as any).PIXI);
-  
+  console.log("🔧 Setting up PixiJS devtools environment...");
+  console.log("🔧 PIXI version:", PIXI.VERSION);
+  console.log("🔧 PIXI globally available:", !!(window as any).PIXI);
+
   // Initialize Scene Inspector
   const inspector = new PixiSceneInspector();
   (window as any).pixiInspector = inspector;
-  
+
   // Initialize Spector.js WebGL debugger
   initializeSpectorJS();
-  
+
   // Create global hook for devtools detection
   if (!(window as any).__PIXI_DEVTOOLS_GLOBAL_HOOK__) {
     (window as any).__PIXI_DEVTOOLS_GLOBAL_HOOK__ = {
       renderers: new Map(),
       apps: new Map(),
-      
+
       // Method called by devtools to register
-      register: function(app: any) {
-        console.log('🔧 Devtools registering app:', app);
+      register: function (app: any) {
+        console.log("🔧 Devtools registering app:", app);
         this.apps.set(app, app);
         if (app.renderer) {
           this.renderers.set(app.renderer, app.renderer);
         }
       },
-      
+
       // Method to get all registered apps
-      getApps: function() {
+      getApps: function () {
         return Array.from(this.apps.keys());
-      }
+      },
     };
   }
-  
+
   // Listen for app ready events
-  window.addEventListener('pixi-app-ready', (event: any) => {
-    console.log('🔧 PixiJS app ready event received');
+  window.addEventListener("pixi-app-ready", (event: any) => {
+    console.log("🔧 PixiJS app ready event received");
     const app = event.detail;
-    
+
     // Setup inspector with the app
     if ((window as any).pixiInspector) {
       (window as any).pixiInspector.setApp(app);
-      console.log('🔍 Scene Inspector ready! Try: window.pixiInspector.inspectScene()');
+      console.log(
+        "🔍 Scene Inspector ready! Try: window.pixiInspector.inspectScene()",
+      );
     }
-    
+
     if ((window as any).__PIXI_DEVTOOLS_GLOBAL_HOOK__) {
       (window as any).__PIXI_DEVTOOLS_GLOBAL_HOOK__.register(app);
     }
-    
+
     // Try to initialize devtools again when app is ready
     setTimeout(() => {
       try {
         initDevtools({ app });
-        console.log('✅ Devtools initialized after app ready event');
+        console.log("✅ Devtools initialized after app ready event");
       } catch (error) {
-        console.warn('⚠️ Could not initialize devtools after app ready:', error);
+        console.warn(
+          "⚠️ Could not initialize devtools after app ready:",
+          error,
+        );
       }
     }, 100);
   });
-  
-  console.log('✅ PixiJS devtools environment setup complete');
+
+  console.log("✅ PixiJS devtools environment setup complete");
 }
 
 // Initialize Spector.js for WebGL debugging
 function initializeSpectorJS() {
   try {
-    console.log('🔍 Initializing Spector.js WebGL debugger...');
-    
+    console.log("🔍 Initializing Spector.js WebGL debugger...");
+
     // Method 1: Try to load from node_modules using dynamic import
-    import('spectorjs').then((SPECTOR) => {
-      if (SPECTOR && SPECTOR.Spector) {
-        const spector = new SPECTOR.Spector();
-        (window as any).spector = spector;
-        (window as any).SPECTOR = SPECTOR;
-        
-        console.log('✅ Spector.js WebGL debugger initialized successfully (ES Module)');
-        logSpectorUsage();
-        addSpectorIndicator();
-      }
-    }).catch(() => {
-      console.log('📦 ES Module import failed, trying script injection...');
-      loadSpectorScript();
-    });
-    
+    import("spectorjs")
+      .then((SPECTOR) => {
+        if (SPECTOR && SPECTOR.Spector) {
+          const spector = new SPECTOR.Spector();
+          (window as any).spector = spector;
+          (window as any).SPECTOR = SPECTOR;
+
+          console.log(
+            "✅ Spector.js WebGL debugger initialized successfully (ES Module)",
+          );
+          logSpectorUsage();
+          addSpectorIndicator();
+        }
+      })
+      .catch(() => {
+        console.log("📦 ES Module import failed, trying script injection...");
+        loadSpectorScript();
+      });
   } catch (error) {
-    console.warn('⚠️ Error initializing Spector.js:', error);
+    console.warn("⚠️ Error initializing Spector.js:", error);
     loadSpectorScript();
   }
 }
 
-// Fallback: Load Spector.js via script tag  
+// Fallback: Load Spector.js via script tag
 function loadSpectorScript() {
   // Load Spector.js script dynamically
-  const script = document.createElement('script');
-  script.src = '/node_modules/spectorjs/dist/spector.bundle.js';
+  const script = document.createElement("script");
+  script.src = "/node_modules/spectorjs/dist/spector.bundle.js";
   script.onload = () => {
     // @ts-ignore - Spector is loaded globally by the script
     if (window.SPECTOR) {
       // @ts-ignore
       const spector = new window.SPECTOR.Spector();
       (window as any).spector = spector;
-      
-      console.log('✅ Spector.js WebGL debugger initialized successfully (Script)');
+
+      console.log(
+        "✅ Spector.js WebGL debugger initialized successfully (Script)",
+      );
       logSpectorUsage();
       addSpectorIndicator();
     }
   };
   script.onerror = () => {
-    console.warn('⚠️ Could not load Spector.js from node_modules, trying CDN...');
+    console.warn(
+      "⚠️ Could not load Spector.js from node_modules, trying CDN...",
+    );
     loadSpectorFromCDN();
   };
-  
+
   document.head.appendChild(script);
 }
 
 // Last resort: Load from CDN
 function loadSpectorFromCDN() {
-  const script = document.createElement('script');
-  script.src = 'https://spectorcdn.babylonjs.com/spector.bundle.js';
+  const script = document.createElement("script");
+  script.src = "https://spectorcdn.babylonjs.com/spector.bundle.js";
   script.onload = () => {
     // @ts-ignore
     if (window.SPECTOR) {
       // @ts-ignore
       const spector = new window.SPECTOR.Spector();
       (window as any).spector = spector;
-      
-      console.log('✅ Spector.js WebGL debugger initialized successfully (CDN)');
+
+      console.log(
+        "✅ Spector.js WebGL debugger initialized successfully (CDN)",
+      );
       logSpectorUsage();
       addSpectorIndicator();
     }
   };
   script.onerror = () => {
-    console.warn('❌ Could not load Spector.js from any source');
-    console.log('💡 Manual setup: Add this to your HTML:');
-    console.log('   <script src="https://spectorcdn.babylonjs.com/spector.bundle.js"></script>');
+    console.warn("❌ Could not load Spector.js from any source");
+    console.log("💡 Manual setup: Add this to your HTML:");
+    console.log(
+      '   <script src="https://spectorcdn.babylonjs.com/spector.bundle.js"></script>',
+    );
   };
-  
+
   document.head.appendChild(script);
 }
 
 // Log usage instructions
 function logSpectorUsage() {
-  console.log('🔍 Spector.js Usage Commands:');
-  console.log('   window.spector.displayUI() - Show Spector UI overlay');
-  console.log('   window.spector.captureCanvas(canvas) - Capture specific canvas');
-  console.log('   window.spector.spyCanvases() - Monitor all canvases');
-  console.log('   window.spector.startCapture() - Start capture session');
-  console.log('   window.spector.stopCapture() - Stop capture session');
+  console.log("🔍 Spector.js Usage Commands:");
+  console.log("   window.spector.displayUI() - Show Spector UI overlay");
+  console.log(
+    "   window.spector.captureCanvas(canvas) - Capture specific canvas",
+  );
+  console.log("   window.spector.spyCanvases() - Monitor all canvases");
+  console.log("   window.spector.startCapture() - Start capture session");
+  console.log("   window.spector.stopCapture() - Stop capture session");
 }
 
 // Add visual indicator that Spector.js is available
 function addSpectorIndicator() {
   try {
     // Create a small indicator in the corner
-    const indicator = document.createElement('div');
-    indicator.id = 'spector-indicator';
+    const indicator = document.createElement("div");
+    indicator.id = "spector-indicator";
     indicator.innerHTML = `
       <div style="
         position: fixed;
@@ -190,25 +208,24 @@ function addSpectorIndicator() {
         🔍 Spector.js Ready
       </div>
     `;
-    
+
     document.body.appendChild(indicator);
-    
+
     // Auto-remove indicator after 5 seconds
     setTimeout(() => {
-      const elem = document.getElementById('spector-indicator');
+      const elem = document.getElementById("spector-indicator");
       if (elem) {
-        elem.style.transition = 'opacity 0.5s';
-        elem.style.opacity = '0';
+        elem.style.transition = "opacity 0.5s";
+        elem.style.opacity = "0";
         setTimeout(() => elem.remove(), 500);
       }
     }, 5000);
-    
   } catch (error) {
-    console.warn('Could not add Spector.js indicator:', error);
+    console.warn("Could not add Spector.js indicator:", error);
   }
 }
 
 // Auto-setup if on coursebuilder page
-if (window.location.pathname.includes('coursebuilder.html')) {
+if (window.location.pathname.includes("coursebuilder.html")) {
   setupPixiDevtools();
 }

--- a/src/scripts/coursebuilder/devtools/PixiSceneInspector.ts
+++ b/src/scripts/coursebuilder/devtools/PixiSceneInspector.ts
@@ -24,16 +24,16 @@ export class PixiSceneInspector {
    */
   public startInspection(intervalMs: number = 2000): void {
     if (this.isInspecting) {
-      console.log('🔍 Scene inspection already running');
+      console.log("🔍 Scene inspection already running");
       return;
     }
 
     this.isInspecting = true;
-    console.log('🔍 Starting PixiJS Scene Inspector...');
-    
+    console.log("🔍 Starting PixiJS Scene Inspector...");
+
     // Initial inspection
     this.inspectScene();
-    
+
     // Set up continuous monitoring
     this.intervalId = window.setInterval(() => {
       this.inspectScene();
@@ -49,7 +49,7 @@ export class PixiSceneInspector {
       this.intervalId = null;
     }
     this.isInspecting = false;
-    console.log('🔍 Scene inspection stopped');
+    console.log("🔍 Scene inspection stopped");
   }
 
   /**
@@ -57,7 +57,7 @@ export class PixiSceneInspector {
    */
   public inspectScene(): void {
     if (!this.app) {
-      console.warn('⚠️ No PixiJS app set for inspection');
+      console.warn("⚠️ No PixiJS app set for inspection");
       return;
     }
 
@@ -74,31 +74,31 @@ export class PixiSceneInspector {
       timestamp: new Date().toLocaleTimeString(),
       totals: { containers: 0, graphics: 0, sprites: 0, text: 0, other: 0 },
       objects: [] as any[],
-      hierarchy: this.buildHierarchy(stage)
+      hierarchy: this.buildHierarchy(stage),
     };
 
     this.walkScene(stage, (object: any, depth: number) => {
       const type = object.constructor.name.toLowerCase();
       const objectInfo = {
-        name: object.label || object.name || 'unnamed',
+        name: object.label || object.name || "unnamed",
         type: object.constructor.name,
         depth: depth,
         children: object.children?.length || 0,
         visible: object.visible,
         position: { x: Math.round(object.x), y: Math.round(object.y) },
-        size: this.getObjectSize(object)
+        size: this.getObjectSize(object),
       };
 
       stats.objects.push(objectInfo);
 
       // Count by type
-      if (type.includes('container')) {
+      if (type.includes("container")) {
         stats.totals.containers++;
-      } else if (type.includes('graphics')) {
+      } else if (type.includes("graphics")) {
         stats.totals.graphics++;
-      } else if (type.includes('sprite')) {
+      } else if (type.includes("sprite")) {
         stats.totals.sprites++;
-      } else if (type.includes('text')) {
+      } else if (type.includes("text")) {
         stats.totals.text++;
       } else {
         stats.totals.other++;
@@ -111,9 +111,13 @@ export class PixiSceneInspector {
   /**
    * Walk through all objects in the scene
    */
-  private walkScene(object: any, callback: (obj: any, depth: number) => void, depth: number = 0): void {
+  private walkScene(
+    object: any,
+    callback: (obj: any, depth: number) => void,
+    depth: number = 0,
+  ): void {
     callback(object, depth);
-    
+
     if (object.children) {
       object.children.forEach((child: any) => {
         this.walkScene(child, callback, depth + 1);
@@ -126,15 +130,15 @@ export class PixiSceneInspector {
    */
   private buildHierarchy(object: any, depth: number = 0): any {
     const hierarchy = {
-      name: object.label || object.name || 'unnamed',
+      name: object.label || object.name || "unnamed",
       type: object.constructor.name,
       depth: depth,
-      children: [] as any[]
+      children: [] as any[],
     };
 
     if (object.children) {
-      hierarchy.children = object.children.map((child: any) => 
-        this.buildHierarchy(child, depth + 1)
+      hierarchy.children = object.children.map((child: any) =>
+        this.buildHierarchy(child, depth + 1),
       );
     }
 
@@ -150,53 +154,58 @@ export class PixiSceneInspector {
         const bounds = object.getBounds();
         return {
           width: Math.round(bounds.width),
-          height: Math.round(bounds.height)
+          height: Math.round(bounds.height),
         };
       }
     } catch (error) {
       // Some objects might not have getBounds
     }
-    return { width: 'unknown', height: 'unknown' };
+    return { width: "unknown", height: "unknown" };
   }
 
   /**
    * Display comprehensive scene report
    */
   private displaySceneReport(stats: any): void {
-    const total = Object.values(stats.totals).reduce((sum: number, count: unknown) => sum + (count as number), 0);
-    
+    const total = Object.values(stats.totals).reduce(
+      (sum: number, count: unknown) => sum + (count as number),
+      0,
+    );
+
     console.group(`🎭 Scene Inspection Report (${stats.timestamp})`);
-    
+
     // Summary
     console.log(`📊 Total Objects: ${total}`);
-    console.log('📈 Breakdown:', {
-      'Containers': stats.totals.containers,
-      'Graphics': stats.totals.graphics,
-      'Sprites': stats.totals.sprites,
-      'Text': stats.totals.text,
-      'Other': stats.totals.other
+    console.log("📈 Breakdown:", {
+      Containers: stats.totals.containers,
+      Graphics: stats.totals.graphics,
+      Sprites: stats.totals.sprites,
+      Text: stats.totals.text,
+      Other: stats.totals.other,
     });
 
     // Hierarchy visualization
-    console.group('🌳 Scene Hierarchy:');
+    console.group("🌳 Scene Hierarchy:");
     this.printHierarchy(stats.hierarchy);
     console.groupEnd();
 
     // Object details
     if (stats.objects.length <= 10) {
-      console.group('🔍 Object Details:');
+      console.group("🔍 Object Details:");
       stats.objects.forEach((obj: any, index: number) => {
-        const indent = '  '.repeat(obj.depth);
+        const indent = "  ".repeat(obj.depth);
         console.log(`${indent}${index}: ${obj.name} (${obj.type})`, {
           position: obj.position,
           size: obj.size,
           visible: obj.visible,
-          children: obj.children
+          children: obj.children,
         });
       });
       console.groupEnd();
     } else {
-      console.log(`📝 Object count too high (${stats.objects.length}) for detailed view`);
+      console.log(
+        `📝 Object count too high (${stats.objects.length}) for detailed view`,
+      );
     }
 
     console.groupEnd();
@@ -205,13 +214,17 @@ export class PixiSceneInspector {
   /**
    * Print hierarchy in a tree-like format
    */
-  private printHierarchy(node: any, prefix: string = '', isLast: boolean = true): void {
-    const connector = isLast ? '└── ' : '├── ';
+  private printHierarchy(
+    node: any,
+    prefix: string = "",
+    isLast: boolean = true,
+  ): void {
+    const connector = isLast ? "└── " : "├── ";
     const display = `${node.name} (${node.type})`;
     console.log(prefix + connector + display);
 
     if (node.children && node.children.length > 0) {
-      const newPrefix = prefix + (isLast ? '    ' : '│   ');
+      const newPrefix = prefix + (isLast ? "    " : "│   ");
       node.children.forEach((child: any, index: number) => {
         const isLastChild = index === node.children.length - 1;
         this.printHierarchy(child, newPrefix, isLastChild);
@@ -242,17 +255,18 @@ export class PixiSceneInspector {
     if (!this.app) return [];
 
     const found: any[] = [];
-    const pattern = typeof namePattern === 'string' 
-      ? new RegExp(namePattern, 'i') 
-      : namePattern;
+    const pattern =
+      typeof namePattern === "string"
+        ? new RegExp(namePattern, "i")
+        : namePattern;
 
     this.walkScene(this.app.stage, (object: any) => {
-      const objectName = object.label || object.name || '';
+      const objectName = object.label || object.name || "";
       if (pattern.test(objectName)) {
         found.push({
           name: objectName,
           type: object.constructor.name,
-          object: object
+          object: object,
         });
       }
     });
@@ -267,7 +281,7 @@ export class PixiSceneInspector {
     if (!this.app) return {};
 
     const counts: { [key: string]: number } = {};
-    
+
     this.walkScene(this.app.stage, (object: any) => {
       const type = object.constructor.name;
       counts[type] = (counts[type] || 0) + 1;
@@ -281,16 +295,20 @@ export class PixiSceneInspector {
 (window as any).pixiInspector = new PixiSceneInspector();
 
 // Auto-setup inspector when course builder is ready
-window.addEventListener('pixi-app-ready', (event: any) => {
+window.addEventListener("pixi-app-ready", (event: any) => {
   const app = event.detail;
   (window as any).pixiInspector.setApp(app);
-  
-  console.log('🔍 PixiJS Scene Inspector ready! Use these commands:');
-  console.log('  window.pixiInspector.inspectScene() - One-time inspection');
-  console.log('  window.pixiInspector.startInspection() - Start continuous monitoring');
-  console.log('  window.pixiInspector.stopInspection() - Stop monitoring');
-  console.log('  window.pixiInspector.findObjects("grid") - Find objects by name');
-  console.log('  window.pixiInspector.countByType() - Count objects by type');
+
+  console.log("🔍 PixiJS Scene Inspector ready! Use these commands:");
+  console.log("  window.pixiInspector.inspectScene() - One-time inspection");
+  console.log(
+    "  window.pixiInspector.startInspection() - Start continuous monitoring",
+  );
+  console.log("  window.pixiInspector.stopInspection() - Stop monitoring");
+  console.log(
+    '  window.pixiInspector.findObjects("grid") - Find objects by name',
+  );
+  console.log("  window.pixiInspector.countByType() - Count objects by type");
 });
 
 export default PixiSceneInspector;

--- a/src/scripts/coursebuilder/font/FontManager.ts
+++ b/src/scripts/coursebuilder/font/FontManager.ts
@@ -4,12 +4,16 @@
  * Single Responsibility: Font family management and coordination only
  */
 
-import { FontStyleController } from './FontStyleController.js';
-import { FontSizeController } from './FontSizeController.js';
+import { FontStyleController } from "./FontStyleController.js";
+import { FontSizeController } from "./FontSizeController.js";
 
 export class FontManager {
-  private currentFont: string = 'Arial';
-  private availableFonts: Array<{ name: string; family: string; loaded: boolean }> = [];
+  private currentFont: string = "Arial";
+  private availableFonts: Array<{
+    name: string;
+    family: string;
+    loaded: boolean;
+  }> = [];
   private fontStyleController: FontStyleController;
   private fontSizeController: FontSizeController;
   private onFontChangeCallback: ((fontFamily: string) => void) | null = null;
@@ -17,7 +21,7 @@ export class FontManager {
   constructor() {
     this.fontStyleController = new FontStyleController();
     this.fontSizeController = new FontSizeController();
-    
+
     this.initializeDefaultFonts();
     this.bindFontFamilyEvents();
     this.setupControllerCallbacks();
@@ -35,29 +39,39 @@ export class FontManager {
    */
   private initializeDefaultFonts(): void {
     const systemFonts = [
-      { name: 'Arial', family: 'Arial, sans-serif', loaded: true },
-      { name: 'Times New Roman', family: 'Times New Roman, serif', loaded: true },
-      { name: 'Courier New', family: 'Courier New, monospace', loaded: true },
-      { name: 'Helvetica', family: 'Helvetica, Arial, sans-serif', loaded: true },
-      { name: 'Georgia', family: 'Georgia, serif', loaded: true },
-      { name: 'Verdana', family: 'Verdana, sans-serif', loaded: true },
-      { name: 'Comic Sans MS', family: 'Comic Sans MS, cursive', loaded: true },
-      { name: 'Impact', family: 'Impact, sans-serif', loaded: true }
+      { name: "Arial", family: "Arial, sans-serif", loaded: true },
+      {
+        name: "Times New Roman",
+        family: "Times New Roman, serif",
+        loaded: true,
+      },
+      { name: "Courier New", family: "Courier New, monospace", loaded: true },
+      {
+        name: "Helvetica",
+        family: "Helvetica, Arial, sans-serif",
+        loaded: true,
+      },
+      { name: "Georgia", family: "Georgia, serif", loaded: true },
+      { name: "Verdana", family: "Verdana, sans-serif", loaded: true },
+      { name: "Comic Sans MS", family: "Comic Sans MS, cursive", loaded: true },
+      { name: "Impact", family: "Impact, sans-serif", loaded: true },
     ];
 
     this.availableFonts = [...systemFonts];
     this.populateFontSelector();
-    
-    console.log('🔤 Default fonts initialized:', this.availableFonts.length);
+
+    console.log("🔤 Default fonts initialized:", this.availableFonts.length);
   }
 
   /**
    * Bind font family selection events
    */
   private bindFontFamilyEvents(): void {
-    const fontSelect = document.getElementById('font-family') as HTMLSelectElement;
+    const fontSelect = document.getElementById(
+      "font-family",
+    ) as HTMLSelectElement;
     if (fontSelect) {
-      fontSelect.addEventListener('change', this.handleFontChange.bind(this));
+      fontSelect.addEventListener("change", this.handleFontChange.bind(this));
     }
   }
 
@@ -67,12 +81,12 @@ export class FontManager {
   private setupControllerCallbacks(): void {
     // Font style changes
     this.fontStyleController.setOnStyleChange((styles) => {
-      console.log('🎨 Font styles changed:', styles);
+      console.log("🎨 Font styles changed:", styles);
     });
 
     // Font size changes
     this.fontSizeController.setOnSizeChange((size) => {
-      console.log('📏 Font size changed:', size);
+      console.log("📏 Font size changed:", size);
     });
   }
 
@@ -81,12 +95,14 @@ export class FontManager {
    */
   private handleFontChange(event: Event): void {
     const select = event.target as HTMLSelectElement;
-    const selectedFont = this.availableFonts.find(font => font.name === select.value);
-    
+    const selectedFont = this.availableFonts.find(
+      (font) => font.name === select.value,
+    );
+
     if (selectedFont) {
       this.currentFont = selectedFont.name;
-      console.log('🔤 Font changed to:', selectedFont.name);
-      
+      console.log("🔤 Font changed to:", selectedFont.name);
+
       // Trigger callback
       if (this.onFontChangeCallback) {
         this.onFontChangeCallback(selectedFont.family);
@@ -98,12 +114,17 @@ export class FontManager {
    * Populate font selector dropdown
    */
   private populateFontSelector(): void {
-    const fontSelect = document.getElementById('font-family') as HTMLSelectElement;
+    const fontSelect = document.getElementById(
+      "font-family",
+    ) as HTMLSelectElement;
     if (!fontSelect) return;
 
-    fontSelect.innerHTML = this.availableFonts.map(font => 
-      `<option value="${font.name}" ${font.name === this.currentFont ? 'selected' : ''}>${font.name}</option>`
-    ).join('');
+    fontSelect.innerHTML = this.availableFonts
+      .map(
+        (font) =>
+          `<option value="${font.name}" ${font.name === this.currentFont ? "selected" : ""}>${font.name}</option>`,
+      )
+      .join("");
   }
 
   /**
@@ -114,20 +135,20 @@ export class FontManager {
       const font = new FontFace(fontName, `url(${fontUrl})`);
       await font.load();
       document.fonts.add(font);
-      
+
       // Add to available fonts
       const customFont = {
         name: fontName,
         family: `${fontName}, sans-serif`,
-        loaded: true
+        loaded: true,
       };
-      
+
       this.availableFonts.push(customFont);
       this.populateFontSelector();
-      
-      console.log('📥 Custom font loaded:', fontName);
+
+      console.log("📥 Custom font loaded:", fontName);
     } catch (error) {
-      console.error('❌ Failed to load custom font:', fontName, error);
+      console.error("❌ Failed to load custom font:", fontName, error);
     }
   }
 
@@ -142,26 +163,30 @@ export class FontManager {
    * Get current font family
    */
   getCurrentFontFamily(): string {
-    const currentFontObj = this.availableFonts.find(font => font.name === this.currentFont);
-    return currentFontObj?.family || 'Arial, sans-serif';
+    const currentFontObj = this.availableFonts.find(
+      (font) => font.name === this.currentFont,
+    );
+    return currentFontObj?.family || "Arial, sans-serif";
   }
 
   /**
    * Set current font
    */
   setCurrentFont(fontName: string): void {
-    const font = this.availableFonts.find(f => f.name === fontName);
+    const font = this.availableFonts.find((f) => f.name === fontName);
     if (font) {
       this.currentFont = fontName;
-      
+
       // Update selector
-      const fontSelect = document.getElementById('font-family') as HTMLSelectElement;
+      const fontSelect = document.getElementById(
+        "font-family",
+      ) as HTMLSelectElement;
       if (fontSelect) {
         fontSelect.value = fontName;
       }
-      
-      console.log('🔤 Font set to:', fontName);
-      
+
+      console.log("🔤 Font set to:", fontName);
+
       // Trigger callback
       if (this.onFontChangeCallback) {
         this.onFontChangeCallback(font.family);
@@ -172,7 +197,11 @@ export class FontManager {
   /**
    * Get available fonts
    */
-  getAvailableFonts(): Array<{ name: string; family: string; loaded: boolean }> {
+  getAvailableFonts(): Array<{
+    name: string;
+    family: string;
+    loaded: boolean;
+  }> {
     return [...this.availableFonts];
   }
 
@@ -201,7 +230,7 @@ export class FontManager {
     return {
       family: this.getCurrentFontFamily(),
       size: this.fontSizeController.getCurrentSize(),
-      styles: this.fontStyleController.getCurrentStyles()
+      styles: this.fontStyleController.getCurrentStyles(),
     };
   }
 
@@ -210,10 +239,10 @@ export class FontManager {
    */
   applyFontToElement(element: HTMLElement): void {
     const config = this.getCurrentFontConfig();
-    
+
     element.style.fontFamily = config.family;
     element.style.fontSize = `${config.size}px`;
-    
+
     this.fontStyleController.applyStylesToElement(element);
   }
 
@@ -221,7 +250,7 @@ export class FontManager {
    * Reset all font settings to defaults
    */
   resetToDefaults(): void {
-    this.setCurrentFont('Arial');
+    this.setCurrentFont("Arial");
     this.fontSizeController.reset();
     this.fontStyleController.resetStyles();
   }

--- a/src/scripts/coursebuilder/font/FontSizeController.ts
+++ b/src/scripts/coursebuilder/font/FontSizeController.ts
@@ -6,7 +6,9 @@ export class FontSizeController {
   private currentSize: number = 16;
   private minSize: number = 8;
   private maxSize: number = 72;
-  private sizeOptions: number[] = [8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 60, 72];
+  private sizeOptions: number[] = [
+    8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 60, 72,
+  ];
   private onSizeChangeCallback: ((size: number) => void) | null = null;
 
   constructor() {
@@ -19,35 +21,52 @@ export class FontSizeController {
   }
 
   private bindEvents(): void {
-    const increaseBtns = document.querySelectorAll('[data-font-action="increase"]');
-    const decreaseBtns = document.querySelectorAll('[data-font-action="decrease"]');
-    increaseBtns.forEach(btn => btn.addEventListener('click', () => this.increaseSize()));
-    decreaseBtns.forEach(btn => btn.addEventListener('click', () => this.decreaseSize()));
+    const increaseBtns = document.querySelectorAll(
+      '[data-font-action="increase"]',
+    );
+    const decreaseBtns = document.querySelectorAll(
+      '[data-font-action="decrease"]',
+    );
+    increaseBtns.forEach((btn) =>
+      btn.addEventListener("click", () => this.increaseSize()),
+    );
+    decreaseBtns.forEach((btn) =>
+      btn.addEventListener("click", () => this.decreaseSize()),
+    );
 
-    const sizeSelects = document.querySelectorAll('select[data-font-property="size"]');
-    sizeSelects.forEach(select => {
-      select.addEventListener('change', (e) => this.handleSizeSelect(e));
+    const sizeSelects = document.querySelectorAll(
+      'select[data-font-property="size"]',
+    );
+    sizeSelects.forEach((select) => {
+      select.addEventListener("change", (e) => this.handleSizeSelect(e));
     });
 
-    const sizeInputs = document.querySelectorAll('input[data-font-property="size"]');
-    sizeInputs.forEach(input => {
-      input.addEventListener('input', (e) => this.handleSizeInput(e));
-      input.addEventListener('blur', (e) => this.handleSizeBlur(e));
+    const sizeInputs = document.querySelectorAll(
+      'input[data-font-property="size"]',
+    );
+    sizeInputs.forEach((input) => {
+      input.addEventListener("input", (e) => this.handleSizeInput(e));
+      input.addEventListener("blur", (e) => this.handleSizeBlur(e));
     });
 
-    document.addEventListener('keydown', (e) => this.handleKeyboardShortcuts(e));
+    document.addEventListener("keydown", (e) =>
+      this.handleKeyboardShortcuts(e),
+    );
   }
 
   private handleKeyboardShortcuts(event: KeyboardEvent): void {
-    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+    if (
+      event.target instanceof HTMLInputElement ||
+      event.target instanceof HTMLTextAreaElement
+    ) {
       return;
     }
 
-    if ((event.ctrlKey || event.metaKey)) {
-      if (event.key === '=') {
+    if (event.ctrlKey || event.metaKey) {
+      if (event.key === "=") {
         event.preventDefault();
         this.increaseSize();
-      } else if (event.key === '-') {
+      } else if (event.key === "-") {
         event.preventDefault();
         this.decreaseSize();
       }
@@ -65,11 +84,14 @@ export class FontSizeController {
   private handleSizeInput(event: Event): void {
     const target = event.target as HTMLInputElement;
     const value = target.value.trim();
-    if (value === '') return;
-    
+    if (value === "") return;
+
     const newSize = parseInt(value);
     if (!isNaN(newSize) && newSize !== this.currentSize) {
-      const clampedSize = Math.min(Math.max(newSize, this.minSize), this.maxSize);
+      const clampedSize = Math.min(
+        Math.max(newSize, this.minSize),
+        this.maxSize,
+      );
       if (clampedSize !== newSize) {
         target.value = clampedSize.toString();
       }
@@ -79,7 +101,7 @@ export class FontSizeController {
 
   private handleSizeBlur(event: Event): void {
     const target = event.target as HTMLInputElement;
-    if (target.value.trim() === '') {
+    if (target.value.trim() === "") {
       target.value = this.currentSize.toString();
     }
   }
@@ -108,17 +130,19 @@ export class FontSizeController {
 
     this.currentSize = clampedSize;
     this.updateUI();
-    
+
     if (this.onSizeChangeCallback) {
       this.onSizeChangeCallback(this.currentSize);
     }
   }
 
   private updateUI(): void {
-    const selects = document.querySelectorAll('select[data-font-property="size"]') as NodeListOf<HTMLSelectElement>;
-    selects.forEach(select => {
+    const selects = document.querySelectorAll(
+      'select[data-font-property="size"]',
+    ) as NodeListOf<HTMLSelectElement>;
+    selects.forEach((select) => {
       if (!select.querySelector(`option[value="${this.currentSize}"]`)) {
-        const option = document.createElement('option');
+        const option = document.createElement("option");
         option.value = this.currentSize.toString();
         option.textContent = this.currentSize.toString();
         select.appendChild(option);
@@ -126,21 +150,23 @@ export class FontSizeController {
       select.value = this.currentSize.toString();
     });
 
-    const inputs = document.querySelectorAll('input[data-font-property="size"]') as NodeListOf<HTMLInputElement>;
-    inputs.forEach(input => {
+    const inputs = document.querySelectorAll(
+      'input[data-font-property="size"]',
+    ) as NodeListOf<HTMLInputElement>;
+    inputs.forEach((input) => {
       input.value = this.currentSize.toString();
     });
 
-    const displays = document.querySelectorAll('[data-font-size-display]');
-    displays.forEach(display => {
+    const displays = document.querySelectorAll("[data-font-size-display]");
+    displays.forEach((display) => {
       display.textContent = `${this.currentSize}px`;
     });
   }
 
   private populateSizeOptions(select: HTMLSelectElement): void {
-    select.innerHTML = '';
-    this.sizeOptions.forEach(size => {
-      const option = document.createElement('option');
+    select.innerHTML = "";
+    this.sizeOptions.forEach((size) => {
+      const option = document.createElement("option");
       option.value = size.toString();
       option.textContent = size.toString();
       if (size === this.currentSize) {
@@ -190,25 +216,33 @@ export class FontSizeController {
   }
 
   destroy(): void {
-    const increaseBtns = document.querySelectorAll('[data-font-action="increase"]');
-    const decreaseBtns = document.querySelectorAll('[data-font-action="decrease"]');
-    const selects = document.querySelectorAll('select[data-font-property="size"]');
-    const inputs = document.querySelectorAll('input[data-font-property="size"]');
+    const increaseBtns = document.querySelectorAll(
+      '[data-font-action="increase"]',
+    );
+    const decreaseBtns = document.querySelectorAll(
+      '[data-font-action="decrease"]',
+    );
+    const selects = document.querySelectorAll(
+      'select[data-font-property="size"]',
+    );
+    const inputs = document.querySelectorAll(
+      'input[data-font-property="size"]',
+    );
 
-    [...increaseBtns, ...decreaseBtns].forEach(btn => {
-      btn.removeEventListener('click', () => this.increaseSize());
+    [...increaseBtns, ...decreaseBtns].forEach((btn) => {
+      btn.removeEventListener("click", () => this.increaseSize());
     });
-    
-    selects.forEach(select => {
-      select.removeEventListener('change', this.handleSizeSelect);
+
+    selects.forEach((select) => {
+      select.removeEventListener("change", this.handleSizeSelect);
     });
-    
-    inputs.forEach(input => {
-      input.removeEventListener('input', this.handleSizeInput);
-      input.removeEventListener('blur', this.handleSizeBlur);
+
+    inputs.forEach((input) => {
+      input.removeEventListener("input", this.handleSizeInput);
+      input.removeEventListener("blur", this.handleSizeBlur);
     });
-    
-    document.removeEventListener('keydown', this.handleKeyboardShortcuts);
+
+    document.removeEventListener("keydown", this.handleKeyboardShortcuts);
     this.onSizeChangeCallback = null;
   }
 }

--- a/src/scripts/coursebuilder/font/FontStyleController.ts
+++ b/src/scripts/coursebuilder/font/FontStyleController.ts
@@ -5,7 +5,13 @@
  */
 
 export class FontStyleController {
-  private onStyleChangeCallback: ((styles: { bold?: boolean; italic?: boolean; underline?: boolean }) => void) | null = null;
+  private onStyleChangeCallback:
+    | ((styles: {
+        bold?: boolean;
+        italic?: boolean;
+        underline?: boolean;
+      }) => void)
+    | null = null;
 
   constructor() {
     this.bindStyleEvents();
@@ -14,7 +20,13 @@ export class FontStyleController {
   /**
    * Set callback for style changes
    */
-  setOnStyleChange(callback: (styles: { bold?: boolean; italic?: boolean; underline?: boolean }) => void): void {
+  setOnStyleChange(
+    callback: (styles: {
+      bold?: boolean;
+      italic?: boolean;
+      underline?: boolean;
+    }) => void,
+  ): void {
     this.onStyleChangeCallback = callback;
   }
 
@@ -23,21 +35,21 @@ export class FontStyleController {
    */
   private bindStyleEvents(): void {
     // Bold button
-    const boldBtn = document.getElementById('font-bold');
+    const boldBtn = document.getElementById("font-bold");
     if (boldBtn) {
-      boldBtn.addEventListener('click', this.toggleBold.bind(this));
+      boldBtn.addEventListener("click", this.toggleBold.bind(this));
     }
 
     // Italic button
-    const italicBtn = document.getElementById('font-italic');
+    const italicBtn = document.getElementById("font-italic");
     if (italicBtn) {
-      italicBtn.addEventListener('click', this.toggleItalic.bind(this));
+      italicBtn.addEventListener("click", this.toggleItalic.bind(this));
     }
 
     // Underline button
-    const underlineBtn = document.getElementById('font-underline');
+    const underlineBtn = document.getElementById("font-underline");
     if (underlineBtn) {
-      underlineBtn.addEventListener('click', this.toggleUnderline.bind(this));
+      underlineBtn.addEventListener("click", this.toggleUnderline.bind(this));
     }
   }
 
@@ -45,21 +57,21 @@ export class FontStyleController {
    * Toggle bold styling
    */
   private toggleBold(): void {
-    const boldBtn = document.getElementById('font-bold');
+    const boldBtn = document.getElementById("font-bold");
     if (boldBtn) {
-      boldBtn.classList.toggle('active');
-      const isActive = boldBtn.classList.contains('active');
-      
-      console.log('💪 Bold toggled:', isActive ? 'ON' : 'OFF');
-      
+      boldBtn.classList.toggle("active");
+      const isActive = boldBtn.classList.contains("active");
+
+      console.log("💪 Bold toggled:", isActive ? "ON" : "OFF");
+
       // Trigger callback
       if (this.onStyleChangeCallback) {
         this.onStyleChangeCallback({ bold: isActive });
       }
 
       // Emit custom event
-      const boldEvent = new CustomEvent('fontBoldToggle', {
-        detail: { active: isActive }
+      const boldEvent = new CustomEvent("fontBoldToggle", {
+        detail: { active: isActive },
       });
       document.dispatchEvent(boldEvent);
     }
@@ -69,21 +81,21 @@ export class FontStyleController {
    * Toggle italic styling
    */
   private toggleItalic(): void {
-    const italicBtn = document.getElementById('font-italic');
+    const italicBtn = document.getElementById("font-italic");
     if (italicBtn) {
-      italicBtn.classList.toggle('active');
-      const isActive = italicBtn.classList.contains('active');
-      
-      console.log('📐 Italic toggled:', isActive ? 'ON' : 'OFF');
-      
+      italicBtn.classList.toggle("active");
+      const isActive = italicBtn.classList.contains("active");
+
+      console.log("📐 Italic toggled:", isActive ? "ON" : "OFF");
+
       // Trigger callback
       if (this.onStyleChangeCallback) {
         this.onStyleChangeCallback({ italic: isActive });
       }
 
       // Emit custom event
-      const italicEvent = new CustomEvent('fontItalicToggle', {
-        detail: { active: isActive }
+      const italicEvent = new CustomEvent("fontItalicToggle", {
+        detail: { active: isActive },
       });
       document.dispatchEvent(italicEvent);
     }
@@ -93,21 +105,21 @@ export class FontStyleController {
    * Toggle underline styling
    */
   private toggleUnderline(): void {
-    const underlineBtn = document.getElementById('font-underline');
+    const underlineBtn = document.getElementById("font-underline");
     if (underlineBtn) {
-      underlineBtn.classList.toggle('active');
-      const isActive = underlineBtn.classList.contains('active');
-      
-      console.log('📝 Underline toggled:', isActive ? 'ON' : 'OFF');
-      
+      underlineBtn.classList.toggle("active");
+      const isActive = underlineBtn.classList.contains("active");
+
+      console.log("📝 Underline toggled:", isActive ? "ON" : "OFF");
+
       // Trigger callback
       if (this.onStyleChangeCallback) {
         this.onStyleChangeCallback({ underline: isActive });
       }
 
       // Emit custom event
-      const underlineEvent = new CustomEvent('fontUnderlineToggle', {
-        detail: { active: isActive }
+      const underlineEvent = new CustomEvent("fontUnderlineToggle", {
+        detail: { active: isActive },
       });
       document.dispatchEvent(underlineEvent);
     }
@@ -118,34 +130,45 @@ export class FontStyleController {
    */
   getCurrentStyles(): { bold: boolean; italic: boolean; underline: boolean } {
     return {
-      bold: document.getElementById('font-bold')?.classList.contains('active') || false,
-      italic: document.getElementById('font-italic')?.classList.contains('active') || false,
-      underline: document.getElementById('font-underline')?.classList.contains('active') || false
+      bold:
+        document.getElementById("font-bold")?.classList.contains("active") ||
+        false,
+      italic:
+        document.getElementById("font-italic")?.classList.contains("active") ||
+        false,
+      underline:
+        document
+          .getElementById("font-underline")
+          ?.classList.contains("active") || false,
     };
   }
 
   /**
    * Apply font styles
    */
-  applyStyles(styles: { bold?: boolean; italic?: boolean; underline?: boolean }): void {
+  applyStyles(styles: {
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+  }): void {
     if (styles.bold !== undefined) {
-      const boldBtn = document.getElementById('font-bold');
+      const boldBtn = document.getElementById("font-bold");
       if (boldBtn) {
-        boldBtn.classList.toggle('active', styles.bold);
+        boldBtn.classList.toggle("active", styles.bold);
       }
     }
-    
+
     if (styles.italic !== undefined) {
-      const italicBtn = document.getElementById('font-italic');
+      const italicBtn = document.getElementById("font-italic");
       if (italicBtn) {
-        italicBtn.classList.toggle('active', styles.italic);
+        italicBtn.classList.toggle("active", styles.italic);
       }
     }
-    
+
     if (styles.underline !== undefined) {
-      const underlineBtn = document.getElementById('font-underline');
+      const underlineBtn = document.getElementById("font-underline");
       if (underlineBtn) {
-        underlineBtn.classList.toggle('active', styles.underline);
+        underlineBtn.classList.toggle("active", styles.underline);
       }
     }
 
@@ -173,14 +196,22 @@ export class FontStyleController {
   /**
    * Get active styles as CSS text properties
    */
-  getStylesAsCSS(): { fontWeight?: string; fontStyle?: string; textDecoration?: string } {
+  getStylesAsCSS(): {
+    fontWeight?: string;
+    fontStyle?: string;
+    textDecoration?: string;
+  } {
     const styles = this.getCurrentStyles();
-    const css: { fontWeight?: string; fontStyle?: string; textDecoration?: string } = {};
-    
-    if (styles.bold) css.fontWeight = 'bold';
-    if (styles.italic) css.fontStyle = 'italic';
-    if (styles.underline) css.textDecoration = 'underline';
-    
+    const css: {
+      fontWeight?: string;
+      fontStyle?: string;
+      textDecoration?: string;
+    } = {};
+
+    if (styles.bold) css.fontWeight = "bold";
+    if (styles.italic) css.fontStyle = "italic";
+    if (styles.underline) css.textDecoration = "underline";
+
     return css;
   }
 
@@ -189,10 +220,10 @@ export class FontStyleController {
    */
   applyStylesToElement(element: HTMLElement): void {
     const cssStyles = this.getStylesAsCSS();
-    
-    element.style.fontWeight = cssStyles.fontWeight || 'normal';
-    element.style.fontStyle = cssStyles.fontStyle || 'normal';
-    element.style.textDecoration = cssStyles.textDecoration || 'none';
+
+    element.style.fontWeight = cssStyles.fontWeight || "normal";
+    element.style.fontStyle = cssStyles.fontStyle || "normal";
+    element.style.textDecoration = cssStyles.textDecoration || "none";
   }
 
   /**

--- a/src/scripts/coursebuilder/layout/CanvasNavigator.ts
+++ b/src/scripts/coursebuilder/layout/CanvasNavigator.ts
@@ -3,7 +3,7 @@
  * Handles navigation between multiple canvases, thumbnails, and table of contents
  */
 
-import type { CourseLayout, CanvasLayout } from './LayoutTypes';
+import type { CourseLayout, CanvasLayout } from "./LayoutTypes";
 
 interface CanvasThumbnail {
   id: string;
@@ -19,7 +19,7 @@ export class CanvasNavigator {
   private tocContainer: HTMLElement | null = null;
   private onCanvasChangeCallback: ((canvasIndex: number) => void) | null = null;
 
-  constructor(tocContainerId: string = 'coursebuilder__toc') {
+  constructor(tocContainerId: string = "coursebuilder__toc") {
     this.tocContainer = document.getElementById(tocContainerId);
     if (!this.tocContainer) {
       console.warn(`TOC container with id "${tocContainerId}" not found`);
@@ -39,7 +39,7 @@ export class CanvasNavigator {
   generateNavigation(courseLayout: CourseLayout): void {
     if (!this.tocContainer) return;
 
-    this.tocContainer.innerHTML = '';
+    this.tocContainer.innerHTML = "";
     this.thumbnails = [];
 
     // Create header with course summary
@@ -62,8 +62,8 @@ export class CanvasNavigator {
    * Create navigation header with course summary
    */
   private createNavigationHeader(courseLayout: CourseLayout): void {
-    const header = document.createElement('div');
-    header.className = 'canvas-toc__header';
+    const header = document.createElement("div");
+    header.className = "canvas-toc__header";
     header.innerHTML = `
       <h3>Course Navigation</h3>
       <div class="canvas-toc__summary">
@@ -73,8 +73,8 @@ export class CanvasNavigator {
       </div>
     `;
 
-    const controls = document.createElement('div');
-    controls.className = 'canvas-toc__controls';
+    const controls = document.createElement("div");
+    controls.className = "canvas-toc__controls";
     controls.innerHTML = `
       <button class="canvas-nav-btn canvas-nav-btn--prev" title="Previous Canvas">
         <span class="canvas-nav-btn__icon">←</span>
@@ -88,11 +88,19 @@ export class CanvasNavigator {
     `;
 
     // Add event listeners
-    const prevBtn = controls.querySelector('.canvas-nav-btn--prev') as HTMLElement;
-    const nextBtn = controls.querySelector('.canvas-nav-btn--next') as HTMLElement;
+    const prevBtn = controls.querySelector(
+      ".canvas-nav-btn--prev",
+    ) as HTMLElement;
+    const nextBtn = controls.querySelector(
+      ".canvas-nav-btn--next",
+    ) as HTMLElement;
 
-    prevBtn?.addEventListener('click', () => this.navigateToCanvas(this.currentCanvasIndex - 1));
-    nextBtn?.addEventListener('click', () => this.navigateToCanvas(this.currentCanvasIndex + 1));
+    prevBtn?.addEventListener("click", () =>
+      this.navigateToCanvas(this.currentCanvasIndex - 1),
+    );
+    nextBtn?.addEventListener("click", () =>
+      this.navigateToCanvas(this.currentCanvasIndex + 1),
+    );
 
     header.appendChild(controls);
     this.tocContainer!.appendChild(header);
@@ -101,24 +109,27 @@ export class CanvasNavigator {
   /**
    * Create thumbnail for a canvas
    */
-  private createCanvasThumbnail(canvas: CanvasLayout, index: number): CanvasThumbnail {
-    const thumbnail = document.createElement('div');
-    thumbnail.className = 'canvas-thumbnail';
+  private createCanvasThumbnail(
+    canvas: CanvasLayout,
+    index: number,
+  ): CanvasThumbnail {
+    const thumbnail = document.createElement("div");
+    thumbnail.className = "canvas-thumbnail";
     thumbnail.dataset.canvasIndex = index.toString();
 
     // Create visual preview of canvas layout
-    const preview = document.createElement('div');
-    preview.className = 'canvas-thumbnail__preview';
+    const preview = document.createElement("div");
+    preview.className = "canvas-thumbnail__preview";
 
     // Add miniature blocks
-    canvas.blocks.forEach(block => {
-      const blockElement = document.createElement('div');
+    canvas.blocks.forEach((block) => {
+      const blockElement = document.createElement("div");
       blockElement.className = `canvas-thumbnail__block canvas-thumbnail__block--${block.blockId}`;
-      
+
       // Scale down the block proportionally
       const scaleX = 0.1; // 10% of original width
       const scaleY = 0.1; // 10% of original height
-      
+
       blockElement.style.cssText = `
         position: absolute;
         left: ${block.x * scaleX}px;
@@ -126,15 +137,18 @@ export class CanvasNavigator {
         width: ${block.width * scaleX}px;
         height: ${block.height * scaleY}px;
       `;
-      
+
       preview.appendChild(blockElement);
     });
 
     // Create label
-    const label = document.createElement('div');
-    label.className = 'canvas-thumbnail__label';
-    
-    const canvasTypeName = this.getCanvasTypeName(canvas.sessionNumber, canvas.canvasNumber);
+    const label = document.createElement("div");
+    label.className = "canvas-thumbnail__label";
+
+    const canvasTypeName = this.getCanvasTypeName(
+      canvas.sessionNumber,
+      canvas.canvasNumber,
+    );
     label.innerHTML = `
       <div class="canvas-thumbnail__session">Session ${canvas.sessionNumber}</div>
       <div class="canvas-thumbnail__type">${canvasTypeName}</div>
@@ -145,7 +159,7 @@ export class CanvasNavigator {
     thumbnail.appendChild(label);
 
     // Add click handler
-    thumbnail.addEventListener('click', () => {
+    thumbnail.addEventListener("click", () => {
       this.navigateToCanvas(index);
     });
 
@@ -154,7 +168,7 @@ export class CanvasNavigator {
       sessionNumber: canvas.sessionNumber,
       canvasNumber: canvas.canvasNumber,
       element: thumbnail,
-      isActive: false
+      isActive: false,
     };
   }
 
@@ -168,7 +182,8 @@ export class CanvasNavigator {
     this.setActiveCanvas(index);
 
     // Update current canvas counter
-    const currentNumberSpan = this.tocContainer?.querySelector('.current-number');
+    const currentNumberSpan =
+      this.tocContainer?.querySelector(".current-number");
     if (currentNumberSpan) {
       currentNumberSpan.textContent = (index + 1).toString();
     }
@@ -184,15 +199,15 @@ export class CanvasNavigator {
    */
   private setActiveCanvas(index: number): void {
     // Remove active class from all thumbnails
-    this.thumbnails.forEach(thumbnail => {
+    this.thumbnails.forEach((thumbnail) => {
       thumbnail.isActive = false;
-      thumbnail.element.classList.remove('canvas-thumbnail--active');
+      thumbnail.element.classList.remove("canvas-thumbnail--active");
     });
 
     // Set new active canvas
     if (this.thumbnails[index]) {
       this.thumbnails[index].isActive = true;
-      this.thumbnails[index].element.classList.add('canvas-thumbnail--active');
+      this.thumbnails[index].element.classList.add("canvas-thumbnail--active");
       this.currentCanvasIndex = index;
     }
   }
@@ -200,10 +215,13 @@ export class CanvasNavigator {
   /**
    * Get canvas type name for display
    */
-  private getCanvasTypeName(_sessionNumber: number, canvasNumber: number): string {
-    if (canvasNumber === 1) return 'Opening';
-    if (canvasNumber === 2) return 'Development';
-    if (canvasNumber === 3) return 'Closing';
+  private getCanvasTypeName(
+    _sessionNumber: number,
+    canvasNumber: number,
+  ): string {
+    if (canvasNumber === 1) return "Opening";
+    if (canvasNumber === 2) return "Development";
+    if (canvasNumber === 3) return "Closing";
     return `Canvas ${canvasNumber}`;
   }
 

--- a/src/scripts/coursebuilder/layout/CourseLayoutFactory.ts
+++ b/src/scripts/coursebuilder/layout/CourseLayoutFactory.ts
@@ -4,12 +4,12 @@
  * This is the main interface that replaces the monolithic LayoutManager
  */
 
-import type { CourseLayout, CanvasLayout, LayoutBlock } from './LayoutTypes';
-import { LayoutCalculator } from './LayoutCalculator';
-import { CanvasNavigator } from './CanvasNavigator';
-import { LayoutRenderer } from './LayoutRenderer';
-import { DEFAULT_BLOCKS } from './LayoutTypes';
-import { Container } from 'pixi.js';
+import type { CourseLayout, CanvasLayout, LayoutBlock } from "./LayoutTypes";
+import { LayoutCalculator } from "./LayoutCalculator";
+import { CanvasNavigator } from "./CanvasNavigator";
+import { LayoutRenderer } from "./LayoutRenderer";
+import { DEFAULT_BLOCKS } from "./LayoutTypes";
+import { Container } from "pixi.js";
 
 export class CourseLayoutFactory {
   private canvasWidth: number;
@@ -18,15 +18,17 @@ export class CourseLayoutFactory {
   private renderer: LayoutRenderer | null = null;
 
   constructor(
-    canvasWidth: number = 794, 
+    canvasWidth: number = 794,
     canvasHeight: number = 1123,
-    tocContainerId: string = 'coursebuilder__toc'
+    tocContainerId: string = "coursebuilder__toc",
   ) {
     this.canvasWidth = canvasWidth;
     this.canvasHeight = canvasHeight;
     this.navigator = new CanvasNavigator(tocContainerId);
-    
-    console.log(`🏭 CourseLayoutFactory created with dimensions: ${this.canvasWidth}x${this.canvasHeight}`);
+
+    console.log(
+      `🏭 CourseLayoutFactory created with dimensions: ${this.canvasWidth}x${this.canvasHeight}`,
+    );
   }
 
   /**
@@ -37,13 +39,20 @@ export class CourseLayoutFactory {
     templateId: string,
     scheduledSessions: number,
     lessonDurationMinutes: number,
-    customBlocks?: LayoutBlock[]
+    customBlocks?: LayoutBlock[],
   ): CourseLayout {
     const blocks = customBlocks || DEFAULT_BLOCKS;
-    const totalCanvases = LayoutCalculator.calculateTotalCanvases(scheduledSessions, lessonDurationMinutes);
-    const lessonDuration = LayoutCalculator.determineLessonDuration(lessonDurationMinutes);
+    const totalCanvases = LayoutCalculator.calculateTotalCanvases(
+      scheduledSessions,
+      lessonDurationMinutes,
+    );
+    const lessonDuration = LayoutCalculator.determineLessonDuration(
+      lessonDurationMinutes,
+    );
 
-    console.log(`🏗️ Creating course layout: ${totalCanvases} canvases for ${scheduledSessions} sessions`);
+    console.log(
+      `🏗️ Creating course layout: ${totalCanvases} canvases for ${scheduledSessions} sessions`,
+    );
 
     // Create all canvas layouts
     const canvases: CanvasLayout[] = [];
@@ -55,7 +64,7 @@ export class CourseLayoutFactory {
         `${courseId}-canvas-${i + 1}`,
         sessionNumber,
         canvasNumber,
-        blocks
+        blocks,
       );
       canvases.push(canvas);
 
@@ -74,7 +83,7 @@ export class CourseLayoutFactory {
       totalCanvases,
       scheduledSessions,
       lessonDuration,
-      canvases
+      canvases,
     };
 
     // Generate navigation
@@ -90,19 +99,19 @@ export class CourseLayoutFactory {
     canvasId: string,
     sessionNumber: number,
     canvasNumber: number,
-    blocks: LayoutBlock[]
+    blocks: LayoutBlock[],
   ): CanvasLayout {
     const renderedBlocks = LayoutCalculator.calculateBlockPositions(
       blocks,
       this.canvasWidth,
-      this.canvasHeight
+      this.canvasHeight,
     );
 
     return {
       id: canvasId,
       sessionNumber,
       canvasNumber,
-      blocks: renderedBlocks
+      blocks: renderedBlocks,
     };
   }
 
@@ -118,7 +127,9 @@ export class CourseLayoutFactory {
    */
   renderLayout(canvasLayout: CanvasLayout, showLabels: boolean = true): void {
     if (!this.renderer) {
-      throw new Error('Renderer not initialized. Call initializeRenderer() first.');
+      throw new Error(
+        "Renderer not initialized. Call initializeRenderer() first.",
+      );
     }
     this.renderer.renderLayoutStructure(canvasLayout.blocks, showLabels);
   }
@@ -149,7 +160,13 @@ export class CourseLayoutFactory {
   /**
    * Calculate total canvases (static utility)
    */
-  static calculateTotalCanvases(scheduledSessions: number, lessonDurationMinutes: number): number {
-    return LayoutCalculator.calculateTotalCanvases(scheduledSessions, lessonDurationMinutes);
+  static calculateTotalCanvases(
+    scheduledSessions: number,
+    lessonDurationMinutes: number,
+  ): number {
+    return LayoutCalculator.calculateTotalCanvases(
+      scheduledSessions,
+      lessonDurationMinutes,
+    );
   }
 }

--- a/src/scripts/coursebuilder/layout/LayoutCalculator.ts
+++ b/src/scripts/coursebuilder/layout/LayoutCalculator.ts
@@ -4,14 +4,22 @@
  * Pure functions - no state, no side effects
  */
 
-import type { LayoutBlock, RenderedBlock, RenderedArea, LessonDuration } from './LayoutTypes';
-import { LESSON_DURATIONS } from './LayoutTypes';
+import type {
+  LayoutBlock,
+  RenderedBlock,
+  RenderedArea,
+  LessonDuration,
+} from "./LayoutTypes";
+import { LESSON_DURATIONS } from "./LayoutTypes";
 
 export class LayoutCalculator {
   /**
    * Calculate total canvases needed for a course
    */
-  static calculateTotalCanvases(scheduledSessions: number, lessonDurationMinutes: number): number {
+  static calculateTotalCanvases(
+    scheduledSessions: number,
+    lessonDurationMinutes: number,
+  ): number {
     const lessonDuration = this.determineLessonDuration(lessonDurationMinutes);
     return Math.ceil(scheduledSessions * lessonDuration.canvasMultiplier);
   }
@@ -20,34 +28,46 @@ export class LayoutCalculator {
    * Determine lesson duration type based on minutes
    */
   static determineLessonDuration(minutes: number): LessonDuration {
-    return LESSON_DURATIONS.find(duration => minutes <= duration.maxMinutes) 
-           || LESSON_DURATIONS[LESSON_DURATIONS.length - 1];
+    return (
+      LESSON_DURATIONS.find((duration) => minutes <= duration.maxMinutes) ||
+      LESSON_DURATIONS[LESSON_DURATIONS.length - 1]
+    );
   }
 
   /**
    * Calculate block positions within canvas
    */
   static calculateBlockPositions(
-    blocks: LayoutBlock[], 
-    canvasWidth: number, 
+    blocks: LayoutBlock[],
+    canvasWidth: number,
     canvasHeight: number,
-    margins = { top: 40, bottom: 40, left: 60, right: 60 }
+    margins = { top: 40, bottom: 40, left: 60, right: 60 },
   ): RenderedBlock[] {
     const availableWidth = canvasWidth - margins.left - margins.right;
     const availableHeight = canvasHeight - margins.top - margins.bottom;
     let currentY = margins.top;
 
-    return blocks.map(block => {
+    return blocks.map((block) => {
       const blockHeight = (availableHeight * block.heightPercentage) / 100;
-      
+
       // Header and Footer span full width, others use margin constraints
-      const isFullWidth = block.id === 'header' || block.id === 'footer';
+      const isFullWidth = block.id === "header" || block.id === "footer";
       const blockX = isFullWidth ? 0 : margins.left;
       const blockWidth = isFullWidth ? canvasWidth : availableWidth;
-      const blockY = isFullWidth ? (block.id === 'header' ? 0 : currentY) : currentY;
+      const blockY = isFullWidth
+        ? block.id === "header"
+          ? 0
+          : currentY
+        : currentY;
 
       // Calculate canvas areas within the block
-      const areas = this.calculateCanvasAreas(block, blockX, blockY, blockWidth, blockHeight);
+      const areas = this.calculateCanvasAreas(
+        block,
+        blockX,
+        blockY,
+        blockWidth,
+        blockHeight,
+      );
 
       const renderedBlock: RenderedBlock = {
         blockId: block.id,
@@ -55,13 +75,13 @@ export class LayoutCalculator {
         y: blockY,
         width: blockWidth,
         height: blockHeight,
-        areas
+        areas,
       };
 
       // Update Y position for next block
-      if (block.id === 'header') {
+      if (block.id === "header") {
         currentY = blockHeight; // Next block starts after header
-      } else if (block.id !== 'footer') {
+      } else if (block.id !== "footer") {
         currentY += blockHeight;
       }
 
@@ -73,24 +93,24 @@ export class LayoutCalculator {
    * Calculate canvas areas within a block
    */
   private static calculateCanvasAreas(
-    block: LayoutBlock, 
-    blockX: number, 
-    blockY: number, 
-    blockWidth: number, 
-    blockHeight: number
+    block: LayoutBlock,
+    blockX: number,
+    blockY: number,
+    blockWidth: number,
+    blockHeight: number,
   ): RenderedArea[] {
     if (!block.canvasAreas || block.canvasAreas.length === 0) {
       return [];
     }
 
     const areaHeight = blockHeight / block.canvasAreas.length;
-    
+
     return block.canvasAreas.map((area, index) => ({
       areaId: area.id,
       x: blockX + 10, // Small padding
-      y: blockY + (index * areaHeight) + 10,
+      y: blockY + index * areaHeight + 10,
       width: blockWidth - 20,
-      height: areaHeight - 20
+      height: areaHeight - 20,
     }));
   }
 
@@ -104,11 +124,11 @@ export class LayoutCalculator {
     // Base A4-like dimensions
     const baseWidth = 794;
     const baseHeight = 1123;
-    
+
     // Adjust based on lesson duration if needed
     return {
       width: baseWidth,
-      height: Math.floor(baseHeight * lessonDuration.canvasMultiplier)
+      height: Math.floor(baseHeight * lessonDuration.canvasMultiplier),
     };
   }
 }

--- a/src/scripts/coursebuilder/layout/LayoutRenderer.ts
+++ b/src/scripts/coursebuilder/layout/LayoutRenderer.ts
@@ -4,8 +4,8 @@
  * Focused on visual rendering only
  */
 
-import { Container, Graphics, Text, TextStyle } from 'pixi.js';
-import type { RenderedBlock, RenderedArea } from './LayoutTypes';
+import { Container, Graphics, Text, TextStyle } from "pixi.js";
+import type { RenderedBlock, RenderedArea } from "./LayoutTypes";
 
 export class LayoutRenderer {
   private layoutContainer: Container;
@@ -17,14 +17,19 @@ export class LayoutRenderer {
   /**
    * Render complete layout structure
    */
-  renderLayoutStructure(renderedBlocks: RenderedBlock[], showLabels: boolean = true): void {
+  renderLayoutStructure(
+    renderedBlocks: RenderedBlock[],
+    showLabels: boolean = true,
+  ): void {
     // Clear previous rendering
     this.layoutContainer.removeChildren();
 
-    console.log(`🎨 Rendering ${renderedBlocks.length} blocks with labels: ${showLabels}`);
+    console.log(
+      `🎨 Rendering ${renderedBlocks.length} blocks with labels: ${showLabels}`,
+    );
 
     // Render each block
-    renderedBlocks.forEach(block => {
+    renderedBlocks.forEach((block) => {
       this.renderBlock(block, showLabels);
     });
   }
@@ -36,9 +41,16 @@ export class LayoutRenderer {
     // Block background
     const blockGraphics = new Graphics();
     blockGraphics.rect(block.x, block.y, block.width, block.height);
-    blockGraphics.fill({ color: this.getBlockColor(block.blockId), alpha: 0.1 });
-    blockGraphics.stroke({ width: 2, color: this.getBlockColor(block.blockId), alpha: 0.8 });
-    
+    blockGraphics.fill({
+      color: this.getBlockColor(block.blockId),
+      alpha: 0.1,
+    });
+    blockGraphics.stroke({
+      width: 2,
+      color: this.getBlockColor(block.blockId),
+      alpha: 0.8,
+    });
+
     blockGraphics.label = `layout-block-${block.blockId}`;
     blockGraphics.interactive = false; // Prevent user interaction
     this.layoutContainer.addChild(blockGraphics);
@@ -50,11 +62,11 @@ export class LayoutRenderer {
         style: new TextStyle({
           fontSize: 16,
           fill: this.getBlockColor(block.blockId),
-          fontWeight: 'bold',
-          fontFamily: 'Arial'
-        })
+          fontWeight: "bold",
+          fontFamily: "Arial",
+        }),
       });
-      
+
       blockLabel.position.set(block.x + 10, block.y + 5);
       blockLabel.label = `layout-block-label-${block.blockId}`;
       blockLabel.interactive = false;
@@ -62,7 +74,7 @@ export class LayoutRenderer {
     }
 
     // Render areas within the block
-    block.areas.forEach(area => {
+    block.areas.forEach((area) => {
       this.renderArea(area, showLabels);
     });
   }
@@ -76,7 +88,7 @@ export class LayoutRenderer {
     areaGraphics.rect(area.x, area.y, area.width, area.height);
     areaGraphics.fill({ color: 0xffffff, alpha: 0.5 });
     areaGraphics.stroke({ width: 1, color: 0x999999, alpha: 0.4 });
-    
+
     areaGraphics.label = `layout-area-${area.areaId}`;
     areaGraphics.interactive = false; // Prevent user interaction
     this.layoutContainer.addChild(areaGraphics);
@@ -88,10 +100,10 @@ export class LayoutRenderer {
         style: new TextStyle({
           fontSize: 12,
           fill: 0x666666,
-          fontFamily: 'Arial'
-        })
+          fontFamily: "Arial",
+        }),
       });
-      
+
       areaLabel.position.set(area.x + 5, area.y + 5);
       areaLabel.label = `layout-area-label-${area.areaId}`;
       areaLabel.interactive = false;
@@ -109,7 +121,7 @@ export class LayoutRenderer {
       resources: 0xf5a623,
       content: 0xd0021b,
       assignment: 0x9013fe,
-      footer: 0x50e3c2
+      footer: 0x50e3c2,
     };
     return colors[blockId] || 0x999999;
   }
@@ -119,12 +131,12 @@ export class LayoutRenderer {
    */
   private getBlockDisplayName(blockId: string): string {
     const names: Record<string, string> = {
-      header: 'Header',
-      program: 'Program',
-      resources: 'Resources', 
-      content: 'Content',
-      assignment: 'Assignment',
-      footer: 'Footer'
+      header: "Header",
+      program: "Program",
+      resources: "Resources",
+      content: "Content",
+      assignment: "Assignment",
+      footer: "Footer",
     };
     return names[blockId] || blockId;
   }
@@ -135,9 +147,9 @@ export class LayoutRenderer {
   private getAreaDisplayName(areaId: string): string {
     // Convert kebab-case to Title Case
     return areaId
-      .split('-')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
   }
 
   /**

--- a/src/scripts/coursebuilder/layout/LayoutTypes.ts
+++ b/src/scripts/coursebuilder/layout/LayoutTypes.ts
@@ -10,12 +10,17 @@ export interface LayoutBlock {
   isRequired: boolean;
   canvasAreas?: CanvasArea[];
   // PixiJS Layout v3 compatibility
-  type?: 'header' | 'content' | 'resources' | 'assignment' | 'footer';
+  type?: "header" | "content" | "resources" | "assignment" | "footer";
   styles?: {
-    display?: 'flex' | 'none';
-    flexDirection?: 'row' | 'column';
-    justifyContent?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around';
-    alignItems?: 'flex-start' | 'flex-end' | 'center' | 'stretch';
+    display?: "flex" | "none";
+    flexDirection?: "row" | "column";
+    justifyContent?:
+      | "flex-start"
+      | "flex-end"
+      | "center"
+      | "space-between"
+      | "space-around";
+    alignItems?: "flex-start" | "flex-end" | "center" | "stretch";
     backgroundColor?: string;
     borderRadius?: number;
     padding?: number;
@@ -29,14 +34,14 @@ export interface LayoutBlock {
 export interface CanvasArea {
   id: string;
   name: string;
-  type: 'instruction' | 'student' | 'teacher';
+  type: "instruction" | "student" | "teacher";
   allowsDrawing: boolean;
   allowsMedia: boolean;
   allowsText: boolean;
 }
 
 export interface LessonDuration {
-  type: 'mini' | 'regular' | 'double' | 'triple' | 'longer';
+  type: "mini" | "regular" | "double" | "triple" | "longer";
   maxMinutes: number;
   canvasMultiplier: number;
 }
@@ -87,132 +92,132 @@ export interface RenderedArea {
 // Default layout blocks with their proportions
 export const DEFAULT_BLOCKS: LayoutBlock[] = [
   {
-    id: 'header',
-    name: 'Header',
+    id: "header",
+    name: "Header",
     heightPercentage: 8,
     isRequired: true,
     canvasAreas: [
       {
-        id: 'header-instruction-title',
-        name: 'Instruction Title',
-        type: 'instruction',
+        id: "header-instruction-title",
+        name: "Instruction Title",
+        type: "instruction",
         allowsDrawing: false,
         allowsMedia: false,
-        allowsText: true
+        allowsText: true,
       },
       {
-        id: 'header-content-area',
-        name: 'Header Content',
-        type: 'teacher',
+        id: "header-content-area",
+        name: "Header Content",
+        type: "teacher",
         allowsDrawing: false,
         allowsMedia: false,
-        allowsText: true
-      }
-    ]
+        allowsText: true,
+      },
+    ],
   },
   {
-    id: 'program',
-    name: 'Program',
+    id: "program",
+    name: "Program",
     heightPercentage: 15,
     isRequired: true,
     canvasAreas: [
       {
-        id: 'program-instruction-area',
-        name: 'Instruction Area',
-        type: 'instruction',
+        id: "program-instruction-area",
+        name: "Instruction Area",
+        type: "instruction",
         allowsDrawing: true,
         allowsMedia: true,
-        allowsText: true
-      }
-    ]
+        allowsText: true,
+      },
+    ],
   },
   {
-    id: 'resources',
-    name: 'Resources',
+    id: "resources",
+    name: "Resources",
     heightPercentage: 12,
     isRequired: false,
     canvasAreas: [
       {
-        id: 'resources-student-title',
-        name: 'Student Title',
-        type: 'student',
+        id: "resources-student-title",
+        name: "Student Title",
+        type: "student",
         allowsDrawing: false,
         allowsMedia: false,
-        allowsText: true
+        allowsText: true,
       },
       {
-        id: 'resources-student-area',
-        name: 'Student Area',
-        type: 'student',
+        id: "resources-student-area",
+        name: "Student Area",
+        type: "student",
         allowsDrawing: true,
         allowsMedia: true,
-        allowsText: true
-      }
-    ]
+        allowsText: true,
+      },
+    ],
   },
   {
-    id: 'content',
-    name: 'Content',
+    id: "content",
+    name: "Content",
     heightPercentage: 50,
     isRequired: true,
     canvasAreas: [
       {
-        id: 'content-teacher-title',
-        name: 'Teacher Title',
-        type: 'teacher',
+        id: "content-teacher-title",
+        name: "Teacher Title",
+        type: "teacher",
         allowsDrawing: false,
         allowsMedia: false,
-        allowsText: true
+        allowsText: true,
       },
       {
-        id: 'content-teacher-area',
-        name: 'Teacher Area',
-        type: 'teacher',
+        id: "content-teacher-area",
+        name: "Teacher Area",
+        type: "teacher",
         allowsDrawing: true,
         allowsMedia: true,
-        allowsText: true
-      }
-    ]
+        allowsText: true,
+      },
+    ],
   },
   {
-    id: 'assignment',
-    name: 'Assignment',
+    id: "assignment",
+    name: "Assignment",
     heightPercentage: 10,
     isRequired: false,
     canvasAreas: [
       {
-        id: 'assignment-instruction-area',
-        name: 'Instruction Area',
-        type: 'instruction',
+        id: "assignment-instruction-area",
+        name: "Instruction Area",
+        type: "instruction",
         allowsDrawing: true,
         allowsMedia: true,
-        allowsText: true
-      }
-    ]
+        allowsText: true,
+      },
+    ],
   },
   {
-    id: 'footer',
-    name: 'Footer',
+    id: "footer",
+    name: "Footer",
     heightPercentage: 5,
     isRequired: true,
     canvasAreas: [
       {
-        id: 'footer-content-area',
-        name: 'Footer Content',
-        type: 'instruction',
+        id: "footer-content-area",
+        name: "Footer Content",
+        type: "instruction",
         allowsDrawing: false,
         allowsMedia: false,
-        allowsText: true
-      }
-    ]
-  }
+        allowsText: true,
+      },
+    ],
+  },
 ];
 
 // Lesson duration configurations
 export const LESSON_DURATIONS: LessonDuration[] = [
-  { type: 'mini', maxMinutes: 30, canvasMultiplier: 1 },
-  { type: 'regular', maxMinutes: 60, canvasMultiplier: 2 },
-  { type: 'double', maxMinutes: 120, canvasMultiplier: 4 },
-  { type: 'triple', maxMinutes: 180, canvasMultiplier: 8 },
-  { type: 'longer', maxMinutes: 999, canvasMultiplier: 16 }
+  { type: "mini", maxMinutes: 30, canvasMultiplier: 1 },
+  { type: "regular", maxMinutes: 60, canvasMultiplier: 2 },
+  { type: "double", maxMinutes: 120, canvasMultiplier: 4 },
+  { type: "triple", maxMinutes: 180, canvasMultiplier: 8 },
+  { type: "longer", maxMinutes: 999, canvasMultiplier: 16 },
 ];

--- a/src/scripts/coursebuilder/managers/MarginSettingsManager.ts
+++ b/src/scripts/coursebuilder/managers/MarginSettingsManager.ts
@@ -4,7 +4,7 @@
  * Single Responsibility: Margin configuration and UI updates only
  */
 
-import { marginSettingsHandler } from '../../backend/courses/marginSettings';
+import { marginSettingsHandler } from "../../backend/courses/marginSettings";
 
 export class MarginSettingsManager {
   private marginInputs: { [key: string]: HTMLInputElement } = {};
@@ -12,9 +12,11 @@ export class MarginSettingsManager {
     top: 20,
     right: 20,
     bottom: 20,
-    left: 20
+    left: 20,
   };
-  private onMarginChangeCallback: ((margins: { [key: string]: number }) => void) | null = null;
+  private onMarginChangeCallback:
+    | ((margins: { [key: string]: number }) => void)
+    | null = null;
 
   constructor() {
     this.initializeMarginInputs();
@@ -24,7 +26,9 @@ export class MarginSettingsManager {
   /**
    * Set callback for margin changes
    */
-  setOnMarginChange(callback: (margins: { [key: string]: number }) => void): void {
+  setOnMarginChange(
+    callback: (margins: { [key: string]: number }) => void,
+  ): void {
     this.onMarginChangeCallback = callback;
   }
 
@@ -40,12 +44,17 @@ export class MarginSettingsManager {
    * Initialize margin input elements
    */
   private initializeMarginInputs(): void {
-    const marginInputIds = ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'];
-    
-    marginInputIds.forEach(id => {
+    const marginInputIds = [
+      "marginTop",
+      "marginRight",
+      "marginBottom",
+      "marginLeft",
+    ];
+
+    marginInputIds.forEach((id) => {
       const input = document.getElementById(id) as HTMLInputElement;
       if (input) {
-        const marginKey = id.replace('margin', '').toLowerCase();
+        const marginKey = id.replace("margin", "").toLowerCase();
         this.marginInputs[marginKey] = input;
         input.value = this.marginValues[marginKey].toString();
       }
@@ -59,10 +68,10 @@ export class MarginSettingsManager {
     Object.entries(this.marginInputs).forEach(([key, input]) => {
       const inputHandler = () => this.handleMarginChange(key, input);
       const changeHandler = () => this.handleMarginChange(key, input);
-      
-      input.addEventListener('input', inputHandler);
-      input.addEventListener('change', changeHandler);
-      
+
+      input.addEventListener("input", inputHandler);
+      input.addEventListener("change", changeHandler);
+
       // Store handlers for cleanup
       (input as any).__inputHandler = inputHandler;
       (input as any).__changeHandler = changeHandler;
@@ -75,12 +84,12 @@ export class MarginSettingsManager {
   private handleMarginChange(marginKey: string, input: HTMLInputElement): void {
     const value = parseInt(input.value) || 0;
     this.marginValues[marginKey] = Math.max(0, value); // Ensure non-negative
-    
+
     // Update input value to reflect clamped value
     input.value = this.marginValues[marginKey].toString();
-    
+
     console.log(`📐 Margin ${marginKey}: ${this.marginValues[marginKey]}px`);
-    
+
     // Trigger callback
     if (this.onMarginChangeCallback) {
       this.onMarginChangeCallback({ ...this.marginValues });
@@ -101,16 +110,16 @@ export class MarginSettingsManager {
     Object.entries(margins).forEach(([key, value]) => {
       if (key in this.marginValues) {
         this.marginValues[key] = Math.max(0, value);
-        
+
         // Update input if it exists
         if (this.marginInputs[key]) {
           this.marginInputs[key].value = this.marginValues[key].toString();
         }
       }
     });
-    
-    console.log('📐 Margins updated:', this.marginValues);
-    
+
+    console.log("📐 Margins updated:", this.marginValues);
+
     // Trigger callback
     if (this.onMarginChangeCallback) {
       this.onMarginChangeCallback({ ...this.marginValues });
@@ -123,14 +132,15 @@ export class MarginSettingsManager {
   setMargin(marginKey: string, value: number): void {
     if (marginKey in this.marginValues) {
       this.marginValues[marginKey] = Math.max(0, value);
-      
+
       // Update input if it exists
       if (this.marginInputs[marginKey]) {
-        this.marginInputs[marginKey].value = this.marginValues[marginKey].toString();
+        this.marginInputs[marginKey].value =
+          this.marginValues[marginKey].toString();
       }
-      
+
       console.log(`📐 Margin ${marginKey}: ${this.marginValues[marginKey]}px`);
-      
+
       // Trigger callback
       if (this.onMarginChangeCallback) {
         this.onMarginChangeCallback({ ...this.marginValues });
@@ -166,7 +176,7 @@ export class MarginSettingsManager {
    */
   areMarginosUniform(): boolean {
     const values = Object.values(this.marginValues);
-    return values.every(value => value === values[0]);
+    return values.every((value) => value === values[0]);
   }
 
   /**
@@ -180,7 +190,7 @@ export class MarginSettingsManager {
    * Remove margins from element
    */
   removeMarginsFromElement(element: HTMLElement): void {
-    element.style.margin = '';
+    element.style.margin = "";
   }
 
   /**
@@ -213,18 +223,18 @@ export class MarginSettingsManager {
    */
   destroy(): void {
     // Remove event listeners
-    Object.values(this.marginInputs).forEach(input => {
+    Object.values(this.marginInputs).forEach((input) => {
       const inputHandler = (input as any).__inputHandler;
       const changeHandler = (input as any).__changeHandler;
-      
+
       if (inputHandler) {
-        input.removeEventListener('input', inputHandler);
+        input.removeEventListener("input", inputHandler);
       }
       if (changeHandler) {
-        input.removeEventListener('change', changeHandler);
+        input.removeEventListener("change", changeHandler);
       }
     });
-    
+
     this.marginInputs = {};
     this.onMarginChangeCallback = null;
   }

--- a/src/scripts/coursebuilder/managers/PageManager.ts
+++ b/src/scripts/coursebuilder/managers/PageManager.ts
@@ -4,11 +4,16 @@
  * Single Responsibility: Page data structure and core operations only
  */
 
-import { PageSettingsModal } from '../modals/PageSettingsModal';
-import { PageNavigationController } from './PageNavigationController.js';
+import { PageSettingsModal } from "../modals/PageSettingsModal";
+import { PageNavigationController } from "./PageNavigationController.js";
 
 export class PageManager {
-  private pages: Array<{ id: string; name: string; content: any; description?: string }> = [];
+  private pages: Array<{
+    id: string;
+    name: string;
+    content: any;
+    description?: string;
+  }> = [];
   private pageSettingsModal: PageSettingsModal;
   private navigationController: PageNavigationController;
   private onPageChangeCallback: ((page: any) => void) | null = null;
@@ -17,7 +22,7 @@ export class PageManager {
   constructor() {
     this.pageSettingsModal = new PageSettingsModal();
     this.navigationController = new PageNavigationController();
-    
+
     this.initializeFirstPage();
     this.bindCoreEvents();
     this.setupNavigationCallbacks();
@@ -43,14 +48,14 @@ export class PageManager {
   private initializeFirstPage(): void {
     const firstPage = {
       id: this.generatePageId(),
-      name: 'Page 1',
+      name: "Page 1",
       content: null,
-      description: ''
+      description: "",
     };
-    
+
     this.pages.push(firstPage);
     this.navigationController.setTotalPages(1);
-    console.log('📄 First page initialized:', firstPage.id);
+    console.log("📄 First page initialized:", firstPage.id);
   }
 
   /**
@@ -58,15 +63,18 @@ export class PageManager {
    */
   private bindCoreEvents(): void {
     // Add page button
-    const addPageBtn = document.getElementById('add-page');
+    const addPageBtn = document.getElementById("add-page");
     if (addPageBtn) {
-      addPageBtn.addEventListener('click', this.addNewPage.bind(this));
+      addPageBtn.addEventListener("click", this.addNewPage.bind(this));
     }
 
     // Page settings button
-    const pageSettingsBtn = document.getElementById('page-settings');
+    const pageSettingsBtn = document.getElementById("page-settings");
     if (pageSettingsBtn) {
-      pageSettingsBtn.addEventListener('click', this.openPageSettings.bind(this));
+      pageSettingsBtn.addEventListener(
+        "click",
+        this.openPageSettings.bind(this),
+      );
     }
   }
 
@@ -90,17 +98,17 @@ export class PageManager {
       id: this.generatePageId(),
       name: `Page ${this.pages.length + 1}`,
       content: null,
-      description: ''
+      description: "",
     };
 
     this.pages.push(newPage);
     this.navigationController.setTotalPages(this.pages.length);
     this.navigationController.updatePageSelector(this.pages);
-    
+
     // Switch to new page
     this.navigationController.setCurrentPage(this.pages.length - 1);
-    
-    console.log('📄 New page added:', newPage.id);
+
+    console.log("📄 New page added:", newPage.id);
 
     // Trigger callbacks
     if (this.onPageAddCallback) {
@@ -117,18 +125,18 @@ export class PageManager {
   async openPageSettings(): Promise<void> {
     const currentPage = this.getCurrentPage();
     if (!currentPage) return;
-    
+
     try {
-      console.log('⚙️ Opening page settings for:', currentPage.id);
+      console.log("⚙️ Opening page settings for:", currentPage.id);
       const updatedPage = await this.pageSettingsModal.show(currentPage);
-      
+
       // Update page data
       Object.assign(currentPage, updatedPage);
       this.navigationController.updatePageSelector(this.pages);
-      
-      console.log('💾 Page settings updated:', currentPage.id);
+
+      console.log("💾 Page settings updated:", currentPage.id);
     } catch (error) {
-      console.log('❌ Page settings cancelled');
+      console.log("❌ Page settings cancelled");
     }
   }
 
@@ -172,13 +180,17 @@ export class PageManager {
    * Remove page by index
    */
   removePage(pageIndex: number): void {
-    if (pageIndex >= 0 && pageIndex < this.pages.length && this.pages.length > 1) {
+    if (
+      pageIndex >= 0 &&
+      pageIndex < this.pages.length &&
+      this.pages.length > 1
+    ) {
       const removedPage = this.pages.splice(pageIndex, 1)[0];
-      
+
       this.navigationController.setTotalPages(this.pages.length);
       this.navigationController.updatePageSelector(this.pages);
-      
-      console.log('🗑️ Page removed:', removedPage.id);
+
+      console.log("🗑️ Page removed:", removedPage.id);
     }
   }
 
@@ -189,7 +201,7 @@ export class PageManager {
     const currentPage = this.getCurrentPage();
     if (currentPage) {
       currentPage.content = content;
-      console.log('💾 Page content saved:', currentPage.id);
+      console.log("💾 Page content saved:", currentPage.id);
     }
   }
 
@@ -197,7 +209,7 @@ export class PageManager {
    * Get page by ID
    */
   getPageById(pageId: string): any {
-    return this.pages.find(page => page.id === pageId);
+    return this.pages.find((page) => page.id === pageId);
   }
 
   /**

--- a/src/scripts/coursebuilder/managers/PageNavigationController.ts
+++ b/src/scripts/coursebuilder/managers/PageNavigationController.ts
@@ -25,25 +25,33 @@ export class PageNavigationController {
    */
   private bindNavigationEvents(): void {
     // Previous page button
-    const prevPageBtn = document.getElementById('prev-page');
+    const prevPageBtn = document.getElementById("prev-page");
     if (prevPageBtn) {
-      prevPageBtn.addEventListener('click', this.goToPreviousPage.bind(this));
+      prevPageBtn.addEventListener("click", this.goToPreviousPage.bind(this));
     }
 
     // Next page button
-    const nextPageBtn = document.getElementById('next-page');
+    const nextPageBtn = document.getElementById("next-page");
     if (nextPageBtn) {
-      nextPageBtn.addEventListener('click', this.goToNextPage.bind(this));
+      nextPageBtn.addEventListener("click", this.goToNextPage.bind(this));
     }
 
     // Page selector dropdown
-    const pageSelector = document.getElementById('page-selector') as HTMLSelectElement;
+    const pageSelector = document.getElementById(
+      "page-selector",
+    ) as HTMLSelectElement;
     if (pageSelector) {
-      pageSelector.addEventListener('change', this.handlePageSelection.bind(this));
+      pageSelector.addEventListener(
+        "change",
+        this.handlePageSelection.bind(this),
+      );
     }
 
     // Keyboard navigation
-    document.addEventListener('keydown', this.handleKeyboardNavigation.bind(this));
+    document.addEventListener(
+      "keydown",
+      this.handleKeyboardNavigation.bind(this),
+    );
   }
 
   /**
@@ -51,18 +59,20 @@ export class PageNavigationController {
    */
   private handleKeyboardNavigation(event: KeyboardEvent): void {
     // Only handle navigation if no input elements are focused
-    if (document.activeElement?.tagName === 'INPUT' || 
-        document.activeElement?.tagName === 'TEXTAREA') {
+    if (
+      document.activeElement?.tagName === "INPUT" ||
+      document.activeElement?.tagName === "TEXTAREA"
+    ) {
       return;
     }
 
     if (event.ctrlKey || event.metaKey) {
       switch (event.key) {
-        case 'ArrowLeft':
+        case "ArrowLeft":
           event.preventDefault();
           this.goToPreviousPage();
           break;
-        case 'ArrowRight':
+        case "ArrowRight":
           event.preventDefault();
           this.goToNextPage();
           break;
@@ -76,7 +86,7 @@ export class PageNavigationController {
   goToPreviousPage(): void {
     if (this.currentPageIndex > 0) {
       this.setCurrentPage(this.currentPageIndex - 1);
-      console.log('⬅️ Previous page');
+      console.log("⬅️ Previous page");
     }
   }
 
@@ -86,7 +96,7 @@ export class PageNavigationController {
   goToNextPage(): void {
     if (this.currentPageIndex < this.totalPages - 1) {
       this.setCurrentPage(this.currentPageIndex + 1);
-      console.log('➡️ Next page');
+      console.log("➡️ Next page");
     }
   }
 
@@ -96,10 +106,10 @@ export class PageNavigationController {
   private handlePageSelection(event: Event): void {
     const select = event.target as HTMLSelectElement;
     const selectedIndex = parseInt(select.value);
-    
+
     if (selectedIndex >= 0 && selectedIndex < this.totalPages) {
       this.setCurrentPage(selectedIndex);
-      console.log('🎯 Page selected:', selectedIndex + 1);
+      console.log("🎯 Page selected:", selectedIndex + 1);
     }
   }
 
@@ -110,7 +120,7 @@ export class PageNavigationController {
     if (pageIndex >= 0 && pageIndex < this.totalPages) {
       this.currentPageIndex = pageIndex;
       this.updateNavigationUI();
-      
+
       // Trigger callback
       if (this.onPageChangeCallback) {
         this.onPageChangeCallback(pageIndex);
@@ -123,12 +133,12 @@ export class PageNavigationController {
    */
   setTotalPages(count: number): void {
     this.totalPages = Math.max(1, count);
-    
+
     // Adjust current page if necessary
     if (this.currentPageIndex >= this.totalPages) {
       this.currentPageIndex = this.totalPages - 1;
     }
-    
+
     this.updateNavigationUI();
   }
 
@@ -136,12 +146,17 @@ export class PageNavigationController {
    * Update page selector with page names
    */
   updatePageSelector(pages: Array<{ name: string }>): void {
-    const pageSelector = document.getElementById('page-selector') as HTMLSelectElement;
+    const pageSelector = document.getElementById(
+      "page-selector",
+    ) as HTMLSelectElement;
     if (!pageSelector) return;
 
-    pageSelector.innerHTML = pages.map((page, index) => 
-      `<option value="${index}" ${index === this.currentPageIndex ? 'selected' : ''}>${page.name}</option>`
-    ).join('');
+    pageSelector.innerHTML = pages
+      .map(
+        (page, index) =>
+          `<option value="${index}" ${index === this.currentPageIndex ? "selected" : ""}>${page.name}</option>`,
+      )
+      .join("");
   }
 
   /**
@@ -149,21 +164,25 @@ export class PageNavigationController {
    */
   private updateNavigationUI(): void {
     // Update navigation buttons
-    const prevBtn = document.getElementById('prev-page') as HTMLButtonElement;
-    const nextBtn = document.getElementById('next-page') as HTMLButtonElement;
-    
+    const prevBtn = document.getElementById("prev-page") as HTMLButtonElement;
+    const nextBtn = document.getElementById("next-page") as HTMLButtonElement;
+
     if (prevBtn) {
       prevBtn.disabled = this.currentPageIndex === 0;
-      prevBtn.title = this.currentPageIndex === 0 ? 'First page' : 'Previous page';
+      prevBtn.title =
+        this.currentPageIndex === 0 ? "First page" : "Previous page";
     }
-    
+
     if (nextBtn) {
       nextBtn.disabled = this.currentPageIndex === this.totalPages - 1;
-      nextBtn.title = this.currentPageIndex === this.totalPages - 1 ? 'Last page' : 'Next page';
+      nextBtn.title =
+        this.currentPageIndex === this.totalPages - 1
+          ? "Last page"
+          : "Next page";
     }
 
     // Update page counter
-    const pageCounter = document.getElementById('page-counter');
+    const pageCounter = document.getElementById("page-counter");
     if (pageCounter) {
       pageCounter.textContent = `${this.currentPageIndex + 1} / ${this.totalPages}`;
     }
@@ -176,11 +195,12 @@ export class PageNavigationController {
    * Update progress indicator
    */
   private updateProgressIndicator(): void {
-    const progressBar = document.getElementById('page-progress');
+    const progressBar = document.getElementById("page-progress");
     if (progressBar) {
-      const progressPercentage = this.totalPages > 1 
-        ? (this.currentPageIndex / (this.totalPages - 1)) * 100 
-        : 100;
+      const progressPercentage =
+        this.totalPages > 1
+          ? (this.currentPageIndex / (this.totalPages - 1)) * 100
+          : 100;
       progressBar.style.width = `${progressPercentage}%`;
     }
   }
@@ -231,7 +251,7 @@ export class PageNavigationController {
    * Cleanup
    */
   destroy(): void {
-    document.removeEventListener('keydown', this.handleKeyboardNavigation);
+    document.removeEventListener("keydown", this.handleKeyboardNavigation);
     this.onPageChangeCallback = null;
   }
 }

--- a/src/scripts/coursebuilder/media/MediaManagerRefactored.ts
+++ b/src/scripts/coursebuilder/media/MediaManagerRefactored.ts
@@ -4,9 +4,9 @@
  * Single Responsibility: High-level media coordination only
  */
 
-import { MediaSelectionController } from './MediaSelectionController';
-import { MediaSearchController } from './MediaSearchController';
-import { MediaPanelManager } from './MediaPanelManager';
+import { MediaSelectionController } from "./MediaSelectionController";
+import { MediaSearchController } from "./MediaSearchController";
+import { MediaPanelManager } from "./MediaPanelManager";
 
 export class MediaManagerRefactored {
   private selectionController: MediaSelectionController;
@@ -18,7 +18,7 @@ export class MediaManagerRefactored {
     this.selectionController = new MediaSelectionController();
     this.searchController = new MediaSearchController();
     this.panelManager = new MediaPanelManager();
-    
+
     this.setupComponentCallbacks();
   }
 
@@ -30,7 +30,7 @@ export class MediaManagerRefactored {
     this.selectionController.setOnMediaSelection((mediaType: string) => {
       this.searchController.setMediaType(mediaType);
       this.panelManager.updateSearchPanel(mediaType);
-      
+
       // Trigger external callback
       if (this.onMediaSelectionCallback) {
         this.onMediaSelectionCallback(mediaType);
@@ -60,13 +60,13 @@ export class MediaManagerRefactored {
    */
   private addMediaToCanvas(mediaUrl: string): void {
     console.log(`➕ Adding media to canvas: ${mediaUrl}`);
-    
+
     // Dispatch event for canvas integration
-    const event = new CustomEvent('addMediaToCanvas', {
+    const event = new CustomEvent("addMediaToCanvas", {
       detail: {
         url: mediaUrl,
-        type: this.selectionController.getSelectedMediaType()
-      }
+        type: this.selectionController.getSelectedMediaType(),
+      },
     });
     document.dispatchEvent(event);
   }
@@ -79,7 +79,7 @@ export class MediaManagerRefactored {
       selectedMediaType: this.selectionController.getSelectedMediaType(),
       searchState: this.searchController.getSearchState(),
       panelOpen: this.panelManager.isPanelOpen(),
-      availableMediaTypes: this.selectionController.getAvailableMediaTypes()
+      availableMediaTypes: this.selectionController.getAvailableMediaTypes(),
     };
   }
 
@@ -90,7 +90,7 @@ export class MediaManagerRefactored {
     this.selectionController.clearSelection();
     this.searchController.clearSearch();
     this.panelManager.closePanel();
-    console.log('🧹 Media manager cleared');
+    console.log("🧹 Media manager cleared");
   }
 
   /**
@@ -101,6 +101,6 @@ export class MediaManagerRefactored {
     this.searchController.destroy();
     this.panelManager.destroy();
     this.onMediaSelectionCallback = null;
-    console.log('🗑️ Media manager destroyed');
+    console.log("🗑️ Media manager destroyed");
   }
 }

--- a/src/scripts/coursebuilder/media/MediaPanelManager.ts
+++ b/src/scripts/coursebuilder/media/MediaPanelManager.ts
@@ -17,8 +17,8 @@ export class MediaPanelManager {
    * Initialize panel elements
    */
   private initializePanelElements(): void {
-    this.panelElement = document.getElementById('media-search-panel');
-    this.resultsContainer = document.getElementById('media-search-results');
+    this.panelElement = document.getElementById("media-search-panel");
+    this.resultsContainer = document.getElementById("media-search-results");
   }
 
   /**
@@ -35,17 +35,17 @@ export class MediaPanelManager {
     if (!this.panelElement) return;
 
     // Update panel title
-    const panelTitle = this.panelElement.querySelector('.media-panel-title');
+    const panelTitle = this.panelElement.querySelector(".media-panel-title");
     if (panelTitle) {
       panelTitle.textContent = `Search ${mediaType.charAt(0).toUpperCase() + mediaType.slice(1)}`;
     }
 
     // Show panel
-    this.panelElement.classList.add('media-panel--active');
-    
+    this.panelElement.classList.add("media-panel--active");
+
     // Show placeholder
     this.showSearchPlaceholder();
-    
+
     console.log(`📱 Media search panel updated for: ${mediaType}`);
   }
 
@@ -56,7 +56,7 @@ export class MediaPanelManager {
     if (!this.resultsContainer) return;
 
     // Clear previous results
-    this.resultsContainer.innerHTML = '';
+    this.resultsContainer.innerHTML = "";
 
     if (results.length === 0) {
       this.showNoResults();
@@ -64,7 +64,7 @@ export class MediaPanelManager {
     }
 
     // Create result items
-    results.forEach(result => {
+    results.forEach((result) => {
       const resultItem = this.createResultItem(result);
       if (this.resultsContainer) {
         this.resultsContainer.appendChild(resultItem);
@@ -78,10 +78,10 @@ export class MediaPanelManager {
    * Create a result item element
    */
   private createResultItem(result: any): HTMLElement {
-    const item = document.createElement('div');
-    item.className = 'media-result-item';
-    item.setAttribute('data-media-url', result.url);
-    
+    const item = document.createElement("div");
+    item.className = "media-result-item";
+    item.setAttribute("data-media-url", result.url);
+
     item.innerHTML = `
       <img src="${result.thumbnail}" alt="${result.title}" class="media-result-thumbnail">
       <div class="media-result-info">
@@ -91,7 +91,7 @@ export class MediaPanelManager {
     `;
 
     // Add click handler
-    item.addEventListener('click', (event) => {
+    item.addEventListener("click", (event) => {
       this.handleMediaItemSelection(event);
     });
 
@@ -103,17 +103,17 @@ export class MediaPanelManager {
    */
   private handleMediaItemSelection(event: Event): void {
     const target = event.currentTarget as HTMLElement;
-    const mediaUrl = target.getAttribute('data-media-url');
-    
+    const mediaUrl = target.getAttribute("data-media-url");
+
     if (!mediaUrl) return;
 
     console.log(`📱 Media item selected: ${mediaUrl}`);
-    
+
     // Trigger callback
     if (this.onMediaSelectionCallback) {
       this.onMediaSelectionCallback(mediaUrl);
     }
-    
+
     // Close panel
     this.closePanel();
   }
@@ -150,21 +150,23 @@ export class MediaPanelManager {
   closePanel(): void {
     if (!this.panelElement) return;
 
-    this.panelElement.classList.remove('media-panel--active');
-    
+    this.panelElement.classList.remove("media-panel--active");
+
     // Clear results
     if (this.resultsContainer) {
-      this.resultsContainer.innerHTML = '';
+      this.resultsContainer.innerHTML = "";
     }
-    
-    console.log('📱 Media search panel closed');
+
+    console.log("📱 Media search panel closed");
   }
 
   /**
    * Check if panel is open
    */
   isPanelOpen(): boolean {
-    return this.panelElement?.classList.contains('media-panel--active') || false;
+    return (
+      this.panelElement?.classList.contains("media-panel--active") || false
+    );
   }
 
   /**
@@ -173,15 +175,16 @@ export class MediaPanelManager {
   destroy(): void {
     // Remove event listeners from result items
     if (this.resultsContainer) {
-      const resultItems = this.resultsContainer.querySelectorAll('.media-result-item');
-      resultItems.forEach(item => {
-        item.removeEventListener('click', this.handleMediaItemSelection);
+      const resultItems =
+        this.resultsContainer.querySelectorAll(".media-result-item");
+      resultItems.forEach((item) => {
+        item.removeEventListener("click", this.handleMediaItemSelection);
       });
     }
-    
+
     this.closePanel();
     this.onMediaSelectionCallback = null;
-    
-    console.log('🗑️ Media panel manager destroyed');
+
+    console.log("🗑️ Media panel manager destroyed");
   }
 }

--- a/src/scripts/coursebuilder/media/MediaSearchController.ts
+++ b/src/scripts/coursebuilder/media/MediaSearchController.ts
@@ -5,8 +5,8 @@
  */
 
 export class MediaSearchController {
-  private currentQuery: string = '';
-  private currentMediaType: string = '';
+  private currentQuery: string = "";
+  private currentMediaType: string = "";
   private onSearchCallback: ((results: any[]) => void) | null = null;
 
   constructor() {
@@ -25,21 +25,23 @@ export class MediaSearchController {
    */
   private bindSearchEvents(): void {
     // Search input
-    const searchInput = document.getElementById('media-search-input') as HTMLInputElement;
+    const searchInput = document.getElementById(
+      "media-search-input",
+    ) as HTMLInputElement;
     if (searchInput) {
-      searchInput.addEventListener('input', (event) => {
+      searchInput.addEventListener("input", (event) => {
         this.handleSearchInput(event);
       });
-      
-      searchInput.addEventListener('keypress', (event) => {
+
+      searchInput.addEventListener("keypress", (event) => {
         this.handleSearchKeypress(event);
       });
     }
 
     // Search button
-    const searchBtn = document.getElementById('media-search-btn');
+    const searchBtn = document.getElementById("media-search-btn");
     if (searchBtn) {
-      searchBtn.addEventListener('click', () => {
+      searchBtn.addEventListener("click", () => {
         this.performSearch();
       });
     }
@@ -57,7 +59,7 @@ export class MediaSearchController {
    * Handle search keypress (Enter to search)
    */
   private handleSearchKeypress(event: KeyboardEvent): void {
-    if (event.key === 'Enter') {
+    if (event.key === "Enter") {
       event.preventDefault();
       this.performSearch();
     }
@@ -68,15 +70,20 @@ export class MediaSearchController {
    */
   private performSearch(): void {
     if (!this.currentQuery || !this.currentMediaType) {
-      console.warn('⚠️ Search query or media type missing');
+      console.warn("⚠️ Search query or media type missing");
       return;
     }
 
-    console.log(`🔍 Searching for ${this.currentMediaType}: "${this.currentQuery}"`);
-    
+    console.log(
+      `🔍 Searching for ${this.currentMediaType}: "${this.currentQuery}"`,
+    );
+
     // Generate mock results (replace with real API call)
-    const results = this.generateMockResults(this.currentQuery, this.currentMediaType);
-    
+    const results = this.generateMockResults(
+      this.currentQuery,
+      this.currentMediaType,
+    );
+
     // Trigger callback with results
     if (this.onSearchCallback) {
       this.onSearchCallback(results);
@@ -95,12 +102,14 @@ export class MediaSearchController {
    * Clear search
    */
   clearSearch(): void {
-    this.currentQuery = '';
-    this.currentMediaType = '';
-    
-    const searchInput = document.getElementById('media-search-input') as HTMLInputElement;
+    this.currentQuery = "";
+    this.currentMediaType = "";
+
+    const searchInput = document.getElementById(
+      "media-search-input",
+    ) as HTMLInputElement;
     if (searchInput) {
-      searchInput.value = '';
+      searchInput.value = "";
     }
   }
 
@@ -110,32 +119,35 @@ export class MediaSearchController {
   getSearchState(): { query: string; mediaType: string } {
     return {
       query: this.currentQuery,
-      mediaType: this.currentMediaType
+      mediaType: this.currentMediaType,
     };
   }
 
   /**
    * Generate mock search results
    */
-  private generateMockResults(query: string, mediaType: string): Array<{
+  private generateMockResults(
+    query: string,
+    mediaType: string,
+  ): Array<{
     url: string;
     thumbnail: string;
     title: string;
     description: string;
   }> {
     const results = [];
-    const baseUrl = 'https://picsum.photos';
-    
+    const baseUrl = "https://picsum.photos";
+
     for (let i = 1; i <= 8; i++) {
       const imageId = 200 + i;
       results.push({
         url: `${baseUrl}/400/300?random=${imageId}`,
         thumbnail: `${baseUrl}/150/150?random=${imageId}`,
         title: `${mediaType} result ${i} for "${query}"`,
-        description: `Sample ${mediaType} found for search term: ${query}`
+        description: `Sample ${mediaType} found for search term: ${query}`,
       });
     }
-    
+
     return results;
   }
 
@@ -144,21 +156,21 @@ export class MediaSearchController {
    */
   destroy(): void {
     // Remove event listeners
-    const searchInput = document.getElementById('media-search-input');
-    const searchBtn = document.getElementById('media-search-btn');
-    
+    const searchInput = document.getElementById("media-search-input");
+    const searchBtn = document.getElementById("media-search-btn");
+
     if (searchInput) {
-      searchInput.removeEventListener('input', this.handleSearchInput);
-      searchInput.removeEventListener('keypress', this.handleSearchKeypress);
+      searchInput.removeEventListener("input", this.handleSearchInput);
+      searchInput.removeEventListener("keypress", this.handleSearchKeypress);
     }
-    
+
     if (searchBtn) {
-      searchBtn.removeEventListener('click', this.performSearch);
+      searchBtn.removeEventListener("click", this.performSearch);
     }
-    
+
     this.onSearchCallback = null;
     this.clearSearch();
-    
-    console.log('🗑️ Media search controller destroyed');
+
+    console.log("🗑️ Media search controller destroyed");
   }
 }

--- a/src/scripts/coursebuilder/media/MediaSelectionController.ts
+++ b/src/scripts/coursebuilder/media/MediaSelectionController.ts
@@ -24,9 +24,9 @@ export class MediaSelectionController {
    */
   private bindMediaEvents(): void {
     // Media type buttons (image, video, audio, etc.)
-    const mediaButtons = document.querySelectorAll('[data-media-type]');
-    mediaButtons.forEach(button => {
-      button.addEventListener('click', (event) => {
+    const mediaButtons = document.querySelectorAll("[data-media-type]");
+    mediaButtons.forEach((button) => {
+      button.addEventListener("click", (event) => {
         this.handleMediaSelection(event);
       });
     });
@@ -37,21 +37,21 @@ export class MediaSelectionController {
    */
   private handleMediaSelection(event: Event): void {
     const target = event.target as HTMLElement;
-    const mediaType = target.getAttribute('data-media-type');
-    
+    const mediaType = target.getAttribute("data-media-type");
+
     if (!mediaType) return;
 
     // Update visual selection
     this.updateSelectionUI(mediaType);
-    
+
     // Store selected media type
     this.selectedMediaType = mediaType;
-    
+
     // Trigger callback
     if (this.onMediaSelectionCallback) {
       this.onMediaSelectionCallback(mediaType);
     }
-    
+
     console.log(`📱 Media type selected: ${mediaType}`);
   }
 
@@ -60,15 +60,17 @@ export class MediaSelectionController {
    */
   private updateSelectionUI(selectedType: string): void {
     // Remove active class from all media buttons
-    const mediaButtons = document.querySelectorAll('[data-media-type]');
-    mediaButtons.forEach(button => {
-      button.classList.remove('media-type--selected');
+    const mediaButtons = document.querySelectorAll("[data-media-type]");
+    mediaButtons.forEach((button) => {
+      button.classList.remove("media-type--selected");
     });
 
     // Add active class to selected button
-    const selectedButton = document.querySelector(`[data-media-type="${selectedType}"]`);
+    const selectedButton = document.querySelector(
+      `[data-media-type="${selectedType}"]`,
+    );
     if (selectedButton) {
-      selectedButton.classList.add('media-type--selected');
+      selectedButton.classList.add("media-type--selected");
     }
   }
 
@@ -84,11 +86,11 @@ export class MediaSelectionController {
    */
   clearSelection(): void {
     this.selectedMediaType = null;
-    
+
     // Remove all active classes
-    const mediaButtons = document.querySelectorAll('[data-media-type]');
-    mediaButtons.forEach(button => {
-      button.classList.remove('media-type--selected');
+    const mediaButtons = document.querySelectorAll("[data-media-type]");
+    mediaButtons.forEach((button) => {
+      button.classList.remove("media-type--selected");
     });
   }
 
@@ -96,10 +98,10 @@ export class MediaSelectionController {
    * Get available media types
    */
   getAvailableMediaTypes(): string[] {
-    const buttons = document.querySelectorAll('[data-media-type]');
-    return Array.from(buttons).map(button => 
-      button.getAttribute('data-media-type')
-    ).filter(type => type !== null) as string[];
+    const buttons = document.querySelectorAll("[data-media-type]");
+    return Array.from(buttons)
+      .map((button) => button.getAttribute("data-media-type"))
+      .filter((type) => type !== null) as string[];
   }
 
   /**
@@ -107,14 +109,14 @@ export class MediaSelectionController {
    */
   destroy(): void {
     // Remove event listeners
-    const mediaButtons = document.querySelectorAll('[data-media-type]');
-    mediaButtons.forEach(button => {
-      button.removeEventListener('click', this.handleMediaSelection);
+    const mediaButtons = document.querySelectorAll("[data-media-type]");
+    mediaButtons.forEach((button) => {
+      button.removeEventListener("click", this.handleMediaSelection);
     });
-    
+
     this.onMediaSelectionCallback = null;
     this.selectedMediaType = null;
-    
-    console.log('🗑️ Media selection controller destroyed');
+
+    console.log("🗑️ Media selection controller destroyed");
   }
 }

--- a/src/scripts/coursebuilder/modals/PageSettingsModal.ts
+++ b/src/scripts/coursebuilder/modals/PageSettingsModal.ts
@@ -15,9 +15,11 @@ export class PageSettingsModal {
       const modal = this.createModal(page);
       document.body.appendChild(modal);
       this.currentModal = modal;
-      
+
       // Focus on page name input
-      const nameInput = modal.querySelector('#page-name-input') as HTMLInputElement;
+      const nameInput = modal.querySelector(
+        "#page-name-input",
+      ) as HTMLInputElement;
       if (nameInput) {
         nameInput.focus();
         nameInput.select();
@@ -33,8 +35,8 @@ export class PageSettingsModal {
    * Create page settings modal
    */
   private createModal(page: any): HTMLElement {
-    const modal = document.createElement('div');
-    modal.className = 'modal modal--page-settings';
+    const modal = document.createElement("div");
+    modal.className = "modal modal--page-settings";
     modal.innerHTML = `
       <div class="modal__backdrop"></div>
       <div class="modal__content">
@@ -49,7 +51,7 @@ export class PageSettingsModal {
           </div>
           <div class="form-group">
             <label for="page-description-input">Description (optional)</label>
-            <textarea id="page-description-input" class="form-control" rows="3" placeholder="Page description...">${page.description || ''}</textarea>
+            <textarea id="page-description-input" class="form-control" rows="3" placeholder="Page description...">${page.description || ""}</textarea>
           </div>
         </div>
         <div class="modal__footer">
@@ -71,27 +73,27 @@ export class PageSettingsModal {
     const reject = (modal as any).__reject;
 
     // Close button
-    const closeBtn = modal.querySelector('.modal__close');
+    const closeBtn = modal.querySelector(".modal__close");
     if (closeBtn) {
-      closeBtn.addEventListener('click', () => {
+      closeBtn.addEventListener("click", () => {
         this.close();
-        reject(new Error('Modal cancelled'));
+        reject(new Error("Modal cancelled"));
       });
     }
 
     // Cancel button
-    const cancelBtn = modal.querySelector('.modal-cancel');
+    const cancelBtn = modal.querySelector(".modal-cancel");
     if (cancelBtn) {
-      cancelBtn.addEventListener('click', () => {
+      cancelBtn.addEventListener("click", () => {
         this.close();
-        reject(new Error('Modal cancelled'));
+        reject(new Error("Modal cancelled"));
       });
     }
 
     // Save button
-    const saveBtn = modal.querySelector('.modal-save');
+    const saveBtn = modal.querySelector(".modal-save");
     if (saveBtn) {
-      saveBtn.addEventListener('click', () => {
+      saveBtn.addEventListener("click", () => {
         const result = this.collectFormData(modal, page);
         if (result) {
           this.close();
@@ -101,34 +103,38 @@ export class PageSettingsModal {
     }
 
     // Backdrop click
-    const backdrop = modal.querySelector('.modal__backdrop');
+    const backdrop = modal.querySelector(".modal__backdrop");
     if (backdrop) {
-      backdrop.addEventListener('click', () => {
+      backdrop.addEventListener("click", () => {
         this.close();
-        reject(new Error('Modal cancelled'));
+        reject(new Error("Modal cancelled"));
       });
     }
 
     // Escape key
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === "Escape") {
         this.close();
-        reject(new Error('Modal cancelled'));
-        document.removeEventListener('keydown', handleEscape);
+        reject(new Error("Modal cancelled"));
+        document.removeEventListener("keydown", handleEscape);
       }
     };
-    document.addEventListener('keydown', handleEscape);
+    document.addEventListener("keydown", handleEscape);
   }
 
   /**
    * Collect form data from modal
    */
   private collectFormData(modal: HTMLElement, page: any): any | null {
-    const nameInput = modal.querySelector('#page-name-input') as HTMLInputElement;
-    const descriptionInput = modal.querySelector('#page-description-input') as HTMLTextAreaElement;
-    
+    const nameInput = modal.querySelector(
+      "#page-name-input",
+    ) as HTMLInputElement;
+    const descriptionInput = modal.querySelector(
+      "#page-description-input",
+    ) as HTMLTextAreaElement;
+
     if (!nameInput || !nameInput.value.trim()) {
-      alert('Page name is required');
+      alert("Page name is required");
       nameInput?.focus();
       return null;
     }
@@ -136,7 +142,7 @@ export class PageSettingsModal {
     return {
       ...page,
       name: nameInput.value.trim(),
-      description: descriptionInput?.value.trim() || ''
+      description: descriptionInput?.value.trim() || "",
     };
   }
 

--- a/src/scripts/coursebuilder/tools/EraserTool.ts
+++ b/src/scripts/coursebuilder/tools/EraserTool.ts
@@ -3,13 +3,13 @@
  * Precision brush-based deletion with professional visual feedback
  */
 
-import { FederatedPointerEvent, Container, Graphics, Point } from 'pixi.js';
-import { BaseTool } from './ToolInterface';
-import { STROKE_SIZES } from './SharedResources';
+import { FederatedPointerEvent, Container, Graphics, Point } from "pixi.js";
+import { BaseTool } from "./ToolInterface";
+import { STROKE_SIZES } from "./SharedResources";
 
 interface EraserSettings {
   size: number;
-  mode: 'brush' | 'object'; // Brush mode for partial deletion, object mode for complete removal
+  mode: "brush" | "object"; // Brush mode for partial deletion, object mode for complete removal
 }
 
 export class EraserTool extends BaseTool {
@@ -18,41 +18,45 @@ export class EraserTool extends BaseTool {
   private erasePreview: Graphics | null = null;
 
   constructor() {
-    super('eraser', 'none'); // Custom cursor
+    super("eraser", "none"); // Custom cursor
     this.settings = {
       size: STROKE_SIZES.ERASER[2], // Start with 20px
-      mode: 'brush' // Default to brush mode for precision
+      mode: "brush", // Default to brush mode for precision
     };
   }
 
   onPointerDown(event: FederatedPointerEvent, container: Container): void {
     this.isErasing = true;
-    console.log(`🗑️ ERASER: Started precision erasing at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
-    console.log(`🗑️ ERASER: Settings - Size: ${this.settings.size}px, Mode: ${this.settings.mode}`);
-    
+    console.log(
+      `🗑️ ERASER: Started precision erasing at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+    );
+    console.log(
+      `🗑️ ERASER: Settings - Size: ${this.settings.size}px, Mode: ${this.settings.mode}`,
+    );
+
     const localPoint = container.toLocal(event.global);
     this.lastErasePoint.copyFrom(localPoint);
-    
+
     this.eraseAtPoint(event, container);
   }
 
   onPointerMove(event: FederatedPointerEvent, container: Container): void {
     this.updateCursorPosition(event);
-    
+
     // Show preview of what would be erased
     this.showErasePreview(event, container);
-    
+
     // Only erase if we're actively erasing (mouse button is pressed)
     if (this.isErasing) {
       const localPoint = container.toLocal(event.global);
-      
+
       // Brush mode: continuous erasing along the path
-      if (this.settings.mode === 'brush') {
+      if (this.settings.mode === "brush") {
         this.brushErase(this.lastErasePoint, localPoint, container);
       } else {
         this.eraseAtPoint(event, container);
       }
-      
+
       this.lastErasePoint.copyFrom(localPoint);
     }
   }
@@ -66,7 +70,9 @@ export class EraserTool extends BaseTool {
   onActivate(): void {
     super.onActivate();
     this.createProfessionalEraserCursor();
-    console.log(`�️ ERASER: Activated precision brush eraser - Size: ${this.settings.size}px, Mode: ${this.settings.mode}`);
+    console.log(
+      `�️ ERASER: Activated precision brush eraser - Size: ${this.settings.size}px, Mode: ${this.settings.mode}`,
+    );
   }
 
   onDeactivate(): void {
@@ -77,60 +83,84 @@ export class EraserTool extends BaseTool {
     console.log(`🗑️ ERASER: Deactivated and cleaned up`);
   }
 
-  private eraseAtPoint(event: FederatedPointerEvent, container: Container): void {
+  private eraseAtPoint(
+    event: FederatedPointerEvent,
+    container: Container,
+  ): void {
     const globalPoint = event.global;
     const eraserRadius = this.settings.size / 2;
 
-    console.log(`🗑️ ERASER: Precision erasing at point (${Math.round(globalPoint.x)}, ${Math.round(globalPoint.y)}) with radius ${eraserRadius}px`);
+    console.log(
+      `🗑️ ERASER: Precision erasing at point (${Math.round(globalPoint.x)}, ${Math.round(globalPoint.y)}) with radius ${eraserRadius}px`,
+    );
 
     // Check all objects in the container
     for (let i = container.children.length - 1; i >= 0; i--) {
       const child = container.children[i];
-      
+
       // LAYOUT PROTECTION: Skip protected objects
       if (this.isProtectedObject(child)) {
         continue;
       }
-      
+
       // Get accurate bounds
       const bounds = child.getBounds();
 
       // Enhanced collision detection for precision
-      if (this.precisionCollisionDetection(
-        globalPoint.x, globalPoint.y, eraserRadius,
-        bounds.x, bounds.y, bounds.width, bounds.height
-      )) {
-        console.log(`�️ ERASER: Removing object (${child.constructor.name}) at bounds (${Math.round(bounds.x)}, ${Math.round(bounds.y)}, ${Math.round(bounds.width)}x${Math.round(bounds.height)})`);
+      if (
+        this.precisionCollisionDetection(
+          globalPoint.x,
+          globalPoint.y,
+          eraserRadius,
+          bounds.x,
+          bounds.y,
+          bounds.width,
+          bounds.height,
+        )
+      ) {
+        console.log(
+          `�️ ERASER: Removing object (${child.constructor.name}) at bounds (${Math.round(bounds.x)}, ${Math.round(bounds.y)}, ${Math.round(bounds.width)}x${Math.round(bounds.height)})`,
+        );
         container.removeChild(child);
         child.destroy();
       }
     }
   }
 
-  private brushErase(fromPoint: Point, toPoint: Point, container: Container): void {
+  private brushErase(
+    fromPoint: Point,
+    toPoint: Point,
+    container: Container,
+  ): void {
     // Create a path between the two points and erase along it
     const distance = Math.sqrt(
-      Math.pow(toPoint.x - fromPoint.x, 2) + 
-      Math.pow(toPoint.y - fromPoint.y, 2)
+      Math.pow(toPoint.x - fromPoint.x, 2) +
+        Math.pow(toPoint.y - fromPoint.y, 2),
     );
-    
+
     // Sample points along the path for smooth erasing
     const steps = Math.max(1, Math.floor(distance / 5)); // Every 5 pixels
-    
+
     for (let i = 0; i <= steps; i++) {
       const t = i / steps;
       const x = fromPoint.x + (toPoint.x - fromPoint.x) * t;
       const y = fromPoint.y + (toPoint.y - fromPoint.y) * t;
-      
+
       // Convert to global coordinates for erasing
       const globalPoint = container.toGlobal({ x, y });
-      const mockEvent = { global: globalPoint, client: globalPoint } as FederatedPointerEvent;
-      
+      const mockEvent = {
+        global: globalPoint,
+        client: globalPoint,
+      } as FederatedPointerEvent;
+
       this.eraseAtPoint(mockEvent, container);
     }
   }
 
-  private showErasePreview(event: FederatedPointerEvent, container: Container): void {
+  private showErasePreview(
+    event: FederatedPointerEvent,
+    container: Container,
+  ): void {
     if (!this.erasePreview) {
       this.erasePreview = new Graphics();
       this.erasePreview.alpha = 0.3;
@@ -155,36 +185,42 @@ export class EraserTool extends BaseTool {
 
   private isProtectedObject(child: any): boolean {
     // LAYOUT PROTECTION: Skip objects that have layout-related names or are system objects
-    if (child.name && (
-      child.name.includes('layout-') ||
-      child.name.includes('grid-') ||
-      child.name.includes('background-') ||
-      child.name.includes('system-')
-    )) {
+    if (
+      child.name &&
+      (child.name.includes("layout-") ||
+        child.name.includes("grid-") ||
+        child.name.includes("background-") ||
+        child.name.includes("system-"))
+    ) {
       console.log(`� ERASER: Skipping protected object: ${child.name}`);
       return true;
     }
-    
+
     // Skip objects with special tags
-    if (child.tag && child.tag.includes('protected')) {
+    if (child.tag && child.tag.includes("protected")) {
       console.log(`🔒 ERASER: Skipping tagged protected object`);
       return true;
     }
-    
+
     return false;
   }
 
   private precisionCollisionDetection(
-    circleX: number, circleY: number, radius: number,
-    rectX: number, rectY: number, rectWidth: number, rectHeight: number
+    circleX: number,
+    circleY: number,
+    radius: number,
+    rectX: number,
+    rectY: number,
+    rectWidth: number,
+    rectHeight: number,
   ): boolean {
     // Enhanced collision detection for better precision
-    
+
     // Handle zero-width or zero-height objects
     if (rectWidth <= 0 || rectHeight <= 0) {
       return false;
     }
-    
+
     // Find the closest point to the circle within the rectangle
     const closestX = Math.max(rectX, Math.min(circleX, rectX + rectWidth));
     const closestY = Math.max(rectY, Math.min(circleY, rectY + rectHeight));
@@ -194,48 +230,48 @@ export class EraserTool extends BaseTool {
     const distanceY = circleY - closestY;
 
     // If the distance is less than the circle's radius, an intersection occurs
-    const distanceSquared = (distanceX * distanceX) + (distanceY * distanceY);
-    return distanceSquared <= (radius * radius);
+    const distanceSquared = distanceX * distanceX + distanceY * distanceY;
+    return distanceSquared <= radius * radius;
   }
 
   private createProfessionalEraserCursor(): void {
     // Create a professional visual cursor for the eraser
-    const cursorElement = document.createElement('div');
-    cursorElement.style.position = 'fixed';
-    cursorElement.style.pointerEvents = 'none';
-    cursorElement.style.zIndex = '10000';
+    const cursorElement = document.createElement("div");
+    cursorElement.style.position = "fixed";
+    cursorElement.style.pointerEvents = "none";
+    cursorElement.style.zIndex = "10000";
     cursorElement.style.width = `${this.settings.size}px`;
     cursorElement.style.height = `${this.settings.size}px`;
-    cursorElement.style.border = '2px solid #ff6b6b';
-    cursorElement.style.borderRadius = '50%';
-    cursorElement.style.backgroundColor = 'rgba(255, 107, 107, 0.15)';
-    cursorElement.style.boxShadow = '0 0 8px rgba(255, 107, 107, 0.3)';
-    cursorElement.style.transform = 'translate(-50%, -50%)';
-    cursorElement.id = 'precision-eraser-cursor';
-    
+    cursorElement.style.border = "2px solid #ff6b6b";
+    cursorElement.style.borderRadius = "50%";
+    cursorElement.style.backgroundColor = "rgba(255, 107, 107, 0.15)";
+    cursorElement.style.boxShadow = "0 0 8px rgba(255, 107, 107, 0.3)";
+    cursorElement.style.transform = "translate(-50%, -50%)";
+    cursorElement.id = "precision-eraser-cursor";
+
     // Add inner dot for precision
-    const innerDot = document.createElement('div');
-    innerDot.style.position = 'absolute';
-    innerDot.style.top = '50%';
-    innerDot.style.left = '50%';
-    innerDot.style.width = '2px';
-    innerDot.style.height = '2px';
-    innerDot.style.backgroundColor = '#ff0000';
-    innerDot.style.borderRadius = '50%';
-    innerDot.style.transform = 'translate(-50%, -50%)';
+    const innerDot = document.createElement("div");
+    innerDot.style.position = "absolute";
+    innerDot.style.top = "50%";
+    innerDot.style.left = "50%";
+    innerDot.style.width = "2px";
+    innerDot.style.height = "2px";
+    innerDot.style.backgroundColor = "#ff0000";
+    innerDot.style.borderRadius = "50%";
+    innerDot.style.transform = "translate(-50%, -50%)";
     cursorElement.appendChild(innerDot);
-    
+
     // Add mode indicator
     cursorElement.title = `🗑️ Precision Eraser - ${this.settings.mode} mode, ${this.settings.size}px`;
-    
+
     document.body.appendChild(cursorElement);
 
     // Hide default cursor
-    document.body.style.cursor = 'none';
+    document.body.style.cursor = "none";
   }
 
   private updateCursorPosition(event: FederatedPointerEvent): void {
-    const cursorElement = document.getElementById('precision-eraser-cursor');
+    const cursorElement = document.getElementById("precision-eraser-cursor");
     if (cursorElement) {
       cursorElement.style.left = `${event.client.x}px`;
       cursorElement.style.top = `${event.client.y}px`;
@@ -243,26 +279,28 @@ export class EraserTool extends BaseTool {
   }
 
   private removeEraserCursor(): void {
-    const cursorElement = document.getElementById('precision-eraser-cursor');
+    const cursorElement = document.getElementById("precision-eraser-cursor");
     if (cursorElement) {
       cursorElement.remove();
     }
-    
+
     // Reset cursor
-    document.body.style.cursor = 'default';
-    
-    const canvasContainer = document.querySelector('.coursebuilder__canvas') as HTMLElement;
+    document.body.style.cursor = "default";
+
+    const canvasContainer = document.querySelector(
+      ".coursebuilder__canvas",
+    ) as HTMLElement;
     if (canvasContainer) {
-      canvasContainer.style.cursor = 'default';
+      canvasContainer.style.cursor = "default";
     }
   }
 
-  setMode(mode: 'brush' | 'object'): void {
+  setMode(mode: "brush" | "object"): void {
     this.settings.mode = mode;
     console.log(`🗑️ ERASER: Mode set to ${mode}`);
-    
+
     // Update cursor tooltip
-    const cursorElement = document.getElementById('precision-eraser-cursor');
+    const cursorElement = document.getElementById("precision-eraser-cursor");
     if (cursorElement) {
       cursorElement.title = `🗑️ Precision Eraser - ${mode} mode, ${this.settings.size}px`;
     }
@@ -273,9 +311,9 @@ export class EraserTool extends BaseTool {
     console.log(`🗑️ ERASER: Updating settings to:`, settings);
     this.settings = { ...this.settings, ...settings };
     console.log(`🗑️ ERASER: Final eraser settings:`, this.settings);
-    
+
     // Update cursor size if it exists
-    const cursorElement = document.getElementById('precision-eraser-cursor');
+    const cursorElement = document.getElementById("precision-eraser-cursor");
     if (cursorElement) {
       cursorElement.style.width = `${this.settings.size}px`;
       cursorElement.style.height = `${this.settings.size}px`;
@@ -290,14 +328,14 @@ export class EraserTool extends BaseTool {
 
   // Get available eraser modes
   static getEraserModes(): string[] {
-    return ['brush', 'object'];
+    return ["brush", "object"];
   }
 
   // Get eraser mode display names
   static getEraserModeNames(): { [key: string]: string } {
     return {
-      'brush': 'Brush Mode (Continuous)',
-      'object': 'Object Mode (Click to Delete)'
+      brush: "Brush Mode (Continuous)",
+      object: "Object Mode (Click to Delete)",
     };
   }
 }

--- a/src/scripts/coursebuilder/tools/HighlighterTool.ts
+++ b/src/scripts/coursebuilder/tools/HighlighterTool.ts
@@ -3,9 +3,14 @@
  * Authentic marker experience with professional colors and realistic behavior
  */
 
-import { FederatedPointerEvent, Container, Graphics, Point } from 'pixi.js';
-import { BaseTool } from './ToolInterface';
-import { HIGHLIGHTER_COLORS, STROKE_SIZES, HIGHLIGHTER_CONSTANTS, hexToNumber } from './SharedResources';
+import { FederatedPointerEvent, Container, Graphics, Point } from "pixi.js";
+import { BaseTool } from "./ToolInterface";
+import {
+  HIGHLIGHTER_COLORS,
+  STROKE_SIZES,
+  HIGHLIGHTER_CONSTANTS,
+  hexToNumber,
+} from "./SharedResources";
 
 interface HighlighterSettings {
   color: string;
@@ -19,86 +24,98 @@ export class HighlighterTool extends BaseTool {
   private strokePoints: Point[] = [];
 
   constructor() {
-    super('highlighter', 'crosshair');
+    super("highlighter", "crosshair");
     this.settings = {
       color: HIGHLIGHTER_COLORS[0], // Start with classic yellow
-      size: STROKE_SIZES.HIGHLIGHTER[1] // Start with 12px
+      size: STROKE_SIZES.HIGHLIGHTER[1], // Start with 12px
     };
   }
 
   onPointerDown(event: FederatedPointerEvent, container: Container): void {
     this.isDrawing = true;
-    console.log(`🖍️ HIGHLIGHTER: Started highlighting at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
-    console.log(`🖍️ HIGHLIGHTER: Settings - Color: ${this.settings.color}, Size: ${this.settings.size}`);
-    
+    console.log(
+      `🖍️ HIGHLIGHTER: Started highlighting at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+    );
+    console.log(
+      `🖍️ HIGHLIGHTER: Settings - Color: ${this.settings.color}, Size: ${this.settings.size}`,
+    );
+
     // Create new graphics object for this stroke with authentic marker properties
     this.currentStroke = new Graphics();
-    this.currentStroke.eventMode = 'static';
+    this.currentStroke.eventMode = "static";
     this.currentStroke.alpha = HIGHLIGHTER_CONSTANTS.FIXED_OPACITY; // Fixed opacity like real markers
-    
+
     // Use local coordinates relative to the container
     const localPoint = container.toLocal(event.global);
     this.lastPoint.copyFrom(localPoint);
     this.strokePoints = [localPoint.clone()];
-    
-    console.log(`🖍️ HIGHLIGHTER: Container local point: (${Math.round(localPoint.x)}, ${Math.round(localPoint.y)})`);
-    
+
+    console.log(
+      `🖍️ HIGHLIGHTER: Container local point: (${Math.round(localPoint.x)}, ${Math.round(localPoint.y)})`,
+    );
+
     // Set stroke style with authentic marker characteristics
     const color = hexToNumber(this.settings.color);
-    console.log(`🖍️ HIGHLIGHTER: Setting authentic marker stroke - color: ${color} (from ${this.settings.color}), width: ${this.settings.size}`);
-    
+    console.log(
+      `🖍️ HIGHLIGHTER: Setting authentic marker stroke - color: ${color} (from ${this.settings.color}), width: ${this.settings.size}`,
+    );
+
     // Start the drawing path with marker-style properties
-    this.currentStroke
-      .moveTo(localPoint.x, localPoint.y)
-      .stroke({ 
-        width: this.settings.size, 
-        color,
-        cap: 'round',    // Authentic marker tip
-        join: 'round'    // Smooth joins like real markers
-      });
-    
+    this.currentStroke.moveTo(localPoint.x, localPoint.y).stroke({
+      width: this.settings.size,
+      color,
+      cap: "round", // Authentic marker tip
+      join: "round", // Smooth joins like real markers
+    });
+
     // Add to container
     container.addChild(this.currentStroke);
-    console.log(`🖍️ HIGHLIGHTER: Marker stroke started with authentic properties`);
+    console.log(
+      `🖍️ HIGHLIGHTER: Marker stroke started with authentic properties`,
+    );
   }
 
   onPointerMove(event: FederatedPointerEvent, container: Container): void {
     // Only respond to move events when actively drawing
     if (!this.isDrawing || !this.currentStroke) return;
-    
+
     // Use local coordinates relative to the container
     const localPoint = container.toLocal(event.global);
-    
+
     // Implement stroke smoothing for authentic marker feel
     if (HIGHLIGHTER_CONSTANTS.STROKE_SMOOTHING) {
       const distance = Math.sqrt(
-        Math.pow(localPoint.x - this.lastPoint.x, 2) + 
-        Math.pow(localPoint.y - this.lastPoint.y, 2)
+        Math.pow(localPoint.x - this.lastPoint.x, 2) +
+          Math.pow(localPoint.y - this.lastPoint.y, 2),
       );
-      
+
       // Only draw if we've moved a minimum distance (reduces jitter)
       if (distance < HIGHLIGHTER_CONSTANTS.MIN_DISTANCE) return;
     }
-    
-    console.log(`🖍️ HIGHLIGHTER: Highlighting to (${Math.round(localPoint.x)}, ${Math.round(localPoint.y)})`);
-    
+
+    console.log(
+      `🖍️ HIGHLIGHTER: Highlighting to (${Math.round(localPoint.x)}, ${Math.round(localPoint.y)})`,
+    );
+
     // Add slight texture variation for authentic marker feel
-    const opacityVariation = 1 + (Math.random() - 0.5) * HIGHLIGHTER_CONSTANTS.TEXTURE_VARIATION;
-    const adjustedOpacity = Math.max(0.3, Math.min(1, HIGHLIGHTER_CONSTANTS.FIXED_OPACITY * opacityVariation));
-    
+    const opacityVariation =
+      1 + (Math.random() - 0.5) * HIGHLIGHTER_CONSTANTS.TEXTURE_VARIATION;
+    const adjustedOpacity = Math.max(
+      0.3,
+      Math.min(1, HIGHLIGHTER_CONSTANTS.FIXED_OPACITY * opacityVariation),
+    );
+
     // Continue the stroke with authentic marker characteristics
-    this.currentStroke
-      .lineTo(localPoint.x, localPoint.y)
-      .stroke({ 
-        width: this.settings.size, 
-        color: hexToNumber(this.settings.color),
-        cap: 'round',
-        join: 'round'
-      });
-    
+    this.currentStroke.lineTo(localPoint.x, localPoint.y).stroke({
+      width: this.settings.size,
+      color: hexToNumber(this.settings.color),
+      cap: "round",
+      join: "round",
+    });
+
     // Apply subtle opacity variation
     this.currentStroke.alpha = adjustedOpacity;
-    
+
     // Update tracking
     this.lastPoint.copyFrom(localPoint);
     this.strokePoints.push(localPoint.clone());
@@ -106,14 +123,16 @@ export class HighlighterTool extends BaseTool {
 
   onPointerUp(): void {
     if (this.isDrawing) {
-      console.log(`🖍️ HIGHLIGHTER: Finished marker stroke with ${this.strokePoints.length} points`);
-      
+      console.log(
+        `🖍️ HIGHLIGHTER: Finished marker stroke with ${this.strokePoints.length} points`,
+      );
+
       // Apply final authentic marker properties
       if (this.currentStroke) {
         this.currentStroke.alpha = HIGHLIGHTER_CONSTANTS.FIXED_OPACITY;
       }
     }
-    
+
     this.isDrawing = false;
     this.currentStroke = null;
     this.strokePoints = [];

--- a/src/scripts/coursebuilder/tools/PenTool.ts
+++ b/src/scripts/coursebuilder/tools/PenTool.ts
@@ -3,9 +3,14 @@
  * Node-based vector drawing system with professional color palette
  */
 
-import { FederatedPointerEvent, Container, Graphics, Point } from 'pixi.js';
-import { BaseTool } from './ToolInterface';
-import { PROFESSIONAL_COLORS, STROKE_SIZES, PEN_CONSTANTS, hexToNumber } from './SharedResources';
+import { FederatedPointerEvent, Container, Graphics, Point } from "pixi.js";
+import { BaseTool } from "./ToolInterface";
+import {
+  PROFESSIONAL_COLORS,
+  STROKE_SIZES,
+  PEN_CONSTANTS,
+  hexToNumber,
+} from "./SharedResources";
 
 interface PenSettings {
   color: string;
@@ -31,36 +36,40 @@ export class PenTool extends BaseTool {
   private lastMousePosition: Point = new Point(0, 0);
 
   constructor() {
-    super('pen', 'crosshair');
+    super("pen", "crosshair");
     this.settings = {
       color: PROFESSIONAL_COLORS[0], // Start with dark charcoal
-      size: STROKE_SIZES.PEN[2] // Start with 3px
+      size: STROKE_SIZES.PEN[2], // Start with 3px
     };
   }
 
   onPointerDown(event: FederatedPointerEvent, container: Container): void {
-    console.log(`✏️ PEN: Node placement at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
-    console.log(`✏️ PEN: Settings - Color: ${this.settings.color}, Size: ${this.settings.size}`);
-    
+    console.log(
+      `✏️ PEN: Node placement at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+    );
+    console.log(
+      `✏️ PEN: Settings - Color: ${this.settings.color}, Size: ${this.settings.size}`,
+    );
+
     const localPoint = container.toLocal(event.global);
     this.lastMousePosition.copyFrom(localPoint);
-    
+
     // Check if we're continuing an existing path or starting a new one
     if (this.currentPath && this.currentPath.nodes.length > 0) {
       // Check if clicking near the first node to close the path
       const firstNode = this.currentPath.nodes[0];
       const distance = Math.sqrt(
-        Math.pow(localPoint.x - firstNode.position.x, 2) + 
-        Math.pow(localPoint.y - firstNode.position.y, 2)
+        Math.pow(localPoint.x - firstNode.position.x, 2) +
+          Math.pow(localPoint.y - firstNode.position.y, 2),
       );
-      
+
       if (distance <= PEN_CONSTANTS.PATH_CLOSE_TOLERANCE) {
         console.log(`✏️ PEN: Closing path - clicked near start node`);
         this.completePath(true);
         return;
       }
     }
-    
+
     // Add new node to current path or start new path
     this.addNodeToPath(localPoint, container);
   }
@@ -68,7 +77,7 @@ export class PenTool extends BaseTool {
   onPointerMove(event: FederatedPointerEvent, container: Container): void {
     const localPoint = container.toLocal(event.global);
     this.lastMousePosition.copyFrom(localPoint);
-    
+
     // Update preview line if we have an active path
     this.updatePreviewLine(container);
   }
@@ -85,70 +94,77 @@ export class PenTool extends BaseTool {
         nodes: [],
         pathGraphics: new Graphics(),
         isComplete: false,
-        settings: { ...this.settings }
+        settings: { ...this.settings },
       };
-      
-      this.currentPath.pathGraphics.eventMode = 'static';
+
+      this.currentPath.pathGraphics.eventMode = "static";
       container.addChild(this.currentPath.pathGraphics);
       console.log(`✏️ PEN: Started new vector path`);
     }
-    
+
     // Create node graphics
     const nodeGraphics = new Graphics();
     nodeGraphics.circle(0, 0, PEN_CONSTANTS.NODE_SIZE);
     nodeGraphics.fill({ color: PEN_CONSTANTS.NODE_COLOR });
-    nodeGraphics.stroke({ width: PEN_CONSTANTS.NODE_STROKE_WIDTH, color: 0xffffff });
+    nodeGraphics.stroke({
+      width: PEN_CONSTANTS.NODE_STROKE_WIDTH,
+      color: 0xffffff,
+    });
     nodeGraphics.position.set(position.x, position.y);
-    nodeGraphics.eventMode = 'static';
-    
+    nodeGraphics.eventMode = "static";
+
     container.addChild(nodeGraphics);
-    
+
     // Create node object
     const node: VectorNode = {
       position: position.clone(),
-      graphics: nodeGraphics
+      graphics: nodeGraphics,
     };
-    
+
     this.currentPath.nodes.push(node);
-    console.log(`✏️ PEN: Added node ${this.currentPath.nodes.length} at (${Math.round(position.x)}, ${Math.round(position.y)})`);
-    
+    console.log(
+      `✏️ PEN: Added node ${this.currentPath.nodes.length} at (${Math.round(position.x)}, ${Math.round(position.y)})`,
+    );
+
     // Update path graphics
     this.updatePathGraphics();
-    
+
     // Update preview line
     this.updatePreviewLine(container);
   }
 
   private updatePathGraphics(): void {
     if (!this.currentPath || this.currentPath.nodes.length === 0) return;
-    
+
     const path = this.currentPath.pathGraphics;
     const color = hexToNumber(this.currentPath.settings.color);
-    
+
     path.clear();
-    
+
     if (this.currentPath.nodes.length === 1) {
       // Single node - just show the node
       return;
     }
-    
+
     // Draw lines between nodes
     const firstNode = this.currentPath.nodes[0];
     path.moveTo(firstNode.position.x, firstNode.position.y);
-    
+
     for (let i = 1; i < this.currentPath.nodes.length; i++) {
       const node = this.currentPath.nodes[i];
       path.lineTo(node.position.x, node.position.y);
     }
-    
+
     path.stroke({
       width: this.currentPath.settings.size,
       color: color,
-      cap: 'round',
-      join: 'round'
+      cap: "round",
+      join: "round",
     });
-    
-    console.log(`✏️ PEN: Updated path graphics with ${this.currentPath.nodes.length} nodes`);
+
+    console.log(
+      `✏️ PEN: Updated path graphics with ${this.currentPath.nodes.length} nodes`,
+    );
   }
 
   private updatePreviewLine(container: Container): void {
@@ -156,23 +172,23 @@ export class PenTool extends BaseTool {
       this.removePreviewLine();
       return;
     }
-    
+
     if (!this.previewLine) {
       this.previewLine = new Graphics();
       this.previewLine.alpha = PEN_CONSTANTS.PREVIEW_LINE_ALPHA;
       container.addChild(this.previewLine);
     }
-    
+
     const lastNode = this.currentPath.nodes[this.currentPath.nodes.length - 1];
     const color = hexToNumber(this.currentPath.settings.color);
-    
+
     this.previewLine.clear();
     this.previewLine.moveTo(lastNode.position.x, lastNode.position.y);
     this.previewLine.lineTo(this.lastMousePosition.x, this.lastMousePosition.y);
     this.previewLine.stroke({
       width: this.currentPath.settings.size,
       color: color,
-      cap: 'round'
+      cap: "round",
     });
   }
 
@@ -185,54 +201,56 @@ export class PenTool extends BaseTool {
 
   private completePath(closeShape: boolean = false): void {
     if (!this.currentPath) return;
-    
+
     if (closeShape && this.currentPath.nodes.length >= 3) {
       // Close the shape by connecting last node to first
       const firstNode = this.currentPath.nodes[0];
       const path = this.currentPath.pathGraphics;
-      
+
       path.lineTo(firstNode.position.x, firstNode.position.y);
       path.stroke({
         width: this.currentPath.settings.size,
         color: hexToNumber(this.currentPath.settings.color),
-        cap: 'round',
-        join: 'round'
+        cap: "round",
+        join: "round",
       });
-      
-      console.log(`✏️ PEN: Closed shape with ${this.currentPath.nodes.length} nodes`);
+
+      console.log(
+        `✏️ PEN: Closed shape with ${this.currentPath.nodes.length} nodes`,
+      );
     }
-    
+
     // Remove individual node graphics since the path is complete
-    this.currentPath.nodes.forEach(node => {
+    this.currentPath.nodes.forEach((node) => {
       if (node.graphics.parent) {
         node.graphics.parent.removeChild(node.graphics);
       }
     });
-    
+
     // Mark path as complete
     this.currentPath.isComplete = true;
-    
+
     // Clean up
     this.removePreviewLine();
     this.currentPath = null;
-    
+
     console.log(`✏️ PEN: Path completed`);
   }
 
   // Handle keyboard events for path completion
   public onKeyDown(event: KeyboardEvent): void {
     if (!this.currentPath) return;
-    
+
     switch (event.key) {
-      case 'Enter':
+      case "Enter":
         // Complete current path without closing
         this.completePath(false);
         break;
-      case 'Escape':
+      case "Escape":
         // Cancel current path
         this.cancelPath();
         break;
-      case ' ': // Spacebar
+      case " ": // Spacebar
         // Complete and close current path
         if (this.currentPath.nodes.length >= 3) {
           this.completePath(true);
@@ -244,46 +262,48 @@ export class PenTool extends BaseTool {
 
   private cancelPath(): void {
     if (!this.currentPath) return;
-    
+
     // Remove all node graphics
-    this.currentPath.nodes.forEach(node => {
+    this.currentPath.nodes.forEach((node) => {
       if (node.graphics.parent) {
         node.graphics.parent.removeChild(node.graphics);
       }
     });
-    
+
     // Remove path graphics
     if (this.currentPath.pathGraphics.parent) {
-      this.currentPath.pathGraphics.parent.removeChild(this.currentPath.pathGraphics);
+      this.currentPath.pathGraphics.parent.removeChild(
+        this.currentPath.pathGraphics,
+      );
     }
-    
+
     // Remove preview line
     this.removePreviewLine();
-    
+
     this.currentPath = null;
     console.log(`✏️ PEN: Path cancelled`);
   }
 
   onActivate(): void {
     super.onActivate();
-    
+
     // Set up keyboard listeners
-    document.addEventListener('keydown', this.handleKeyDown);
+    document.addEventListener("keydown", this.handleKeyDown);
   }
 
   onDeactivate(): void {
     super.onDeactivate();
-    
+
     // Complete any active path
     if (this.currentPath) {
       console.log(`✏️ PEN: Tool deactivated, completing active path`);
       this.removePreviewLine();
       this.currentPath = null;
     }
-    
+
     // Remove keyboard listeners
-    document.removeEventListener('keydown', this.handleKeyDown);
-    
+    document.removeEventListener("keydown", this.handleKeyDown);
+
     // Clean up preview line
     this.removePreviewLine();
   }
@@ -291,14 +311,14 @@ export class PenTool extends BaseTool {
   private handleKeyDown = (event: KeyboardEvent): void => {
     // This would need to be handled by the tool manager to get container reference
     console.log(`✏️ PEN: Key pressed: ${event.key}`);
-  }
+  };
 
   updateSettings(settings: PenSettings): void {
     console.log(`✏️ PEN: Updating settings from:`, this.settings);
     console.log(`✏️ PEN: Updating settings to:`, settings);
     this.settings = { ...this.settings, ...settings };
     console.log(`✏️ PEN: Final settings:`, this.settings);
-    
+
     // Update current path settings if drawing
     if (this.currentPath) {
       this.currentPath.settings = { ...this.settings };

--- a/src/scripts/coursebuilder/tools/SelectionTool.ts
+++ b/src/scripts/coursebuilder/tools/SelectionTool.ts
@@ -3,17 +3,23 @@
  * Comprehensive selection and transformation system with marquee selection
  */
 
-import { FederatedPointerEvent, Container, Graphics, Point, Rectangle } from 'pixi.js';
-import { BaseTool } from './ToolInterface';
-import { SELECTION_CONSTANTS } from './SharedResources';
+import {
+  FederatedPointerEvent,
+  Container,
+  Graphics,
+  Point,
+  Rectangle,
+} from "pixi.js";
+import { BaseTool } from "./ToolInterface";
+import { SELECTION_CONSTANTS } from "./SharedResources";
 
 interface SelectionSettings {
   // Selection settings can be expanded as needed
 }
 
 interface TransformHandle {
-  type: 'corner' | 'edge';
-  position: 'tl' | 'tr' | 'bl' | 'br' | 't' | 'r' | 'b' | 'l';
+  type: "corner" | "edge";
+  position: "tl" | "tr" | "bl" | "br" | "t" | "r" | "b" | "l";
   graphics: Graphics;
   bounds: Rectangle;
 }
@@ -36,16 +42,18 @@ export class SelectionTool extends BaseTool {
   private transformStart: Point = new Point(0, 0);
 
   constructor() {
-    super('selection', 'default');
+    super("selection", "default");
     this.settings = {};
   }
 
   onPointerDown(event: FederatedPointerEvent, container: Container): void {
-    console.log(`🎯 SELECTION: Starting selection at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
-    
+    console.log(
+      `🎯 SELECTION: Starting selection at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+    );
+
     const localPoint = container.toLocal(event.global);
     this.marqueeStart.copyFrom(localPoint);
-    
+
     // Check if clicking on a transform handle
     if (this.selectionGroup) {
       const clickedHandle = this.getHandleAtPoint(localPoint);
@@ -54,7 +62,7 @@ export class SelectionTool extends BaseTool {
         return;
       }
     }
-    
+
     // Check if clicking on a selected object (for dragging)
     const clickedObject = this.getObjectAtPoint(localPoint, container);
     if (clickedObject && this.selectedObjects.includes(clickedObject)) {
@@ -63,7 +71,7 @@ export class SelectionTool extends BaseTool {
       this.transformStart.copyFrom(localPoint);
       return;
     }
-    
+
     // Start new marquee selection
     this.clearSelection();
     this.startMarqueeSelection(localPoint, container);
@@ -71,7 +79,7 @@ export class SelectionTool extends BaseTool {
 
   onPointerMove(event: FederatedPointerEvent, container: Container): void {
     const localPoint = container.toLocal(event.global);
-    
+
     if (this.isTransforming && this.activeHandle) {
       // Handle transformation
       this.updateTransform(localPoint);
@@ -86,7 +94,7 @@ export class SelectionTool extends BaseTool {
 
   onPointerUp(event: FederatedPointerEvent, container: Container): void {
     const localPoint = container.toLocal(event.global);
-    
+
     if (this.isTransforming) {
       console.log(`🎯 SELECTION: Finished transformation`);
       this.isTransforming = false;
@@ -100,67 +108,81 @@ export class SelectionTool extends BaseTool {
     }
   }
 
-  private startMarqueeSelection(_startPoint: Point, container: Container): void {
+  private startMarqueeSelection(
+    _startPoint: Point,
+    container: Container,
+  ): void {
     this.isSelecting = true;
-    
+
     // Create marquee graphics
     this.marqueeGraphics = new Graphics();
     this.marqueeGraphics.alpha = SELECTION_CONSTANTS.MARQUEE_FILL_ALPHA;
     container.addChild(this.marqueeGraphics);
-    
+
     console.log(`🎯 SELECTION: Started marquee selection`);
   }
 
   private updateMarqueeSelection(currentPoint: Point): void {
     if (!this.marqueeGraphics) return;
-    
+
     const x = Math.min(this.marqueeStart.x, currentPoint.x);
     const y = Math.min(this.marqueeStart.y, currentPoint.y);
     const width = Math.abs(currentPoint.x - this.marqueeStart.x);
     const height = Math.abs(currentPoint.y - this.marqueeStart.y);
-    
+
     this.marqueeGraphics.clear();
-    
+
     // Fill
     this.marqueeGraphics.rect(x, y, width, height);
-    this.marqueeGraphics.fill({ 
-      color: SELECTION_CONSTANTS.SELECTION_COLOR, 
-      alpha: SELECTION_CONSTANTS.MARQUEE_FILL_ALPHA 
+    this.marqueeGraphics.fill({
+      color: SELECTION_CONSTANTS.SELECTION_COLOR,
+      alpha: SELECTION_CONSTANTS.MARQUEE_FILL_ALPHA,
     });
-    
+
     // Border
     this.marqueeGraphics.stroke({
       width: SELECTION_CONSTANTS.SELECTION_LINE_WIDTH,
       color: SELECTION_CONSTANTS.SELECTION_COLOR,
-      alpha: SELECTION_CONSTANTS.MARQUEE_STROKE_ALPHA
+      alpha: SELECTION_CONSTANTS.MARQUEE_STROKE_ALPHA,
     });
   }
 
   private completeMarqueeSelection(container: Container): void {
     this.isSelecting = false;
-    
+
     if (this.marqueeGraphics) {
       const bounds = this.marqueeGraphics.getBounds();
-      const rect = new Rectangle(bounds.x, bounds.y, bounds.width, bounds.height);
-      
+      const rect = new Rectangle(
+        bounds.x,
+        bounds.y,
+        bounds.width,
+        bounds.height,
+      );
+
       // Find objects within the marquee
       const objectsInMarquee = this.findObjectsInBounds(rect, container);
-      
-      console.log(`🎯 SELECTION: Marquee selection found ${objectsInMarquee.length} objects`);
-      
+
+      console.log(
+        `🎯 SELECTION: Marquee selection found ${objectsInMarquee.length} objects`,
+      );
+
       if (objectsInMarquee.length > 0) {
         this.selectObjects(objectsInMarquee);
       }
-      
+
       // Remove marquee graphics
       container.removeChild(this.marqueeGraphics);
       this.marqueeGraphics = null;
     }
   }
 
-  private handleSingleClick(point: Point, container: Container, shiftKey: boolean): void {
+  private handleSingleClick(
+    point: Point,
+    container: Container,
+    shiftKey: boolean,
+  ): void {
     const clickedObject = this.getObjectAtPoint(point, container);
-    
+
     if (clickedObject) {
       if (shiftKey) {
         // Add to selection
@@ -169,7 +191,9 @@ export class SelectionTool extends BaseTool {
         // Replace selection
         this.selectObjects([clickedObject]);
       }
-      console.log(`🎯 SELECTION: Single click selected object, total selected: ${this.selectedObjects.length}`);
+      console.log(
+        `🎯 SELECTION: Single click selected object, total selected: ${this.selectedObjects.length}`,
+      );
     } else if (!shiftKey) {
       // Clear selection if not holding shift
       this.clearSelection();
@@ -197,90 +221,136 @@ export class SelectionTool extends BaseTool {
   private createSelectionGroup(): void {
     // Remove existing selection group
     this.removeSelectionGroup();
-    
+
     if (this.selectedObjects.length === 0) return;
-    
+
     // Calculate combined bounds
     const bounds = this.calculateCombinedBounds(this.selectedObjects);
-    
+
     // Create selection box
     const selectionBox = new Graphics();
     selectionBox.rect(bounds.x, bounds.y, bounds.width, bounds.height);
     selectionBox.stroke({
       width: SELECTION_CONSTANTS.SELECTION_LINE_WIDTH,
       color: SELECTION_CONSTANTS.SELECTION_COLOR,
-      alpha: SELECTION_CONSTANTS.SELECTION_ALPHA
+      alpha: SELECTION_CONSTANTS.SELECTION_ALPHA,
     });
-    
+
     // Create transform handles
     const handles = this.createTransformHandles(bounds);
-    
+
     this.selectionGroup = {
       objects: this.selectedObjects,
       bounds,
       transformHandles: handles,
-      selectionBox
+      selectionBox,
     };
-    
+
     // Add to container (assuming first object's parent)
     if (this.selectedObjects[0] && this.selectedObjects[0].parent) {
       const container = this.selectedObjects[0].parent;
       container.addChild(selectionBox);
-      handles.forEach(handle => container.addChild(handle.graphics));
+      handles.forEach((handle) => container.addChild(handle.graphics));
     }
-    
-    console.log(`🎯 SELECTION: Created selection group with ${handles.length} transform handles`);
+
+    console.log(
+      `🎯 SELECTION: Created selection group with ${handles.length} transform handles`,
+    );
   }
 
   private createTransformHandles(bounds: Rectangle): TransformHandle[] {
     const handles: TransformHandle[] = [];
     const size = SELECTION_CONSTANTS.HANDLE_SIZE;
-    
+
     // Corner handles
     const positions = [
-      { type: 'corner' as const, position: 'tl' as const, x: bounds.x, y: bounds.y },
-      { type: 'corner' as const, position: 'tr' as const, x: bounds.x + bounds.width, y: bounds.y },
-      { type: 'corner' as const, position: 'bl' as const, x: bounds.x, y: bounds.y + bounds.height },
-      { type: 'corner' as const, position: 'br' as const, x: bounds.x + bounds.width, y: bounds.y + bounds.height },
-      { type: 'edge' as const, position: 't' as const, x: bounds.x + bounds.width / 2, y: bounds.y },
-      { type: 'edge' as const, position: 'r' as const, x: bounds.x + bounds.width, y: bounds.y + bounds.height / 2 },
-      { type: 'edge' as const, position: 'b' as const, x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height },
-      { type: 'edge' as const, position: 'l' as const, x: bounds.x, y: bounds.y + bounds.height / 2 }
+      {
+        type: "corner" as const,
+        position: "tl" as const,
+        x: bounds.x,
+        y: bounds.y,
+      },
+      {
+        type: "corner" as const,
+        position: "tr" as const,
+        x: bounds.x + bounds.width,
+        y: bounds.y,
+      },
+      {
+        type: "corner" as const,
+        position: "bl" as const,
+        x: bounds.x,
+        y: bounds.y + bounds.height,
+      },
+      {
+        type: "corner" as const,
+        position: "br" as const,
+        x: bounds.x + bounds.width,
+        y: bounds.y + bounds.height,
+      },
+      {
+        type: "edge" as const,
+        position: "t" as const,
+        x: bounds.x + bounds.width / 2,
+        y: bounds.y,
+      },
+      {
+        type: "edge" as const,
+        position: "r" as const,
+        x: bounds.x + bounds.width,
+        y: bounds.y + bounds.height / 2,
+      },
+      {
+        type: "edge" as const,
+        position: "b" as const,
+        x: bounds.x + bounds.width / 2,
+        y: bounds.y + bounds.height,
+      },
+      {
+        type: "edge" as const,
+        position: "l" as const,
+        x: bounds.x,
+        y: bounds.y + bounds.height / 2,
+      },
     ];
-    
-    positions.forEach(pos => {
+
+    positions.forEach((pos) => {
       const graphics = new Graphics();
       graphics.rect(-size / 2, -size / 2, size, size);
       graphics.fill({ color: 0xffffff });
       graphics.stroke({ width: 1, color: SELECTION_CONSTANTS.HANDLE_COLOR });
       graphics.position.set(pos.x, pos.y);
-      graphics.eventMode = 'static';
-      
+      graphics.eventMode = "static";
+
       const handle: TransformHandle = {
         type: pos.type,
         position: pos.position,
         graphics,
-        bounds: new Rectangle(pos.x - size / 2, pos.y - size / 2, size, size)
+        bounds: new Rectangle(pos.x - size / 2, pos.y - size / 2, size, size),
       };
-      
+
       handles.push(handle);
     });
-    
+
     return handles;
   }
 
   private getHandleAtPoint(point: Point): TransformHandle | null {
     if (!this.selectionGroup) return null;
-    
+
     for (const handle of this.selectionGroup.transformHandles) {
       const bounds = handle.bounds;
       // Use manual bounds checking for consistency
-      if (point.x >= bounds.x && point.x <= bounds.x + bounds.width &&
-          point.y >= bounds.y && point.y <= bounds.y + bounds.height) {
+      if (
+        point.x >= bounds.x &&
+        point.x <= bounds.x + bounds.width &&
+        point.y >= bounds.y &&
+        point.y <= bounds.y + bounds.height
+      ) {
         return handle;
       }
     }
-    
+
     return null;
   }
 
@@ -288,83 +358,97 @@ export class SelectionTool extends BaseTool {
     this.isTransforming = true;
     this.activeHandle = handle;
     this.transformStart.copyFrom(point);
-    console.log(`🎯 SELECTION: Started transform with ${handle.position} handle`);
+    console.log(
+      `🎯 SELECTION: Started transform with ${handle.position} handle`,
+    );
   }
 
   private updateTransform(currentPoint: Point): void {
     if (!this.activeHandle || !this.selectionGroup) return;
-    
+
     const dx = currentPoint.x - this.transformStart.x;
     const dy = currentPoint.y - this.transformStart.y;
-    
+
     // Simple scaling for now (can be enhanced with more complex transforms)
-    if (this.activeHandle.type === 'corner') {
+    if (this.activeHandle.type === "corner") {
       this.scaleSelection(dx, dy, this.activeHandle.position);
     }
-    
+
     this.transformStart.copyFrom(currentPoint);
   }
 
   private updateDrag(currentPoint: Point): void {
     if (this.selectedObjects.length === 0) return;
-    
+
     const dx = currentPoint.x - this.transformStart.x;
     const dy = currentPoint.y - this.transformStart.y;
-    
+
     // Move all selected objects
-    this.selectedObjects.forEach(obj => {
+    this.selectedObjects.forEach((obj) => {
       if (obj.position) {
         obj.position.x += dx;
         obj.position.y += dy;
       }
     });
-    
+
     // Update selection group
     this.createSelectionGroup();
-    
+
     this.transformStart.copyFrom(currentPoint);
   }
 
   private scaleSelection(dx: number, dy: number, _corner: string): void {
     // Simplified scaling - can be enhanced
     const scaleFactor = 1 + Math.max(dx, dy) / 100;
-    
-    this.selectedObjects.forEach(obj => {
+
+    this.selectedObjects.forEach((obj) => {
       if (obj.scale) {
         obj.scale.x *= scaleFactor;
         obj.scale.y *= scaleFactor;
       }
     });
-    
+
     this.createSelectionGroup();
   }
 
   private findObjectsInBounds(bounds: Rectangle, container: Container): any[] {
     const objectsInBounds: any[] = [];
-    
+
     for (const child of container.children) {
       // Skip selection UI elements
       if (this.isSelectionUIElement(child)) continue;
-      
+
       try {
         const childBounds = child.getBounds();
         // Manual bounds intersection check since PIXI bounds types might be inconsistent
-        if (childBounds && typeof childBounds.x === 'number' && typeof childBounds.y === 'number' && 
-            typeof childBounds.width === 'number' && typeof childBounds.height === 'number') {
+        if (
+          childBounds &&
+          typeof childBounds.x === "number" &&
+          typeof childBounds.y === "number" &&
+          typeof childBounds.width === "number" &&
+          typeof childBounds.height === "number"
+        ) {
           // Check if rectangles intersect
-          if (!(bounds.x + bounds.width < childBounds.x || 
-                childBounds.x + childBounds.width < bounds.x ||
-                bounds.y + bounds.height < childBounds.y || 
-                childBounds.y + childBounds.height < bounds.y)) {
+          if (
+            !(
+              bounds.x + bounds.width < childBounds.x ||
+              childBounds.x + childBounds.width < bounds.x ||
+              bounds.y + bounds.height < childBounds.y ||
+              childBounds.y + childBounds.height < bounds.y
+            )
+          ) {
             objectsInBounds.push(child);
           }
         }
       } catch (error) {
-        console.warn('🎯 SELECTION: Error checking bounds intersection:', error);
+        console.warn(
+          "🎯 SELECTION: Error checking bounds intersection:",
+          error,
+        );
         continue;
       }
     }
-    
+
     return objectsInBounds;
   }
 
@@ -372,27 +456,36 @@ export class SelectionTool extends BaseTool {
     // Check objects from top to bottom
     for (let i = container.children.length - 1; i >= 0; i--) {
       const child = container.children[i];
-      
+
       // Skip selection UI elements
       if (this.isSelectionUIElement(child)) continue;
-      
+
       try {
         const bounds = child.getBounds();
         // Check if bounds is valid and has the required properties
-        if (bounds && typeof bounds.x === 'number' && typeof bounds.y === 'number' && 
-            typeof bounds.width === 'number' && typeof bounds.height === 'number') {
+        if (
+          bounds &&
+          typeof bounds.x === "number" &&
+          typeof bounds.y === "number" &&
+          typeof bounds.width === "number" &&
+          typeof bounds.height === "number"
+        ) {
           // Use manual bounds checking since bounds.contains might not work as expected
-          if (point.x >= bounds.x && point.x <= bounds.x + bounds.width &&
-              point.y >= bounds.y && point.y <= bounds.y + bounds.height) {
+          if (
+            point.x >= bounds.x &&
+            point.x <= bounds.x + bounds.width &&
+            point.y >= bounds.y &&
+            point.y <= bounds.y + bounds.height
+          ) {
             return child;
           }
         }
       } catch (error) {
-        console.warn('🎯 SELECTION: Error getting bounds for object:', error);
+        console.warn("🎯 SELECTION: Error getting bounds for object:", error);
         continue;
       }
     }
-    
+
     return null;
   }
 
@@ -400,38 +493,52 @@ export class SelectionTool extends BaseTool {
     // Check if this is part of the selection UI
     if (this.selectionGroup) {
       if (object === this.selectionGroup.selectionBox) return true;
-      if (this.selectionGroup.transformHandles.some(h => h.graphics === object)) return true;
+      if (
+        this.selectionGroup.transformHandles.some((h) => h.graphics === object)
+      )
+        return true;
     }
     if (object === this.marqueeGraphics) return true;
-    
+
     return false;
   }
 
   private calculateCombinedBounds(objects: any[]): Rectangle {
     if (objects.length === 0) return new Rectangle(0, 0, 0, 0);
-    
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    
-    objects.forEach(obj => {
+
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+
+    objects.forEach((obj) => {
       try {
         const bounds = obj.getBounds();
-        if (bounds && typeof bounds.x === 'number' && typeof bounds.y === 'number' && 
-            typeof bounds.width === 'number' && typeof bounds.height === 'number') {
+        if (
+          bounds &&
+          typeof bounds.x === "number" &&
+          typeof bounds.y === "number" &&
+          typeof bounds.width === "number" &&
+          typeof bounds.height === "number"
+        ) {
           minX = Math.min(minX, bounds.x);
           minY = Math.min(minY, bounds.y);
           maxX = Math.max(maxX, bounds.x + bounds.width);
           maxY = Math.max(maxY, bounds.y + bounds.height);
         }
       } catch (error) {
-        console.warn('🎯 SELECTION: Error calculating bounds for object:', error);
+        console.warn(
+          "🎯 SELECTION: Error calculating bounds for object:",
+          error,
+        );
       }
     });
-    
+
     // If no valid bounds were found, return a default rectangle
     if (minX === Infinity) {
       return new Rectangle(0, 0, 0, 0);
     }
-    
+
     return new Rectangle(minX, minY, maxX - minX, maxY - minY);
   }
 
@@ -439,16 +546,18 @@ export class SelectionTool extends BaseTool {
     if (this.selectionGroup) {
       // Remove selection box
       if (this.selectionGroup.selectionBox.parent) {
-        this.selectionGroup.selectionBox.parent.removeChild(this.selectionGroup.selectionBox);
+        this.selectionGroup.selectionBox.parent.removeChild(
+          this.selectionGroup.selectionBox,
+        );
       }
-      
+
       // Remove transform handles
-      this.selectionGroup.transformHandles.forEach(handle => {
+      this.selectionGroup.transformHandles.forEach((handle) => {
         if (handle.graphics.parent) {
           handle.graphics.parent.removeChild(handle.graphics);
         }
       });
-      
+
       this.selectionGroup = null;
     }
   }
@@ -461,13 +570,13 @@ export class SelectionTool extends BaseTool {
   onDeactivate(): void {
     super.onDeactivate();
     this.clearSelection();
-    
+
     // Remove marquee if active
     if (this.marqueeGraphics && this.marqueeGraphics.parent) {
       this.marqueeGraphics.parent.removeChild(this.marqueeGraphics);
       this.marqueeGraphics = null;
     }
-    
+
     this.isSelecting = false;
     this.isTransforming = false;
     console.log(`🎯 SELECTION: Tool deactivated and cleaned up`);

--- a/src/scripts/coursebuilder/tools/ShapesTool.ts
+++ b/src/scripts/coursebuilder/tools/ShapesTool.ts
@@ -3,16 +3,27 @@
  * Multi-geometry creation with professional styling and advanced shape options
  */
 
-import { FederatedPointerEvent, Container, Graphics, Point } from 'pixi.js';
-import { BaseTool } from './ToolInterface';
-import { PROFESSIONAL_COLORS, STROKE_SIZES, hexToNumber } from './SharedResources';
+import { FederatedPointerEvent, Container, Graphics, Point } from "pixi.js";
+import { BaseTool } from "./ToolInterface";
+import {
+  PROFESSIONAL_COLORS,
+  STROKE_SIZES,
+  hexToNumber,
+} from "./SharedResources";
 
 interface ShapesSettings {
   color: string;
   strokeWidth: number;
   fillColor?: string;
   fillEnabled: boolean;
-  shapeType: 'rectangle' | 'triangle' | 'circle' | 'ellipse' | 'line' | 'arrow' | 'polygon';
+  shapeType:
+    | "rectangle"
+    | "triangle"
+    | "circle"
+    | "ellipse"
+    | "line"
+    | "arrow"
+    | "polygon";
   cornerRadius?: number; // For rounded rectangles
   sides?: number; // For polygons
 }
@@ -24,23 +35,27 @@ export class ShapesTool extends BaseTool {
   private currentPoint: Point = new Point(0, 0);
 
   constructor() {
-    super('shapes', 'crosshair');
+    super("shapes", "crosshair");
     this.settings = {
-      color: PROFESSIONAL_COLORS[0],        // Dark charcoal stroke
-      strokeWidth: STROKE_SIZES.SHAPES[2],  // 4px stroke
-      fillColor: PROFESSIONAL_COLORS[13],   // Light gray fill
+      color: PROFESSIONAL_COLORS[0], // Dark charcoal stroke
+      strokeWidth: STROKE_SIZES.SHAPES[2], // 4px stroke
+      fillColor: PROFESSIONAL_COLORS[13], // Light gray fill
       fillEnabled: false,
-      shapeType: 'rectangle',
+      shapeType: "rectangle",
       cornerRadius: 0,
-      sides: 6 // For hexagon default
+      sides: 6, // For hexagon default
     };
   }
 
   onPointerDown(event: FederatedPointerEvent, container: Container): void {
     this.isDrawing = true;
-    console.log(`🔶 SHAPES: Started drawing ${this.settings.shapeType} at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
-    console.log(`🔶 SHAPES: Settings - Color: ${this.settings.color}, Stroke: ${this.settings.strokeWidth}px, Fill: ${this.settings.fillEnabled ? this.settings.fillColor : 'none'}`);
-    
+    console.log(
+      `🔶 SHAPES: Started drawing ${this.settings.shapeType} at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+    );
+    console.log(
+      `🔶 SHAPES: Settings - Color: ${this.settings.color}, Stroke: ${this.settings.strokeWidth}px, Fill: ${this.settings.fillEnabled ? this.settings.fillColor : "none"}`,
+    );
+
     // Use local coordinates relative to the container
     const localPoint = container.toLocal(event.global);
     this.startPoint.copyFrom(localPoint);
@@ -48,10 +63,12 @@ export class ShapesTool extends BaseTool {
 
     // Create new graphics object with professional styling
     this.currentShape = new Graphics();
-    this.currentShape.eventMode = 'static';
-    
+    this.currentShape.eventMode = "static";
+
     container.addChild(this.currentShape);
-    console.log(`🔶 SHAPES: Professional ${this.settings.shapeType} graphics object created`);
+    console.log(
+      `🔶 SHAPES: Professional ${this.settings.shapeType} graphics object created`,
+    );
   }
 
   onPointerMove(event: FederatedPointerEvent, container: Container): void {
@@ -60,13 +77,15 @@ export class ShapesTool extends BaseTool {
     // Use local coordinates relative to the container
     const localPoint = container.toLocal(event.global);
     this.currentPoint.copyFrom(localPoint);
-    
+
     this.drawShape();
   }
 
   onPointerUp(): void {
     if (this.isDrawing) {
-      console.log(`🔶 SHAPES: Finished drawing professional ${this.settings.shapeType}`);
+      console.log(
+        `🔶 SHAPES: Finished drawing professional ${this.settings.shapeType}`,
+      );
     }
     this.isDrawing = false;
     this.currentShape = null;
@@ -83,11 +102,11 @@ export class ShapesTool extends BaseTool {
     const height = this.currentPoint.y - this.startPoint.y;
 
     // Apply stroke style
-    const strokeStyle = { 
-      width: this.settings.strokeWidth, 
+    const strokeStyle = {
+      width: this.settings.strokeWidth,
       color: strokeColor,
-      cap: 'round' as const,
-      join: 'round' as const
+      cap: "round" as const,
+      join: "round" as const,
     };
 
     // Apply fill if enabled
@@ -97,58 +116,73 @@ export class ShapesTool extends BaseTool {
     }
 
     switch (this.settings.shapeType) {
-      case 'rectangle':
+      case "rectangle":
         this.drawRectangle(width, height, strokeStyle, fillStyle);
         break;
 
-      case 'triangle':
+      case "triangle":
         this.drawTriangle(width, height, strokeStyle, fillStyle);
         break;
 
-      case 'circle':
+      case "circle":
         this.drawCircle(width, height, strokeStyle, fillStyle);
         break;
 
-      case 'ellipse':
+      case "ellipse":
         this.drawEllipse(width, height, strokeStyle, fillStyle);
         break;
 
-      case 'line':
+      case "line":
         this.drawLine(strokeStyle);
         break;
 
-      case 'arrow':
+      case "arrow":
         this.drawArrow(strokeStyle);
         break;
 
-      case 'polygon':
+      case "polygon":
         this.drawPolygon(width, height, strokeStyle, fillStyle);
         break;
     }
   }
 
-  private drawRectangle(width: number, height: number, strokeStyle: any, fillStyle: any): void {
+  private drawRectangle(
+    width: number,
+    height: number,
+    strokeStyle: any,
+    fillStyle: any,
+  ): void {
     if (!this.currentShape) return;
 
     if (this.settings.cornerRadius && this.settings.cornerRadius > 0) {
       // Rounded rectangle
       this.currentShape.roundRect(
-        this.startPoint.x, 
-        this.startPoint.y, 
-        width, 
-        height, 
-        this.settings.cornerRadius
+        this.startPoint.x,
+        this.startPoint.y,
+        width,
+        height,
+        this.settings.cornerRadius,
       );
     } else {
       // Standard rectangle
-      this.currentShape.rect(this.startPoint.x, this.startPoint.y, width, height);
+      this.currentShape.rect(
+        this.startPoint.x,
+        this.startPoint.y,
+        width,
+        height,
+      );
     }
 
     if (fillStyle) this.currentShape.fill(fillStyle);
     this.currentShape.stroke(strokeStyle);
   }
 
-  private drawTriangle(width: number, height: number, strokeStyle: any, fillStyle: any): void {
+  private drawTriangle(
+    width: number,
+    height: number,
+    strokeStyle: any,
+    fillStyle: any,
+  ): void {
     if (!this.currentShape) return;
 
     // Equilateral triangle pointing up
@@ -158,41 +192,51 @@ export class ShapesTool extends BaseTool {
     const bottomLeftY = this.startPoint.y + height;
     const bottomRightX = this.startPoint.x + width;
     const bottomRightY = this.startPoint.y + height;
-    
+
     this.currentShape
       .moveTo(topX, topY)
       .lineTo(bottomLeftX, bottomLeftY)
       .lineTo(bottomRightX, bottomRightY)
       .closePath();
-    
+
     if (fillStyle) this.currentShape.fill(fillStyle);
     this.currentShape.stroke(strokeStyle);
   }
 
-  private drawCircle(width: number, height: number, strokeStyle: any, fillStyle: any): void {
+  private drawCircle(
+    width: number,
+    height: number,
+    strokeStyle: any,
+    fillStyle: any,
+  ): void {
     if (!this.currentShape) return;
 
     // Perfect circle using the larger dimension
     const radius = Math.max(Math.abs(width), Math.abs(height)) / 2;
     const centerX = this.startPoint.x + width / 2;
     const centerY = this.startPoint.y + height / 2;
-    
+
     this.currentShape.circle(centerX, centerY, radius);
-    
+
     if (fillStyle) this.currentShape.fill(fillStyle);
     this.currentShape.stroke(strokeStyle);
   }
 
-  private drawEllipse(width: number, height: number, strokeStyle: any, fillStyle: any): void {
+  private drawEllipse(
+    width: number,
+    height: number,
+    strokeStyle: any,
+    fillStyle: any,
+  ): void {
     if (!this.currentShape) return;
 
     const centerX = this.startPoint.x + width / 2;
     const centerY = this.startPoint.y + height / 2;
     const radiusX = Math.abs(width) / 2;
     const radiusY = Math.abs(height) / 2;
-    
+
     this.currentShape.ellipse(centerX, centerY, radiusX, radiusY);
-    
+
     if (fillStyle) this.currentShape.fill(fillStyle);
     this.currentShape.stroke(strokeStyle);
   }
@@ -213,23 +257,27 @@ export class ShapesTool extends BaseTool {
     const dy = this.currentPoint.y - this.startPoint.y;
     const angle = Math.atan2(dy, dx);
     const length = Math.sqrt(dx * dx + dy * dy);
-    
+
     // Arrow head size
     const headLength = Math.min(20, length * 0.3);
     const headAngle = Math.PI / 6; // 30 degrees
-    
+
     // Draw line
     this.currentShape
       .moveTo(this.startPoint.x, this.startPoint.y)
       .lineTo(this.currentPoint.x, this.currentPoint.y)
       .stroke(strokeStyle);
-    
+
     // Draw arrow head
-    const headX1 = this.currentPoint.x - headLength * Math.cos(angle - headAngle);
-    const headY1 = this.currentPoint.y - headLength * Math.sin(angle - headAngle);
-    const headX2 = this.currentPoint.x - headLength * Math.cos(angle + headAngle);
-    const headY2 = this.currentPoint.y - headLength * Math.sin(angle + headAngle);
-    
+    const headX1 =
+      this.currentPoint.x - headLength * Math.cos(angle - headAngle);
+    const headY1 =
+      this.currentPoint.y - headLength * Math.sin(angle - headAngle);
+    const headX2 =
+      this.currentPoint.x - headLength * Math.cos(angle + headAngle);
+    const headY2 =
+      this.currentPoint.y - headLength * Math.sin(angle + headAngle);
+
     this.currentShape
       .moveTo(this.currentPoint.x, this.currentPoint.y)
       .lineTo(headX1, headY1)
@@ -238,14 +286,20 @@ export class ShapesTool extends BaseTool {
       .stroke(strokeStyle);
   }
 
-  private drawPolygon(width: number, height: number, strokeStyle: any, fillStyle: any): void {
-    if (!this.currentShape || !this.settings.sides || this.settings.sides < 3) return;
+  private drawPolygon(
+    width: number,
+    height: number,
+    strokeStyle: any,
+    fillStyle: any,
+  ): void {
+    if (!this.currentShape || !this.settings.sides || this.settings.sides < 3)
+      return;
 
     const centerX = this.startPoint.x + width / 2;
     const centerY = this.startPoint.y + height / 2;
     const radius = Math.max(Math.abs(width), Math.abs(height)) / 2;
     const sides = this.settings.sides;
-    
+
     // Generate polygon points
     const points: number[] = [];
     for (let i = 0; i < sides; i++) {
@@ -254,14 +308,23 @@ export class ShapesTool extends BaseTool {
       const y = centerY + radius * Math.sin(angle);
       points.push(x, y);
     }
-    
+
     this.currentShape.poly(points);
-    
+
     if (fillStyle) this.currentShape.fill(fillStyle);
     this.currentShape.stroke(strokeStyle);
   }
 
-  setShapeType(shapeType: 'rectangle' | 'triangle' | 'circle' | 'ellipse' | 'line' | 'arrow' | 'polygon'): void {
+  setShapeType(
+    shapeType:
+      | "rectangle"
+      | "triangle"
+      | "circle"
+      | "ellipse"
+      | "line"
+      | "arrow"
+      | "polygon",
+  ): void {
     this.settings.shapeType = shapeType;
     console.log(`🔶 SHAPES: Professional shape type set to ${shapeType}`);
   }
@@ -278,7 +341,9 @@ export class ShapesTool extends BaseTool {
 
   toggleFill(): void {
     this.settings.fillEnabled = !this.settings.fillEnabled;
-    console.log(`🔶 SHAPES: Fill ${this.settings.fillEnabled ? 'enabled' : 'disabled'}`);
+    console.log(
+      `🔶 SHAPES: Fill ${this.settings.fillEnabled ? "enabled" : "disabled"}`,
+    );
   }
 
   updateSettings(settings: ShapesSettings): void {
@@ -300,19 +365,27 @@ export class ShapesTool extends BaseTool {
 
   // Get available shape types
   static getShapeTypes(): string[] {
-    return ['rectangle', 'triangle', 'circle', 'ellipse', 'line', 'arrow', 'polygon'];
+    return [
+      "rectangle",
+      "triangle",
+      "circle",
+      "ellipse",
+      "line",
+      "arrow",
+      "polygon",
+    ];
   }
 
   // Get shape type display names
   static getShapeTypeNames(): { [key: string]: string } {
     return {
-      'rectangle': 'Rectangle',
-      'triangle': 'Triangle', 
-      'circle': 'Circle',
-      'ellipse': 'Ellipse',
-      'line': 'Line',
-      'arrow': 'Arrow',
-      'polygon': 'Polygon'
+      rectangle: "Rectangle",
+      triangle: "Triangle",
+      circle: "Circle",
+      ellipse: "Ellipse",
+      line: "Line",
+      arrow: "Arrow",
+      polygon: "Polygon",
     };
   }
 }

--- a/src/scripts/coursebuilder/tools/SharedResources.ts
+++ b/src/scripts/coursebuilder/tools/SharedResources.ts
@@ -5,36 +5,36 @@
 
 // Beautiful, desaturated color palette extracted from project variables
 export const PROFESSIONAL_COLORS = [
-  '#1f2937', // Gray-800 - Dark charcoal
-  '#4b5563', // Gray-600 - Medium gray
-  '#5083f1', // Primary blue - Professional
-  '#3b82f6', // Student blue - Clear sky
-  '#059669', // Teacher green - Forest
-  '#10b981', // Success green - Emerald
-  '#f59e0b', // Accent amber - Warm
-  '#ef4444', // Error red - Clear red
-  '#8b5cf6', // Purple - Creative
-  '#06b6d4', // Cyan - Fresh
-  '#84cc16', // Lime - Energetic
-  '#f97316', // Orange - Vibrant
-  '#ec4899', // Pink - Accent
-  '#6b7280', // Gray-500 - Neutral
-  '#374151', // Gray-700 - Deep gray
-  '#d1d5db'  // Gray-300 - Light gray
+  "#1f2937", // Gray-800 - Dark charcoal
+  "#4b5563", // Gray-600 - Medium gray
+  "#5083f1", // Primary blue - Professional
+  "#3b82f6", // Student blue - Clear sky
+  "#059669", // Teacher green - Forest
+  "#10b981", // Success green - Emerald
+  "#f59e0b", // Accent amber - Warm
+  "#ef4444", // Error red - Clear red
+  "#8b5cf6", // Purple - Creative
+  "#06b6d4", // Cyan - Fresh
+  "#84cc16", // Lime - Energetic
+  "#f97316", // Orange - Vibrant
+  "#ec4899", // Pink - Accent
+  "#6b7280", // Gray-500 - Neutral
+  "#374151", // Gray-700 - Deep gray
+  "#d1d5db", // Gray-300 - Light gray
 ];
 
 // Authentic highlighter colors (marker-style pastels with slight saturation)
 export const HIGHLIGHTER_COLORS = [
-  '#ffef3e', // Classic highlighter yellow
-  '#90ee90', // Light green 
-  '#ffb3ba', // Light pink
-  '#87ceeb', // Sky blue
-  '#dda0dd', // Plum
-  '#ffd700', // Gold
-  '#98fb98', // Pale green
-  '#ffa07a', // Light salmon
-  '#d3d3d3', // Light gray
-  '#f0e68c'  // Khaki
+  "#ffef3e", // Classic highlighter yellow
+  "#90ee90", // Light green
+  "#ffb3ba", // Light pink
+  "#87ceeb", // Sky blue
+  "#dda0dd", // Plum
+  "#ffd700", // Gold
+  "#98fb98", // Pale green
+  "#ffa07a", // Light salmon
+  "#d3d3d3", // Light gray
+  "#f0e68c", // Khaki
 ];
 
 // Stroke sizes for different tools
@@ -42,7 +42,7 @@ export const STROKE_SIZES = {
   PEN: [1, 2, 3, 5, 8, 12],
   HIGHLIGHTER: [8, 12, 16, 24, 32],
   SHAPES: [1, 2, 4, 6, 8, 12],
-  ERASER: [10, 15, 20, 30, 40, 60]
+  ERASER: [10, 15, 20, 30, 40, 60],
 };
 
 // Text sizes
@@ -50,19 +50,19 @@ export const TEXT_SIZES = [8, 10, 12, 14, 16, 18, 24, 32, 48, 64];
 
 // Font families
 export const FONT_FAMILIES = [
-  'Inter',
-  'Arial',
-  'Helvetica',
-  'Times New Roman',
-  'Georgia',
-  'Courier New'
+  "Inter",
+  "Arial",
+  "Helvetica",
+  "Times New Roman",
+  "Georgia",
+  "Courier New",
 ];
 
 /**
  * Convert hex color to PIXI number format
  */
 export function hexToNumber(hex: string): number {
-  return parseInt(hex.replace('#', ''), 16);
+  return parseInt(hex.replace("#", ""), 16);
 }
 
 /**
@@ -75,33 +75,36 @@ export function getProfessionalColor(index: number): string {
 /**
  * Create a color palette element for UI
  */
-export function createColorPaletteElement(selectedColor: string, onColorSelect: (color: string) => void): HTMLElement {
-  const palette = document.createElement('div');
-  palette.className = 'color-palette';
-  
-  PROFESSIONAL_COLORS.forEach(color => {
-    const colorElement = document.createElement('div');
-    colorElement.className = 'color-palette__color';
+export function createColorPaletteElement(
+  selectedColor: string,
+  onColorSelect: (color: string) => void,
+): HTMLElement {
+  const palette = document.createElement("div");
+  palette.className = "color-palette";
+
+  PROFESSIONAL_COLORS.forEach((color) => {
+    const colorElement = document.createElement("div");
+    colorElement.className = "color-palette__color";
     if (color === selectedColor) {
-      colorElement.classList.add('color-palette__color--active');
+      colorElement.classList.add("color-palette__color--active");
     }
     colorElement.style.backgroundColor = color;
     colorElement.title = color;
     colorElement.dataset.color = color;
-    
-    colorElement.addEventListener('click', () => {
+
+    colorElement.addEventListener("click", () => {
       // Update active state
-      palette.querySelectorAll('.color-palette__color').forEach(el => {
-        el.classList.remove('color-palette__color--active');
+      palette.querySelectorAll(".color-palette__color").forEach((el) => {
+        el.classList.remove("color-palette__color--active");
       });
-      colorElement.classList.add('color-palette__color--active');
-      
+      colorElement.classList.add("color-palette__color--active");
+
       onColorSelect(color);
     });
-    
+
     palette.appendChild(colorElement);
   });
-  
+
   return palette;
 }
 
@@ -109,33 +112,33 @@ export function createColorPaletteElement(selectedColor: string, onColorSelect: 
  * Create a stroke size selector
  */
 export function createStrokeSizeSelector(
-  sizes: number[], 
-  selectedSize: number, 
+  sizes: number[],
+  selectedSize: number,
   onSizeSelect: (size: number) => void,
-  unit: string = 'px'
+  unit: string = "px",
 ): HTMLElement {
-  const container = document.createElement('div');
-  container.className = 'size-slider';
-  
-  const slider = document.createElement('input');
-  slider.type = 'range';
+  const container = document.createElement("div");
+  container.className = "size-slider";
+
+  const slider = document.createElement("input");
+  slider.type = "range";
   slider.min = Math.min(...sizes).toString();
   slider.max = Math.max(...sizes).toString();
   slider.value = selectedSize.toString();
-  
-  const valueDisplay = document.createElement('span');
-  valueDisplay.className = 'size-slider__value';
+
+  const valueDisplay = document.createElement("span");
+  valueDisplay.className = "size-slider__value";
   valueDisplay.textContent = `${selectedSize}${unit}`;
-  
-  slider.addEventListener('input', () => {
+
+  slider.addEventListener("input", () => {
     const newSize = parseInt(slider.value);
     valueDisplay.textContent = `${newSize}${unit}`;
     onSizeSelect(newSize);
   });
-  
+
   container.appendChild(slider);
   container.appendChild(valueDisplay);
-  
+
   return container;
 }
 
@@ -144,14 +147,14 @@ export function createStrokeSizeSelector(
  */
 export const SELECTION_CONSTANTS = {
   HANDLE_SIZE: 6,
-  HANDLE_COLOR: 0x3b82f6,      // Brighter blue for handles
-  SELECTION_COLOR: 0x3b82f6,   // Brighter blue for selection
-  SELECTION_ALPHA: 0.9,        // More opaque selection outline
+  HANDLE_COLOR: 0x3b82f6, // Brighter blue for handles
+  SELECTION_COLOR: 0x3b82f6, // Brighter blue for selection
+  SELECTION_ALPHA: 0.9, // More opaque selection outline
   SELECTION_LINE_WIDTH: 2,
-  MARQUEE_FILL_ALPHA: 0.25,    // Much more visible fill (25% instead of 10%)
-  MARQUEE_STROKE_ALPHA: 0.9,   // More opaque stroke
+  MARQUEE_FILL_ALPHA: 0.25, // Much more visible fill (25% instead of 10%)
+  MARQUEE_STROKE_ALPHA: 0.9, // More opaque stroke
   HIT_TOLERANCE: 8,
-  SNAP_TOLERANCE: 10
+  SNAP_TOLERANCE: 10,
 };
 
 /**
@@ -162,26 +165,26 @@ export const PEN_CONSTANTS = {
   NODE_COLOR: 0x5083f1,
   NODE_STROKE_WIDTH: 1,
   PATH_CLOSE_TOLERANCE: 8,
-  PREVIEW_LINE_ALPHA: 0.5
+  PREVIEW_LINE_ALPHA: 0.5,
 };
 
 /**
  * Text tool constants
  */
 export const TEXT_CONSTANTS = {
-  TEXTAREA_BORDER: '2px dashed #5083f1',
-  TEXTAREA_BACKGROUND: 'rgba(255, 255, 255, 0.9)',
-  MIN_TEXT_AREA_SIZE: { width: 100, height: 30 }
+  TEXTAREA_BORDER: "2px dashed #5083f1",
+  TEXTAREA_BACKGROUND: "rgba(255, 255, 255, 0.9)",
+  MIN_TEXT_AREA_SIZE: { width: 100, height: 30 },
 };
 
 /**
  * Highlighter tool constants for authentic marker experience
  */
 export const HIGHLIGHTER_CONSTANTS = {
-  FIXED_OPACITY: 0.4,         // Authentic marker transparency
-  OVERLAP_OPACITY: 0.6,       // When strokes overlap
-  MIN_DISTANCE: 3,            // Minimum distance between points for smoothing
-  TEXTURE_VARIATION: 0.1,     // Slight opacity variation for texture
-  MARKER_TIP_STYLE: 'round',  // Always round like real markers
-  STROKE_SMOOTHING: true      // Enable stroke smoothing
+  FIXED_OPACITY: 0.4, // Authentic marker transparency
+  OVERLAP_OPACITY: 0.6, // When strokes overlap
+  MIN_DISTANCE: 3, // Minimum distance between points for smoothing
+  TEXTURE_VARIATION: 0.1, // Slight opacity variation for texture
+  MARKER_TIP_STYLE: "round", // Always round like real markers
+  STROKE_SMOOTHING: true, // Enable stroke smoothing
 };

--- a/src/scripts/coursebuilder/tools/TextTool.ts
+++ b/src/scripts/coursebuilder/tools/TextTool.ts
@@ -3,9 +3,20 @@
  * Professional text area system with rich formatting and proper canvas integration
  */
 
-import { FederatedPointerEvent, Container, Text, TextStyle, Point } from 'pixi.js';
-import { BaseTool } from './ToolInterface';
-import { PROFESSIONAL_COLORS, TEXT_SIZES, FONT_FAMILIES, TEXT_CONSTANTS } from './SharedResources';
+import {
+  FederatedPointerEvent,
+  Container,
+  Text,
+  TextStyle,
+  Point,
+} from "pixi.js";
+import { BaseTool } from "./ToolInterface";
+import {
+  PROFESSIONAL_COLORS,
+  TEXT_SIZES,
+  FONT_FAMILIES,
+  TEXT_CONSTANTS,
+} from "./SharedResources";
 
 interface TextSettings {
   fontFamily: string;
@@ -22,27 +33,31 @@ export class TextTool extends BaseTool {
   private canvasContainer: HTMLElement | null = null;
 
   constructor() {
-    super('text', 'text');
+    super("text", "text");
     this.settings = {
       fontFamily: FONT_FAMILIES[0], // Start with Inter
-      fontSize: TEXT_SIZES[4],      // Start with 16px
+      fontSize: TEXT_SIZES[4], // Start with 16px
       color: PROFESSIONAL_COLORS[0], // Start with dark charcoal
-      fontWeight: 'normal',
-      fontStyle: 'normal',
-      align: 'left'
+      fontWeight: "normal",
+      fontStyle: "normal",
+      align: "left",
     };
   }
 
   onPointerDown(event: FederatedPointerEvent, container: Container): void {
-    console.log(`📝 TEXT: Text placement at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
-    console.log(`📝 TEXT: Settings - Font: ${this.settings.fontFamily}, Size: ${this.settings.fontSize}px, Color: ${this.settings.color}`);
-    
+    console.log(
+      `📝 TEXT: Text placement at (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+    );
+    console.log(
+      `📝 TEXT: Settings - Font: ${this.settings.fontFamily}, Size: ${this.settings.fontSize}px, Color: ${this.settings.color}`,
+    );
+
     const localPoint = container.toLocal(event.global);
     this.textPosition.copyFrom(localPoint);
-    
+
     // Find canvas container for proper positioning
     this.findCanvasContainer();
-    
+
     this.createTextArea(event.global.x, event.global.y, container);
   }
 
@@ -56,7 +71,7 @@ export class TextTool extends BaseTool {
 
   private findCanvasContainer(): void {
     // Try to find the canvas container element for proper positioning
-    const canvasElement = document.querySelector('canvas');
+    const canvasElement = document.querySelector("canvas");
     if (canvasElement) {
       this.canvasContainer = canvasElement.parentElement || document.body;
     } else {
@@ -68,13 +83,15 @@ export class TextTool extends BaseTool {
     // Remove any existing text area
     this.removeTextArea();
 
-    console.log(`📝 TEXT: Creating professional text area at global (${Math.round(x)}, ${Math.round(y)})`);
+    console.log(
+      `📝 TEXT: Creating professional text area at global (${Math.round(x)}, ${Math.round(y)})`,
+    );
 
     // Create HTML textarea for professional text entry
-    this.activeTextArea = document.createElement('textarea');
-    
+    this.activeTextArea = document.createElement("textarea");
+
     // Professional styling
-    this.activeTextArea.style.position = 'absolute';
+    this.activeTextArea.style.position = "absolute";
     this.activeTextArea.style.left = `${x}px`;
     this.activeTextArea.style.top = `${y}px`;
     this.activeTextArea.style.minWidth = `${TEXT_CONSTANTS.MIN_TEXT_AREA_SIZE.width}px`;
@@ -87,13 +104,13 @@ export class TextTool extends BaseTool {
     this.activeTextArea.style.textAlign = this.settings.align as any;
     this.activeTextArea.style.background = TEXT_CONSTANTS.TEXTAREA_BACKGROUND;
     this.activeTextArea.style.border = TEXT_CONSTANTS.TEXTAREA_BORDER;
-    this.activeTextArea.style.outline = 'none';
-    this.activeTextArea.style.resize = 'both';
-    this.activeTextArea.style.zIndex = '1000';
-    this.activeTextArea.style.padding = '8px';
-    this.activeTextArea.style.borderRadius = '4px';
-    this.activeTextArea.style.boxShadow = '0 2px 8px rgba(0,0,0,0.15)';
-    this.activeTextArea.placeholder = 'Enter your text here...';
+    this.activeTextArea.style.outline = "none";
+    this.activeTextArea.style.resize = "both";
+    this.activeTextArea.style.zIndex = "1000";
+    this.activeTextArea.style.padding = "8px";
+    this.activeTextArea.style.borderRadius = "4px";
+    this.activeTextArea.style.boxShadow = "0 2px 8px rgba(0,0,0,0.15)";
+    this.activeTextArea.placeholder = "Enter your text here...";
 
     // Professional interaction
     this.activeTextArea.rows = 3;
@@ -107,7 +124,7 @@ export class TextTool extends BaseTool {
     console.log(`📝 TEXT: Professional text area created and focused`);
 
     // Handle text completion with improved events
-    this.activeTextArea.addEventListener('blur', () => {
+    this.activeTextArea.addEventListener("blur", () => {
       // Small delay to allow other interactions
       setTimeout(() => {
         if (this.activeTextArea) {
@@ -116,12 +133,12 @@ export class TextTool extends BaseTool {
       }, 100);
     });
 
-    this.activeTextArea.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    this.activeTextArea.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
         // Ctrl+Enter or Cmd+Enter to finalize
         e.preventDefault();
         this.finalizeText(container);
-      } else if (e.key === 'Escape') {
+      } else if (e.key === "Escape") {
         e.preventDefault();
         this.removeTextArea();
       }
@@ -129,23 +146,23 @@ export class TextTool extends BaseTool {
     });
 
     // Auto-resize textarea as user types
-    this.activeTextArea.addEventListener('input', () => {
+    this.activeTextArea.addEventListener("input", () => {
       this.autoResizeTextArea();
     });
   }
 
   private autoResizeTextArea(): void {
     if (!this.activeTextArea) return;
-    
+
     // Reset height to auto to get proper scrollHeight
-    this.activeTextArea.style.height = 'auto';
-    
+    this.activeTextArea.style.height = "auto";
+
     // Set height to scrollHeight with some padding
     const newHeight = Math.max(
       TEXT_CONSTANTS.MIN_TEXT_AREA_SIZE.height,
-      this.activeTextArea.scrollHeight + 4
+      this.activeTextArea.scrollHeight + 4,
     );
-    
+
     this.activeTextArea.style.height = `${newHeight}px`;
   }
 
@@ -153,9 +170,9 @@ export class TextTool extends BaseTool {
     if (!this.activeTextArea) return;
 
     const textContent = this.activeTextArea.value.trim();
-    
+
     console.log(`📝 TEXT: Finalizing text: "${textContent}"`);
-    
+
     if (textContent) {
       // Create professional PixiJS text object
       const style = new TextStyle({
@@ -168,16 +185,18 @@ export class TextTool extends BaseTool {
         wordWrap: true,
         wordWrapWidth: 400, // Reasonable wrap width
         lineHeight: this.settings.fontSize * 1.2, // Professional line spacing
-        padding: 4 // Prevent text clipping
+        padding: 4, // Prevent text clipping
       });
 
       const textObject = new Text({ text: textContent, style });
       textObject.position.set(this.textPosition.x, this.textPosition.y);
-      textObject.eventMode = 'static'; // Make it selectable for future tools
+      textObject.eventMode = "static"; // Make it selectable for future tools
 
       container.addChild(textObject);
-      
-      console.log(`📝 TEXT: Professional text object created and added to canvas`);
+
+      console.log(
+        `📝 TEXT: Professional text object created and added to canvas`,
+      );
     }
 
     this.removeTextArea();
@@ -202,7 +221,7 @@ export class TextTool extends BaseTool {
     console.log(`📝 TEXT: Updating settings to:`, settings);
     this.settings = { ...this.settings, ...settings };
     console.log(`📝 TEXT: Final text settings:`, this.settings);
-    
+
     // Update active text area if it exists
     if (this.activeTextArea) {
       this.activeTextArea.style.fontSize = `${this.settings.fontSize}px`;
@@ -231,16 +250,28 @@ export class TextTool extends BaseTool {
 
   // Get text alignment options
   static getAlignmentOptions(): string[] {
-    return ['left', 'center', 'right', 'justify'];
+    return ["left", "center", "right", "justify"];
   }
 
   // Get font weight options
   static getFontWeights(): string[] {
-    return ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
+    return [
+      "normal",
+      "bold",
+      "100",
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "700",
+      "800",
+      "900",
+    ];
   }
 
   // Get font style options
   static getFontStyles(): string[] {
-    return ['normal', 'italic', 'oblique'];
+    return ["normal", "italic", "oblique"];
   }
 }

--- a/src/scripts/coursebuilder/tools/ToolInterface.ts
+++ b/src/scripts/coursebuilder/tools/ToolInterface.ts
@@ -3,7 +3,7 @@
  * Defines the structure for all drawing tools
  */
 
-import { FederatedPointerEvent, Container } from 'pixi.js';
+import { FederatedPointerEvent, Container } from "pixi.js";
 
 export interface ToolSettings {
   pen: {
@@ -24,7 +24,7 @@ export interface ToolSettings {
     color: string;
     strokeWidth: number;
     fillColor?: string;
-    shapeType: 'rectangle' | 'triangle' | 'circle';
+    shapeType: "rectangle" | "triangle" | "circle";
   };
   eraser: {
     size: number;
@@ -34,7 +34,7 @@ export interface ToolSettings {
 export interface Tool {
   name: string;
   cursor: string;
-  
+
   onPointerDown(event: FederatedPointerEvent, container: Container): void;
   onPointerMove(event: FederatedPointerEvent, container: Container): void;
   onPointerUp(event: FederatedPointerEvent, container: Container): void;
@@ -49,14 +49,23 @@ export abstract class BaseTool implements Tool {
   protected isActive: boolean = false;
   protected settings: any;
 
-  constructor(name: string, cursor: string = 'default') {
+  constructor(name: string, cursor: string = "default") {
     this.name = name;
     this.cursor = cursor;
   }
 
-  abstract onPointerDown(event: FederatedPointerEvent, container: Container): void;
-  abstract onPointerMove(event: FederatedPointerEvent, container: Container): void;
-  abstract onPointerUp(event: FederatedPointerEvent, container: Container): void;
+  abstract onPointerDown(
+    event: FederatedPointerEvent,
+    container: Container,
+  ): void;
+  abstract onPointerMove(
+    event: FederatedPointerEvent,
+    container: Container,
+  ): void;
+  abstract onPointerUp(
+    event: FederatedPointerEvent,
+    container: Container,
+  ): void;
 
   onActivate(): void {
     this.isActive = true;
@@ -73,6 +82,6 @@ export abstract class BaseTool implements Tool {
   }
 
   protected hexToNumber(hex: string): number {
-    return parseInt(hex.replace('#', ''), 16);
+    return parseInt(hex.replace("#", ""), 16);
   }
 }

--- a/src/scripts/coursebuilder/tools/ToolManager.ts
+++ b/src/scripts/coursebuilder/tools/ToolManager.ts
@@ -3,14 +3,14 @@
  * Manages all drawing tools and their interactions with the canvas
  */
 
-import { FederatedPointerEvent, Container } from 'pixi.js';
-import { Tool, ToolSettings } from './ToolInterface';
-import { SelectionTool } from './SelectionTool';
-import { PenTool } from './PenTool';
-import { HighlighterTool } from './HighlighterTool';
-import { TextTool } from './TextTool';
-import { ShapesTool } from './ShapesTool';
-import { EraserTool } from './EraserTool';
+import { FederatedPointerEvent, Container } from "pixi.js";
+import { Tool, ToolSettings } from "./ToolInterface";
+import { SelectionTool } from "./SelectionTool";
+import { PenTool } from "./PenTool";
+import { HighlighterTool } from "./HighlighterTool";
+import { TextTool } from "./TextTool";
+import { ShapesTool } from "./ShapesTool";
+import { EraserTool } from "./EraserTool";
 
 export class ToolManager {
   private tools: Map<string, Tool> = new Map();
@@ -20,28 +20,28 @@ export class ToolManager {
   constructor() {
     this.settings = {
       pen: {
-        color: '#000000', // Black for good visibility
-        size: 4 // Increased size for better visibility
+        color: "#000000", // Black for good visibility
+        size: 4, // Increased size for better visibility
       },
       text: {
-        fontFamily: 'Arial',
+        fontFamily: "Arial",
         fontSize: 16,
-        color: '#000000'
+        color: "#000000",
       },
       highlighter: {
-        color: '#ffff00', // Bright yellow
+        color: "#ffff00", // Bright yellow
         opacity: 0.8, // Increased opacity for better visibility
-        size: 20 // Larger size for better visibility
+        size: 20, // Larger size for better visibility
       },
       shapes: {
-        color: '#000000',
+        color: "#000000",
         strokeWidth: 2,
         fillColor: undefined,
-        shapeType: 'rectangle'
+        shapeType: "rectangle",
       },
       eraser: {
-        size: 20
-      }
+        size: 20,
+      },
     };
 
     this.initializeTools();
@@ -49,15 +49,15 @@ export class ToolManager {
 
   private initializeTools(): void {
     // Register all tools
-    this.tools.set('selection', new SelectionTool());
-    this.tools.set('pen', new PenTool());
-    this.tools.set('highlighter', new HighlighterTool());
-    this.tools.set('text', new TextTool());
-    this.tools.set('shapes', new ShapesTool());
-    this.tools.set('eraser', new EraserTool());
+    this.tools.set("selection", new SelectionTool());
+    this.tools.set("pen", new PenTool());
+    this.tools.set("highlighter", new HighlighterTool());
+    this.tools.set("text", new TextTool());
+    this.tools.set("shapes", new ShapesTool());
+    this.tools.set("eraser", new EraserTool());
 
     // Set default tool
-    this.activeTool = this.tools.get('selection') || null;
+    this.activeTool = this.tools.get("selection") || null;
     if (this.activeTool) {
       this.activeTool.onActivate();
     }
@@ -84,7 +84,10 @@ export class ToolManager {
     this.updateToolSettings(toolName);
 
     console.log(`✅ Switched to ${toolName} tool`);
-    console.log(`🔧 Tool settings:`, this.settings[toolName as keyof ToolSettings]);
+    console.log(
+      `🔧 Tool settings:`,
+      this.settings[toolName as keyof ToolSettings],
+    );
     console.log(`🔧 Applied settings to tool (${this.activeTool.name})`);
     return true;
   }
@@ -94,21 +97,31 @@ export class ToolManager {
   }
 
   public getActiveToolName(): string {
-    return this.activeTool?.name || 'none';
+    return this.activeTool?.name || "none";
   }
 
-  public onPointerDown(event: FederatedPointerEvent, container: Container): void {
+  public onPointerDown(
+    event: FederatedPointerEvent,
+    container: Container,
+  ): void {
     if (this.activeTool) {
-      console.log(`👆 Pointer DOWN - Tool: ${this.activeTool.name}, Position: (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
+      console.log(
+        `👆 Pointer DOWN - Tool: ${this.activeTool.name}, Position: (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+      );
       this.activeTool.onPointerDown(event, container);
     }
   }
 
-  public onPointerMove(event: FederatedPointerEvent, container: Container): void {
+  public onPointerMove(
+    event: FederatedPointerEvent,
+    container: Container,
+  ): void {
     if (this.activeTool) {
       // Only log move events for drawing tools when they're actually drawing
       if (this.shouldLogMove()) {
-        console.log(`👈 Pointer MOVE [DRAWING] - Tool: ${this.activeTool.name}, Position: (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
+        console.log(
+          `👈 Pointer MOVE [DRAWING] - Tool: ${this.activeTool.name}, Position: (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+        );
       }
       this.activeTool.onPointerMove(event, container);
     }
@@ -116,30 +129,32 @@ export class ToolManager {
 
   public onPointerUp(event: FederatedPointerEvent, container: Container): void {
     if (this.activeTool) {
-      console.log(`👆 Pointer UP - Tool: ${this.activeTool.name}, Position: (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`);
+      console.log(
+        `👆 Pointer UP - Tool: ${this.activeTool.name}, Position: (${Math.round(event.global.x)}, ${Math.round(event.global.y)})`,
+      );
       this.activeTool.onPointerUp(event, container);
     }
   }
 
   private shouldLogMove(): boolean {
     if (!this.activeTool) return false;
-    
+
     // Only log move events for drawing tools when they're actively drawing
     const toolName = this.activeTool.name;
-    
+
     // Check if the tool is actively drawing
-    if (toolName === 'pen' || toolName === 'highlighter') {
+    if (toolName === "pen" || toolName === "highlighter") {
       // Only log if the tool is currently drawing (we need to check the tool's state)
       const tool = this.activeTool as any;
       return tool.isDrawing === true;
     }
-    
-    if (toolName === 'selection') {
+
+    if (toolName === "selection") {
       // Only log for selection tool when dragging
       const tool = this.activeTool as any;
       return tool.isDragging === true;
     }
-    
+
     return false;
   }
 
@@ -162,19 +177,19 @@ export class ToolManager {
 
     const toolName = this.activeTool.name;
     console.log(`🎨 Updating color for ${toolName} tool to: ${color}`);
-    
+
     switch (toolName) {
-      case 'pen':
-        this.updateToolSettings('pen', { color });
+      case "pen":
+        this.updateToolSettings("pen", { color });
         break;
-      case 'highlighter':
-        this.updateToolSettings('highlighter', { color });
+      case "highlighter":
+        this.updateToolSettings("highlighter", { color });
         break;
-      case 'text':
-        this.updateToolSettings('text', { color });
+      case "text":
+        this.updateToolSettings("text", { color });
         break;
-      case 'shapes':
-        this.updateToolSettings('shapes', { color });
+      case "shapes":
+        this.updateToolSettings("shapes", { color });
         break;
     }
   }
@@ -184,7 +199,7 @@ export class ToolManager {
   }
 
   public getCursor(): string {
-    return this.activeTool?.cursor || 'default';
+    return this.activeTool?.cursor || "default";
   }
 
   public destroy(): void {

--- a/src/scripts/coursebuilder/ui/ToolStateManager.ts
+++ b/src/scripts/coursebuilder/ui/ToolStateManager.ts
@@ -23,7 +23,7 @@ interface ToolSettings {
     color: string;
     strokeWidth: number;
     fillColor?: string;
-    shapeType: 'rectangle' | 'triangle' | 'circle';
+    shapeType: "rectangle" | "triangle" | "circle";
   };
   eraser: {
     size: number;
@@ -31,34 +31,34 @@ interface ToolSettings {
 }
 
 export class ToolStateManager {
-  private currentTool: string = 'selection';
+  private currentTool: string = "selection";
   private selectedMedia: string | null = null;
   private toolSettings: ToolSettings;
 
   constructor() {
     this.toolSettings = {
       pen: {
-        color: '#000000',
-        size: 2
+        color: "#000000",
+        size: 2,
       },
       text: {
-        fontFamily: 'Arial',
+        fontFamily: "Arial",
         fontSize: 16,
-        color: '#000000'
+        color: "#000000",
       },
       highlighter: {
-        color: '#ffff00',
+        color: "#ffff00",
         opacity: 0.3,
-        size: 20
+        size: 20,
       },
       shapes: {
-        color: '#000000',
+        color: "#000000",
         strokeWidth: 2,
-        shapeType: 'rectangle'
+        shapeType: "rectangle",
       },
       eraser: {
-        size: 20
-      }
+        size: 20,
+      },
     };
   }
 
@@ -81,9 +81,15 @@ export class ToolStateManager {
   /**
    * Update tool settings
    */
-  updateToolSettings(toolName: string, settings: Partial<ToolSettings[keyof ToolSettings]>): void {
+  updateToolSettings(
+    toolName: string,
+    settings: Partial<ToolSettings[keyof ToolSettings]>,
+  ): void {
     if (toolName in this.toolSettings) {
-      Object.assign(this.toolSettings[toolName as keyof ToolSettings], settings);
+      Object.assign(
+        this.toolSettings[toolName as keyof ToolSettings],
+        settings,
+      );
       console.log(`🔧 Updated ${toolName} settings:`, settings);
     }
   }
@@ -114,23 +120,27 @@ export class ToolStateManager {
    */
   private updateToolUI(toolName: string): void {
     // Remove active class from all tools
-    document.querySelectorAll('.tool').forEach(t => t.classList.remove('tool--selected'));
-    
+    document
+      .querySelectorAll(".tool")
+      .forEach((t) => t.classList.remove("tool--selected"));
+
     // Add active class to selected tool
     const selectedTool = document.querySelector(`[data-tool="${toolName}"]`);
     if (selectedTool) {
-      selectedTool.classList.add('tool--selected');
+      selectedTool.classList.add("tool--selected");
     }
 
     // Hide all tool settings
-    document.querySelectorAll('.tool-settings').forEach(settings => {
-      settings.classList.remove('tool-settings--active');
+    document.querySelectorAll(".tool-settings").forEach((settings) => {
+      settings.classList.remove("tool-settings--active");
     });
 
     // Show settings for current tool - look for the div with data-tool attribute matching the tool name
-    const toolSettings = document.querySelector(`.tool-settings[data-tool="${toolName}"]`);
+    const toolSettings = document.querySelector(
+      `.tool-settings[data-tool="${toolName}"]`,
+    );
     if (toolSettings) {
-      toolSettings.classList.add('tool-settings--active');
+      toolSettings.classList.add("tool-settings--active");
     }
   }
 
@@ -138,28 +148,34 @@ export class ToolStateManager {
    * Update canvas cursor based on current tool
    */
   updateCanvasCursor(): void {
-    const canvas = document.querySelector('#pixi-canvas') as HTMLElement;
+    const canvas = document.querySelector("#pixi-canvas") as HTMLElement;
     if (!canvas) return;
 
     // Remove all cursor classes
-    canvas.classList.remove('cursor-pen', 'cursor-eraser', 'cursor-text', 'cursor-highlighter', 'cursor-selection');
+    canvas.classList.remove(
+      "cursor-pen",
+      "cursor-eraser",
+      "cursor-text",
+      "cursor-highlighter",
+      "cursor-selection",
+    );
 
     // Add cursor class for current tool
     switch (this.currentTool) {
-      case 'pen':
-        canvas.classList.add('cursor-pen');
+      case "pen":
+        canvas.classList.add("cursor-pen");
         break;
-      case 'eraser':
-        canvas.classList.add('cursor-eraser');
+      case "eraser":
+        canvas.classList.add("cursor-eraser");
         break;
-      case 'text':
-        canvas.classList.add('cursor-text');
+      case "text":
+        canvas.classList.add("cursor-text");
         break;
-      case 'highlighter':
-        canvas.classList.add('cursor-highlighter');
+      case "highlighter":
+        canvas.classList.add("cursor-highlighter");
         break;
       default:
-        canvas.classList.add('cursor-selection');
+        canvas.classList.add("cursor-selection");
     }
   }
 }

--- a/src/scripts/coursebuilder/ui/UIEventHandler.ts
+++ b/src/scripts/coursebuilder/ui/UIEventHandler.ts
@@ -4,7 +4,7 @@
  * Single Responsibility: Event handling and UI interactions only
  */
 
-import { ToolStateManager } from './ToolStateManager';
+import { ToolStateManager } from "./ToolStateManager";
 
 export class UIEventHandler {
   private toolStateManager: ToolStateManager;
@@ -34,31 +34,33 @@ export class UIEventHandler {
    * Bind all UI events
    */
   private bindEvents(): void {
-    document.addEventListener('click', this.handleGlobalClick.bind(this));
-    
+    document.addEventListener("click", this.handleGlobalClick.bind(this));
+
     // Tool selection events
-    document.querySelectorAll('[data-tool]').forEach(button => {
-      button.addEventListener('click', this.handleToolSelection.bind(this));
+    document.querySelectorAll("[data-tool]").forEach((button) => {
+      button.addEventListener("click", this.handleToolSelection.bind(this));
     });
 
     // Color palette events
-    document.querySelectorAll('.color-palette__color').forEach(color => {
-      color.addEventListener('click', this.handleColorSelection.bind(this));
+    document.querySelectorAll(".color-palette__color").forEach((color) => {
+      color.addEventListener("click", this.handleColorSelection.bind(this));
     });
 
     // Shape tool events
-    document.querySelectorAll('.shape-btn').forEach(button => {
-      button.addEventListener('click', this.handleShapeSelection.bind(this));
+    document.querySelectorAll(".shape-btn").forEach((button) => {
+      button.addEventListener("click", this.handleShapeSelection.bind(this));
     });
 
     // Slider events for tool settings
-    document.querySelectorAll('input[type="range"][data-setting]').forEach(slider => {
-      slider.addEventListener('input', this.handleSliderChange.bind(this));
-    });
+    document
+      .querySelectorAll('input[type="range"][data-setting]')
+      .forEach((slider) => {
+        slider.addEventListener("input", this.handleSliderChange.bind(this));
+      });
 
     // Select dropdown events for font settings
-    document.querySelectorAll('select[data-setting]').forEach(select => {
-      select.addEventListener('change', this.handleSelectChange.bind(this));
+    document.querySelectorAll("select[data-setting]").forEach((select) => {
+      select.addEventListener("change", this.handleSelectChange.bind(this));
     });
 
     // Canvas actions
@@ -72,13 +74,16 @@ export class UIEventHandler {
     const target = event.target as HTMLElement;
 
     // Handle color selection
-    if (target.classList.contains('color-palette__color')) {
+    if (target.classList.contains("color-palette__color")) {
       this.handleColorSelection(event);
       return;
     }
 
     // Handle shape selection
-    if (target.classList.contains('shape-btn') || target.closest('.shape-btn')) {
+    if (
+      target.classList.contains("shape-btn") ||
+      target.closest(".shape-btn")
+    ) {
       this.handleShapeSelection(event);
       return;
     }
@@ -91,7 +96,7 @@ export class UIEventHandler {
     event.preventDefault();
     const button = event.currentTarget as HTMLElement;
     const toolName = button.dataset.tool;
-    
+
     if (!toolName) return;
 
     this.toolStateManager.setTool(toolName);
@@ -110,31 +115,35 @@ export class UIEventHandler {
     event.preventDefault();
     const colorSquare = event.currentTarget as HTMLElement;
     const colorValue = colorSquare.dataset.color;
-    
+
     if (!colorValue) {
-      console.warn('🎨 Color selection failed: no color data found');
+      console.warn("🎨 Color selection failed: no color data found");
       return;
     }
 
     // Update UI - find the parent color palette and update active state
-    const parentPalette = colorSquare.closest('.color-palette');
+    const parentPalette = colorSquare.closest(".color-palette");
     if (parentPalette) {
-      parentPalette.querySelectorAll('.color-palette__color').forEach(color => {
-        color.classList.remove('color-palette__color--active');
-      });
-      colorSquare.classList.add('color-palette__color--active');
+      parentPalette
+        .querySelectorAll(".color-palette__color")
+        .forEach((color) => {
+          color.classList.remove("color-palette__color--active");
+        });
+      colorSquare.classList.add("color-palette__color--active");
     }
 
     // Update tool settings based on currently active tool
     const currentTool = this.toolStateManager.getCurrentTool();
-    if (currentTool === 'pen') {
-      this.toolStateManager.updateToolSettings('pen', { color: colorValue });
-    } else if (currentTool === 'text') {
-      this.toolStateManager.updateToolSettings('text', { color: colorValue });
-    } else if (currentTool === 'highlighter') {
-      this.toolStateManager.updateToolSettings('highlighter', { color: colorValue });
-    } else if (currentTool === 'shapes') {
-      this.toolStateManager.updateToolSettings('shapes', { color: colorValue });
+    if (currentTool === "pen") {
+      this.toolStateManager.updateToolSettings("pen", { color: colorValue });
+    } else if (currentTool === "text") {
+      this.toolStateManager.updateToolSettings("text", { color: colorValue });
+    } else if (currentTool === "highlighter") {
+      this.toolStateManager.updateToolSettings("highlighter", {
+        color: colorValue,
+      });
+    } else if (currentTool === "shapes") {
+      this.toolStateManager.updateToolSettings("shapes", { color: colorValue });
     }
 
     // Trigger callback
@@ -150,13 +159,15 @@ export class UIEventHandler {
     const slider = event.currentTarget as HTMLInputElement;
     const setting = slider.dataset.setting;
     const value = slider.value;
-    
+
     if (!setting) return;
 
     // Update the displayed value
-    const valueDisplay = slider.parentElement?.querySelector('.size-slider__value');
+    const valueDisplay = slider.parentElement?.querySelector(
+      ".size-slider__value",
+    );
     if (valueDisplay) {
-      if (setting === 'opacity') {
+      if (setting === "opacity") {
         const percentage = Math.round(parseFloat(value) * 100);
         valueDisplay.textContent = `${percentage}%`;
       } else {
@@ -166,18 +177,32 @@ export class UIEventHandler {
 
     // Update tool settings based on currently active tool
     const currentTool = this.toolStateManager.getCurrentTool();
-    const numericValue = setting === 'opacity' ? parseFloat(value) : parseInt(value);
-    
-    if (currentTool === 'pen' && (setting === 'size')) {
-      this.toolStateManager.updateToolSettings('pen', { [setting]: numericValue });
-    } else if (currentTool === 'text' && (setting === 'fontSize')) {
-      this.toolStateManager.updateToolSettings('text', { [setting]: numericValue });
-    } else if (currentTool === 'highlighter' && (setting === 'size' || setting === 'opacity')) {
-      this.toolStateManager.updateToolSettings('highlighter', { [setting]: numericValue });
-    } else if (currentTool === 'shapes' && (setting === 'strokeWidth')) {
-      this.toolStateManager.updateToolSettings('shapes', { [setting]: numericValue });
-    } else if (currentTool === 'eraser' && (setting === 'size')) {
-      this.toolStateManager.updateToolSettings('eraser', { [setting]: numericValue });
+    const numericValue =
+      setting === "opacity" ? parseFloat(value) : parseInt(value);
+
+    if (currentTool === "pen" && setting === "size") {
+      this.toolStateManager.updateToolSettings("pen", {
+        [setting]: numericValue,
+      });
+    } else if (currentTool === "text" && setting === "fontSize") {
+      this.toolStateManager.updateToolSettings("text", {
+        [setting]: numericValue,
+      });
+    } else if (
+      currentTool === "highlighter" &&
+      (setting === "size" || setting === "opacity")
+    ) {
+      this.toolStateManager.updateToolSettings("highlighter", {
+        [setting]: numericValue,
+      });
+    } else if (currentTool === "shapes" && setting === "strokeWidth") {
+      this.toolStateManager.updateToolSettings("shapes", {
+        [setting]: numericValue,
+      });
+    } else if (currentTool === "eraser" && setting === "size") {
+      this.toolStateManager.updateToolSettings("eraser", {
+        [setting]: numericValue,
+      });
     }
   }
 
@@ -188,14 +213,14 @@ export class UIEventHandler {
     const select = event.currentTarget as HTMLSelectElement;
     const setting = select.dataset.setting;
     const value = select.value;
-    
+
     if (!setting) return;
 
     // Update tool settings based on currently active tool
     const currentTool = this.toolStateManager.getCurrentTool();
-    
-    if (currentTool === 'text' && setting === 'fontFamily') {
-      this.toolStateManager.updateToolSettings('text', { [setting]: value });
+
+    if (currentTool === "text" && setting === "fontFamily") {
+      this.toolStateManager.updateToolSettings("text", { [setting]: value });
     }
   }
 
@@ -206,28 +231,30 @@ export class UIEventHandler {
     event.preventDefault();
     const button = event.currentTarget as HTMLElement;
     const shapeType = button.dataset.shape;
-    
+
     if (!shapeType) return;
 
     // Update UI - set active state for shape buttons
-    const parentShapeButtons = button.closest('.shape-buttons');
+    const parentShapeButtons = button.closest(".shape-buttons");
     if (parentShapeButtons) {
-      parentShapeButtons.querySelectorAll('.shape-btn').forEach(btn => {
-        btn.classList.remove('shape-btn--active');
+      parentShapeButtons.querySelectorAll(".shape-btn").forEach((btn) => {
+        btn.classList.remove("shape-btn--active");
       });
-      button.classList.add('shape-btn--active');
+      button.classList.add("shape-btn--active");
     }
 
     // Set tool to shapes and update shape type
-    this.toolStateManager.setTool('shapes');
-    this.toolStateManager.updateToolSettings('shapes', { shapeType: shapeType as 'rectangle' | 'triangle' | 'circle' });
+    this.toolStateManager.setTool("shapes");
+    this.toolStateManager.updateToolSettings("shapes", {
+      shapeType: shapeType as "rectangle" | "triangle" | "circle",
+    });
     this.toolStateManager.updateCanvasCursor();
 
     console.log(`🔷 Shape selected: ${shapeType}`);
 
     // Trigger tool change callback
     if (this.onToolChangeCallback) {
-      this.onToolChangeCallback('shapes');
+      this.onToolChangeCallback("shapes");
     }
   }
 
@@ -236,37 +263,37 @@ export class UIEventHandler {
    */
   private bindCanvasActions(): void {
     // Clear canvas button
-    const clearBtn = document.getElementById('clear-canvas');
+    const clearBtn = document.getElementById("clear-canvas");
     if (clearBtn) {
-      clearBtn.addEventListener('click', () => {
-        const event = new CustomEvent('clearCanvas');
+      clearBtn.addEventListener("click", () => {
+        const event = new CustomEvent("clearCanvas");
         document.dispatchEvent(event);
       });
     }
 
     // Clear all button
-    const clearAllBtn = document.getElementById('clear-all');
+    const clearAllBtn = document.getElementById("clear-all");
     if (clearAllBtn) {
-      clearAllBtn.addEventListener('click', () => {
-        const event = new CustomEvent('clearAll');
+      clearAllBtn.addEventListener("click", () => {
+        const event = new CustomEvent("clearAll");
         document.dispatchEvent(event);
       });
     }
 
     // Add page button
-    const addPageBtn = document.getElementById('add-page');
+    const addPageBtn = document.getElementById("add-page");
     if (addPageBtn) {
-      addPageBtn.addEventListener('click', () => {
-        const event = new CustomEvent('addPage');
+      addPageBtn.addEventListener("click", () => {
+        const event = new CustomEvent("addPage");
         document.dispatchEvent(event);
       });
     }
 
     // Layout toggle button
-    const layoutToggleBtn = document.getElementById('toggle-layout');
+    const layoutToggleBtn = document.getElementById("toggle-layout");
     if (layoutToggleBtn) {
-      layoutToggleBtn.addEventListener('click', () => {
-        const event = new CustomEvent('toggleLayout');
+      layoutToggleBtn.addEventListener("click", () => {
+        const event = new CustomEvent("toggleLayout");
         document.dispatchEvent(event);
       });
     }
@@ -276,7 +303,7 @@ export class UIEventHandler {
    * Cleanup event listeners
    */
   destroy(): void {
-    document.removeEventListener('click', this.handleGlobalClick);
+    document.removeEventListener("click", this.handleGlobalClick);
     // Additional cleanup as needed
   }
 }

--- a/src/scripts/navigation/aside/aside.ts
+++ b/src/scripts/navigation/aside/aside.ts
@@ -5,36 +5,36 @@
 export class AsideNavigation {
   private asideLinks: NodeListOf<HTMLAnchorElement>;
   private contentSections: NodeListOf<HTMLElement>;
-  private readonly STORAGE_KEY = 'coursebuilder_active_section';
+  private readonly STORAGE_KEY = "coursebuilder_active_section";
   private boundHandleLinkClick: (e: Event) => void;
 
   constructor() {
-    this.asideLinks = document.querySelectorAll('.aside__link');
-    this.contentSections = document.querySelectorAll('.article');
+    this.asideLinks = document.querySelectorAll(".aside__link");
+    this.contentSections = document.querySelectorAll(".article");
     this.boundHandleLinkClick = this.handleLinkClick.bind(this);
-    
-    console.log('Aside links found:', this.asideLinks.length);
-    console.log('Content sections found:', this.contentSections.length);
-    
+
+    console.log("Aside links found:", this.asideLinks.length);
+    console.log("Content sections found:", this.contentSections.length);
+
     this.init();
   }
 
   private init(): void {
     if (this.asideLinks.length === 0) {
-      console.error('No aside links found');
+      console.error("No aside links found");
       return;
     }
-    
+
     if (this.contentSections.length === 0) {
-      console.error('No content sections found');
+      console.error("No content sections found");
       return;
     }
-    
+
     // Restore last active section before binding events
     this.restoreActiveSection();
-    
+
     this.bindEvents();
-    console.log('Aside navigation initialized');
+    console.log("Aside navigation initialized");
   }
 
   /**
@@ -42,27 +42,29 @@ export class AsideNavigation {
    */
   private restoreActiveSection(): void {
     const savedSection = localStorage.getItem(this.STORAGE_KEY);
-    
+
     if (savedSection) {
-      console.log('Restoring saved section:', savedSection);
-      
+      console.log("Restoring saved section:", savedSection);
+
       // Find the link and section elements
-      const savedLink = document.querySelector(`[data-section="${savedSection}"]`) as HTMLAnchorElement;
+      const savedLink = document.querySelector(
+        `[data-section="${savedSection}"]`,
+      ) as HTMLAnchorElement;
       const savedSectionElement = document.getElementById(savedSection);
-      
+
       if (savedLink && savedSectionElement) {
         // Remove all active states first
         this.removeActiveStates();
-        
+
         // Set the saved section as active
         this.setActiveStates(savedLink, savedSection);
-        
-        console.log('Successfully restored section:', savedSection);
+
+        console.log("Successfully restored section:", savedSection);
       } else {
-        console.warn('Saved section not found in DOM:', savedSection);
+        console.warn("Saved section not found in DOM:", savedSection);
       }
     } else {
-      console.log('No saved section found, using default');
+      console.log("No saved section found, using default");
     }
   }
 
@@ -71,45 +73,53 @@ export class AsideNavigation {
    */
   private saveActiveSection(sectionId: string): void {
     localStorage.setItem(this.STORAGE_KEY, sectionId);
-    console.log('Saved active section to localStorage:', sectionId);
+    console.log("Saved active section to localStorage:", sectionId);
   }
 
   private bindEvents(): void {
     this.asideLinks.forEach((link: HTMLAnchorElement, index: number) => {
       console.log(`Binding event to link ${index}:`, link.textContent);
-      link.addEventListener('click', this.boundHandleLinkClick);
+      link.addEventListener("click", this.boundHandleLinkClick);
     });
   }
 
   private handleLinkClick(e: Event): void {
     const target = e.target as HTMLAnchorElement;
-    const href = target.getAttribute('href');
-    const targetSection = target.getAttribute('data-section');
-    
-    console.log('Aside link clicked:', target.textContent, 'Href:', href, 'Target section:', targetSection);
-    
+    const href = target.getAttribute("href");
+    const targetSection = target.getAttribute("data-section");
+
+    console.log(
+      "Aside link clicked:",
+      target.textContent,
+      "Href:",
+      href,
+      "Target section:",
+      targetSection,
+    );
+
     // Only handle aside navigation if we're currently in the setup section
     const currentHash = window.location.hash.substring(1);
-    const setupSection = document.getElementById('setup');
-    const isInSetupSection = (currentHash === 'setup' || !currentHash) && 
-                            setupSection?.classList.contains('section--active');
-    
+    const setupSection = document.getElementById("setup");
+    const isInSetupSection =
+      (currentHash === "setup" || !currentHash) &&
+      setupSection?.classList.contains("section--active");
+
     if (!isInSetupSection) {
-      console.log('🚫 Aside navigation: Not in setup section, ignoring click');
+      console.log("🚫 Aside navigation: Not in setup section, ignoring click");
       return; // Don't handle clicks when not in setup section
     }
-    
+
     // If the href is a full page URL (not a hash), allow normal navigation
-    if (href && href.startsWith('/') && !href.startsWith('#')) {
-      console.log('Full page navigation detected, allowing default behavior');
+    if (href && href.startsWith("/") && !href.startsWith("#")) {
+      console.log("Full page navigation detected, allowing default behavior");
       return; // Don't prevent default, let the browser navigate
     }
-    
+
     // For hash navigation (single-page), prevent default and handle manually
     e.preventDefault();
-    
+
     if (!targetSection) {
-      console.error('No data-section attribute found');
+      console.error("No data-section attribute found");
       return;
     }
 
@@ -117,45 +127,50 @@ export class AsideNavigation {
     if (this.isInCourseBuilderSetup()) {
       this.removeActiveStates();
       this.setActiveStates(target, targetSection);
-      
+
       // Save the active section to localStorage
       this.saveActiveSection(targetSection);
     } else {
       // For home page or other contexts, handle normally
       this.removeActiveStates();
       this.setActiveStates(target, targetSection);
-      
+
       // Save the active section to localStorage
       this.saveActiveSection(targetSection);
     }
   }
 
   private isInCourseBuilderSetup(): boolean {
-    const setupSection = document.getElementById('setup');
-    return setupSection ? setupSection.classList.contains('section--active') : false;
+    const setupSection = document.getElementById("setup");
+    return setupSection
+      ? setupSection.classList.contains("section--active")
+      : false;
   }
 
   private removeActiveStates(): void {
     this.asideLinks.forEach((link: HTMLAnchorElement) => {
-      link.classList.remove('aside__link--active');
+      link.classList.remove("aside__link--active");
     });
-    
+
     this.contentSections.forEach((section: HTMLElement) => {
-      section.classList.remove('article--active');
+      section.classList.remove("article--active");
     });
-    
-    console.log('Removed all active states');
+
+    console.log("Removed all active states");
   }
 
-  private setActiveStates(activeLink: HTMLAnchorElement, targetSectionId: string): void {
-    activeLink.classList.add('aside__link--active');
-    
+  private setActiveStates(
+    activeLink: HTMLAnchorElement,
+    targetSectionId: string,
+  ): void {
+    activeLink.classList.add("aside__link--active");
+
     const targetSection = document.getElementById(targetSectionId);
     if (targetSection) {
-      targetSection.classList.add('article--active');
-      console.log('Activated section:', targetSectionId);
+      targetSection.classList.add("article--active");
+      console.log("Activated section:", targetSectionId);
     } else {
-      console.error('Target section not found:', targetSectionId);
+      console.error("Target section not found:", targetSectionId);
     }
   }
 
@@ -165,9 +180,9 @@ export class AsideNavigation {
   public destroy(): void {
     // Remove event listeners
     this.asideLinks.forEach((link: HTMLAnchorElement) => {
-      link.removeEventListener('click', this.boundHandleLinkClick);
+      link.removeEventListener("click", this.boundHandleLinkClick);
     });
-    
-    console.log('AsideNavigation destroyed');
+
+    console.log("AsideNavigation destroyed");
   }
 }

--- a/src/scripts/navigation/coursebuilder/coursebuilder.ts
+++ b/src/scripts/navigation/coursebuilder/coursebuilder.ts
@@ -3,7 +3,7 @@
 // ==========================================================================
 
 export class CourseBuilderNavigation {
-  private sections: string[] = ['setup', 'create', 'preview', 'launch'];
+  private sections: string[] = ["setup", "create", "preview", "launch"];
   private currentSectionIndex: number = 0;
   private previousBtn: HTMLButtonElement;
   private nextBtn: HTMLButtonElement;
@@ -13,52 +13,68 @@ export class CourseBuilderNavigation {
   constructor() {
     CourseBuilderNavigation.instanceCount++;
     this.instanceId = CourseBuilderNavigation.instanceCount;
-    console.log(`🎯 CourseBuilderNavigation instance ${this.instanceId} created (total: ${CourseBuilderNavigation.instanceCount})`);
-    
-    this.previousBtn = document.getElementById('previous-btn') as HTMLButtonElement;
-    this.nextBtn = document.getElementById('next-btn') as HTMLButtonElement;
-    
+    console.log(
+      `🎯 CourseBuilderNavigation instance ${this.instanceId} created (total: ${CourseBuilderNavigation.instanceCount})`,
+    );
+
+    this.previousBtn = document.getElementById(
+      "previous-btn",
+    ) as HTMLButtonElement;
+    this.nextBtn = document.getElementById("next-btn") as HTMLButtonElement;
+
     this.init();
   }
 
   private init(): void {
-    console.log(`🎯 CourseBuilderNavigation instance ${this.instanceId} initializing...`);
-    
+    console.log(
+      `🎯 CourseBuilderNavigation instance ${this.instanceId} initializing...`,
+    );
+
     if (!this.previousBtn || !this.nextBtn) {
-      console.error(`🎯 Instance ${this.instanceId}: Previous or Next button not found`);
+      console.error(
+        `🎯 Instance ${this.instanceId}: Previous or Next button not found`,
+      );
       return;
     }
 
     // Set initial section based on URL hash
     this.setInitialSection();
-    
+
     // Bind button events
     this.bindEvents();
-    
+
     // Update UI
     this.updateUI();
-    
-    console.log(`🎯 Instance ${this.instanceId}: Course builder navigation initialized`);
+
+    console.log(
+      `🎯 Instance ${this.instanceId}: Course builder navigation initialized`,
+    );
   }
 
   private setInitialSection(): void {
     const hash = window.location.hash.substring(1); // Remove #
-    console.log(`🎯 CourseBuilderNavigation.setInitialSection() called with hash: "${hash}"`);
-    console.log(`🎯 Available sections: [${this.sections.join(', ')}]`);
-    
+    console.log(
+      `🎯 CourseBuilderNavigation.setInitialSection() called with hash: "${hash}"`,
+    );
+    console.log(`🎯 Available sections: [${this.sections.join(", ")}]`);
+
     const sectionIndex = this.sections.indexOf(hash);
     console.log(`🎯 Section index for "${hash}": ${sectionIndex}`);
-    
+
     if (sectionIndex !== -1) {
       this.currentSectionIndex = sectionIndex;
-      console.log(`🎯 Set current section index to: ${sectionIndex} (${this.sections[sectionIndex]})`);
+      console.log(
+        `🎯 Set current section index to: ${sectionIndex} (${this.sections[sectionIndex]})`,
+      );
       // Force navigate to the correct section immediately
       this.navigateToSection();
     } else {
-      console.log(`🎯 Hash "${hash}" not found in sections, defaulting to setup`);
+      console.log(
+        `🎯 Hash "${hash}" not found in sections, defaulting to setup`,
+      );
       this.currentSectionIndex = 0; // Default to setup
       // Only navigate if we're not already on setup and the hash isn't empty
-      if (hash && hash !== 'setup') {
+      if (hash && hash !== "setup") {
         console.log(`🎯 Navigating to setup because unknown hash: "${hash}"`);
         this.navigateToSection();
       } else {
@@ -68,104 +84,152 @@ export class CourseBuilderNavigation {
   }
 
   private bindEvents(): void {
-    this.previousBtn.addEventListener('click', () => {
+    this.previousBtn.addEventListener("click", () => {
       console.log(`🎯 Instance ${this.instanceId}: Previous button clicked!`);
       this.goToPrevious();
     });
-    this.nextBtn.addEventListener('click', () => {
+    this.nextBtn.addEventListener("click", () => {
       console.log(`🎯 Instance ${this.instanceId}: Next button clicked!`);
       this.goToNext();
+    });
+
+    // Listen for hash changes to keep section in sync
+    window.addEventListener("hashchange", () => {
+      console.log(
+        `🎯 Instance ${this.instanceId}: Hash changed! Re-evaluating section.`,
+      );
+      this.setInitialSection();
     });
   }
 
   private goToPrevious(): void {
-    console.log(`🎯 Instance ${this.instanceId}: goToPrevious() called - current index: ${this.currentSectionIndex}`);
-    
+    console.log(
+      `🎯 Instance ${this.instanceId}: goToPrevious() called - current index: ${this.currentSectionIndex}`,
+    );
+
     // If we're in the first section (setup), navigate to courses.html
     if (this.currentSectionIndex === 0) {
-      console.log(`🎯 Instance ${this.instanceId}: Navigating to courses.html from setup`);
-      window.location.href = '/src/pages/teacher/courses.html';
+      console.log(
+        `🎯 Instance ${this.instanceId}: Navigating to courses.html from setup`,
+      );
+      window.location.href = "/src/pages/teacher/courses.html";
       return;
     }
-    
+
     // Otherwise, go to previous section
     this.currentSectionIndex--;
-    console.log(`🎯 Instance ${this.instanceId}: Going to previous section, new index: ${this.currentSectionIndex}`);
+    console.log(
+      `🎯 Instance ${this.instanceId}: Going to previous section, new index: ${this.currentSectionIndex}`,
+    );
     this.navigateToSection();
   }
 
   private goToNext(): void {
-    console.log(`🎯 Instance ${this.instanceId}: goToNext() called - current index: ${this.currentSectionIndex}`);
-    
+    console.log(
+      `🎯 Instance ${this.instanceId}: goToNext() called - current index: ${this.currentSectionIndex}`,
+    );
+
     if (this.currentSectionIndex < this.sections.length - 1) {
       this.currentSectionIndex++;
-      console.log(`🎯 Instance ${this.instanceId}: Going to next section, new index: ${this.currentSectionIndex}`);
+      console.log(
+        `🎯 Instance ${this.instanceId}: Going to next section, new index: ${this.currentSectionIndex}`,
+      );
       this.navigateToSection();
     } else {
-      console.log(`🎯 Instance ${this.instanceId}: Already at last section, no navigation`);
+      console.log(
+        `🎯 Instance ${this.instanceId}: Already at last section, no navigation`,
+      );
     }
   }
 
   private navigateToSection(): void {
     const targetSection = this.sections[this.currentSectionIndex];
-    console.log(`🚀 Instance ${this.instanceId}: Navigating to section: ${targetSection} (index: ${this.currentSectionIndex})`);
-    console.log(`🚀 Instance ${this.instanceId}: Call stack:`, new Error().stack);
-    
+    console.log(
+      `🚀 Instance ${this.instanceId}: Navigating to section: ${targetSection} (index: ${this.currentSectionIndex})`,
+    );
+    console.log(
+      `🚀 Instance ${this.instanceId}: Call stack:`,
+      new Error().stack,
+    );
+
     // Check if DOM is ready
-    console.log(`🚀 Instance ${this.instanceId}: DOM sections found:`, this.sections.map(id => {
-      const element = document.getElementById(id);
-      return `${id}: ${element ? 'exists' : 'MISSING'}`;
-    }).join(', '));
-    
+    console.log(
+      `🚀 Instance ${this.instanceId}: DOM sections found:`,
+      this.sections
+        .map((id) => {
+          const element = document.getElementById(id);
+          return `${id}: ${element ? "exists" : "MISSING"}`;
+        })
+        .join(", "),
+    );
+
     // Hide all sections
-    this.sections.forEach(sectionId => {
+    this.sections.forEach((sectionId) => {
       const section = document.getElementById(sectionId);
       if (section) {
-        section.classList.remove('section--active');
-        console.log(`🚀 Instance ${this.instanceId}: Hiding section: ${sectionId}`);
+        section.classList.remove("section--active");
+        console.log(
+          `🚀 Instance ${this.instanceId}: Hiding section: ${sectionId}`,
+        );
       } else {
-        console.error(`🚀 Instance ${this.instanceId}: Section element not found when hiding: ${sectionId}`);
+        console.error(
+          `🚀 Instance ${this.instanceId}: Section element not found when hiding: ${sectionId}`,
+        );
       }
     });
-    
+
     // Show target section
     const activeSection = document.getElementById(targetSection);
     if (activeSection) {
-      activeSection.classList.add('section--active');
-      console.log(`🚀 Instance ${this.instanceId}: Showing section: ${targetSection}`);
+      activeSection.classList.add("section--active");
+      console.log(
+        `🚀 Instance ${this.instanceId}: Showing section: ${targetSection}`,
+      );
     } else {
-      console.error(`🚀 Instance ${this.instanceId}: Target section element not found: ${targetSection}`);
+      console.error(
+        `🚀 Instance ${this.instanceId}: Target section element not found: ${targetSection}`,
+      );
     }
-    
-    // Update URL hash - this will trigger the hashchange event
-    console.log(`🚀 Instance ${this.instanceId}: Setting hash to: ${targetSection}`);
-    window.location.hash = targetSection;
-    
+
+    // Update URL hash only if it's different to avoid redundant hashchange events
+    const currentHash = window.location.hash.substring(1);
+    if (currentHash !== targetSection) {
+      console.log(
+        `🚀 Instance ${this.instanceId}: Setting hash to: ${targetSection}`,
+      );
+      window.location.hash = targetSection;
+    }
+
     // For the create section, we need to trigger coursebuilder initialization
     // after the DOM has updated but before the hashchange event fires
-    if (targetSection === 'create') {
+    if (targetSection === "create") {
       // Dispatch a custom event that the coursebuilder can listen to
       setTimeout(() => {
-        console.log(`🚀 Instance ${this.instanceId}: Dispatching coursebuilder:section-activated event for ${targetSection}`);
-        const event = new CustomEvent('coursebuilder:section-activated', {
-          detail: { section: targetSection }
+        console.log(
+          `🚀 Instance ${this.instanceId}: Dispatching coursebuilder:section-activated event for ${targetSection}`,
+        );
+        const event = new CustomEvent("coursebuilder:section-activated", {
+          detail: { section: targetSection },
         });
         window.dispatchEvent(event);
       }, 50);
     }
-    
+
     // Update UI
     this.updateUI();
-    
-    console.log(`🚀 Instance ${this.instanceId}: Navigation complete. Active section: ${targetSection}`);
+
+    console.log(
+      `🚀 Instance ${this.instanceId}: Navigation complete. Active section: ${targetSection}`,
+    );
   }
 
   private updateUI(): void {
     // Update button states
     // Previous button is never disabled, it either goes to previous section or courses.html
     this.previousBtn.disabled = false;
-    this.nextBtn.disabled = this.currentSectionIndex === this.sections.length - 1;
-    
+    this.nextBtn.disabled =
+      this.currentSectionIndex === this.sections.length - 1;
+
     // Update button text and styling based on current section
     this.updateButtonText();
   }
@@ -173,21 +237,24 @@ export class CourseBuilderNavigation {
   private updateButtonText(): void {
     // Update Previous button - always shows "Courses" when in setup section
     if (this.currentSectionIndex === 0) {
-      this.previousBtn.textContent = 'Courses';
-      this.previousBtn.classList.add('button--secondary');
-      this.previousBtn.classList.remove('button--disabled');
+      this.previousBtn.textContent = "Courses";
+      this.previousBtn.classList.add("button--secondary");
+      this.previousBtn.classList.remove("button--disabled");
     } else {
       const previousSection = this.sections[this.currentSectionIndex - 1];
       this.previousBtn.textContent = `← ${this.capitalizeFirst(previousSection)}`;
-      this.previousBtn.classList.remove('button--secondary', 'button--disabled');
+      this.previousBtn.classList.remove(
+        "button--secondary",
+        "button--disabled",
+      );
     }
-    
+
     // Update Next button
     if (this.currentSectionIndex < this.sections.length - 1) {
       const nextSection = this.sections[this.currentSectionIndex + 1];
       this.nextBtn.textContent = `${this.capitalizeFirst(nextSection)} →`;
     } else {
-      this.nextBtn.textContent = 'Launch Course';
+      this.nextBtn.textContent = "Launch Course";
     }
   }
 

--- a/src/scripts/navigation/index.ts
+++ b/src/scripts/navigation/index.ts
@@ -2,8 +2,8 @@
 // NAVIGATION INDEX
 // ==========================================================================
 
-import { AsideNavigation } from './aside/aside';
-import { CourseBuilderNavigation } from './coursebuilder/coursebuilder';
+import { AsideNavigation } from "./aside/aside";
+import { CourseBuilderNavigation } from "./coursebuilder/coursebuilder";
 
 // Global navigation instances
 let asideNavigationInstance: AsideNavigation | null = null;
@@ -12,18 +12,18 @@ let courseBuilderNavigationInstance: CourseBuilderNavigation | null = null;
 // Navigation initialization based on page type
 export function initNavigation(): void {
   const path = window.location.pathname;
-  
+
   // Initialize course builder navigation first (it handles section switching)
   if (isCourseBuilderPage(path)) {
     courseBuilderNavigationInstance = new CourseBuilderNavigation();
-    
+
     // Listen for section changes to manage aside navigation
-    window.addEventListener('hashchange', handleCourseBuilderSectionChange);
-    
+    window.addEventListener("hashchange", handleCourseBuilderSectionChange);
+
     // Initialize aside navigation based on current section
     handleCourseBuilderSectionChange();
   }
-  
+
   // For non-coursebuilder pages, initialize aside navigation normally
   if (hasAsideNavigation(path) && !isCourseBuilderPage(path)) {
     asideNavigationInstance = new AsideNavigation();
@@ -33,20 +33,23 @@ export function initNavigation(): void {
 // Handle section changes in coursebuilder to manage aside navigation
 function handleCourseBuilderSectionChange(): void {
   if (!isCourseBuilderPage(window.location.pathname)) return;
-  
+
   const hash = window.location.hash.substring(1);
   console.log(`🧭 Section changed to: ${hash}`);
-  
+
   // Only initialize aside navigation for setup section
-  if (hash === 'setup' || (!hash && window.location.pathname.includes('coursebuilder.html'))) {
+  if (
+    hash === "setup" ||
+    (!hash && window.location.pathname.includes("coursebuilder.html"))
+  ) {
     if (!asideNavigationInstance) {
-      console.log('🧭 Initializing aside navigation for setup section');
+      console.log("🧭 Initializing aside navigation for setup section");
       asideNavigationInstance = new AsideNavigation();
     }
   } else {
     // Clean up aside navigation when leaving setup
     if (asideNavigationInstance) {
-      console.log('🧭 Cleaning up aside navigation (leaving setup section)');
+      console.log("🧭 Cleaning up aside navigation (leaving setup section)");
       asideNavigationInstance.destroy();
       asideNavigationInstance = null;
     }
@@ -55,18 +58,20 @@ function handleCourseBuilderSectionChange(): void {
 
 // Check if current page has aside navigation
 function hasAsideNavigation(path: string): boolean {
-  return path.includes('/pages/teacher/home.html') ||
-         path.includes('/pages/teacher/coursebuilder.html') ||
-         path.includes('/pages/student/home.html') ||
-         path.includes('/pages/admin/home.html');
+  return (
+    path.includes("/pages/teacher/home.html") ||
+    path.includes("/pages/teacher/coursebuilder.html") ||
+    path.includes("/pages/student/home.html") ||
+    path.includes("/pages/admin/home.html")
+  );
 }
 
 // Check if current page is course builder
 function isCourseBuilderPage(path: string): boolean {
-  return path.includes('/pages/teacher/coursebuilder.html');
+  return path.includes("/pages/teacher/coursebuilder.html");
 }
 
 // Initialize when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   initNavigation();
 });

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -5,16 +5,24 @@
 // Responsive breakpoints
 @mixin respond-to($breakpoint) {
   @if $breakpoint == sm {
-    @media (min-width: 640px) { @content; }
+    @media (min-width: 640px) {
+      @content;
+    }
   }
   @if $breakpoint == md {
-    @media (min-width: 768px) { @content; }
+    @media (min-width: 768px) {
+      @content;
+    }
   }
   @if $breakpoint == lg {
-    @media (min-width: 1024px) { @content; }
+    @media (min-width: 1024px) {
+      @content;
+    }
   }
   @if $breakpoint == xl {
-    @media (min-width: 1280px) { @content; }
+    @media (min-width: 1280px) {
+      @content;
+    }
   }
 }
 

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -3,15 +3,15 @@
 // ==========================================================================
 
 // Primary Colors - Educational Theme
-$primary-color: #5083f1;          // Blue - Professional and trustworthy
-$primary-color-light: #dbeafe;    // Light blue variant
-$secondary-color: #059669;        // Green - Success and growth
-$accent-color: #f59e0b;           // Amber - Warm and inviting
+$primary-color: #5083f1; // Blue - Professional and trustworthy
+$primary-color-light: #dbeafe; // Light blue variant
+$secondary-color: #059669; // Green - Success and growth
+$accent-color: #f59e0b; // Amber - Warm and inviting
 
 // User Role Colors
-$student-color: #3b82f6;          // Light blue for students
-$teacher-color: #059669;          // Green for teachers  
-$admin-color: #ef4444;            // Red for admin
+$student-color: #3b82f6; // Light blue for students
+$teacher-color: #059669; // Green for teachers
+$admin-color: #ef4444; // Red for admin
 
 // Neutral Colors
 $white: #ffffff;
@@ -29,11 +29,11 @@ $gray-900: #111827;
 
 // Status Colors
 $success: #10b981;
-$success-color: #10b981;          // Alias for consistency
+$success-color: #10b981; // Alias for consistency
 $warning: #f59e0b;
-$warning-color: #f59e0b;          // Alias for consistency  
+$warning-color: #f59e0b; // Alias for consistency
 $error: #ef4444;
-$danger-color: #ef4444;           // Alias for consistency
+$danger-color: #ef4444; // Alias for consistency
 $info: #3b82f6;
 
 // Background Colors
@@ -48,19 +48,31 @@ $text-muted: $gray-400;
 $text-on-dark: $white;
 
 // Typography
-$font-family-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-$font-family-heading: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-$font-family-mono: 'Fira Code', 'SF Mono', Monaco, 'Cascadia Code', monospace;
+$font-family-base:
+  "Inter",
+  -apple-system,
+  BlinkMacSystemFont,
+  "Segoe UI",
+  Roboto,
+  sans-serif;
+$font-family-heading:
+  "Inter",
+  -apple-system,
+  BlinkMacSystemFont,
+  "Segoe UI",
+  Roboto,
+  sans-serif;
+$font-family-mono: "Fira Code", "SF Mono", Monaco, "Cascadia Code", monospace;
 
 // Font Sizes
-$font-size-xs: 0.75rem;    // 12px
-$font-size-sm: 0.875rem;   // 14px  
-$font-size-base: 1rem;     // 16px
-$font-size-lg: 1.125rem;   // 18px
-$font-size-xl: 1.25rem;    // 20px
-$font-size-2xl: 1.5rem;    // 24px
-$font-size-3xl: 1.875rem;  // 30px
-$font-size-4xl: 2.25rem;   // 36px
+$font-size-xs: 0.75rem; // 12px
+$font-size-sm: 0.875rem; // 14px
+$font-size-base: 1rem; // 16px
+$font-size-lg: 1.125rem; // 18px
+$font-size-xl: 1.25rem; // 20px
+$font-size-2xl: 1.5rem; // 24px
+$font-size-3xl: 1.875rem; // 30px
+$font-size-4xl: 2.25rem; // 36px
 
 // Font Weights
 $font-weight-light: 300;
@@ -76,33 +88,41 @@ $line-height-relaxed: 1.625;
 
 // Spacing Scale
 $spacing-0: 0;
-$spacing-1: 0.25rem;    // 4px
-$spacing-2: 0.5rem;     // 8px
-$spacing-3: 0.75rem;    // 12px
-$spacing-4: 1rem;       // 16px
-$spacing-5: 1.25rem;    // 20px
-$spacing-6: 1.5rem;     // 24px
-$spacing-8: 2rem;       // 32px
-$spacing-10: 2.5rem;    // 40px
-$spacing-12: 3rem;      // 48px
-$spacing-16: 4rem;      // 64px
-$spacing-20: 5rem;      // 80px
-$spacing-24: 6rem;      // 96px
+$spacing-1: 0.25rem; // 4px
+$spacing-2: 0.5rem; // 8px
+$spacing-3: 0.75rem; // 12px
+$spacing-4: 1rem; // 16px
+$spacing-5: 1.25rem; // 20px
+$spacing-6: 1.5rem; // 24px
+$spacing-8: 2rem; // 32px
+$spacing-10: 2.5rem; // 40px
+$spacing-12: 3rem; // 48px
+$spacing-16: 4rem; // 64px
+$spacing-20: 5rem; // 80px
+$spacing-24: 6rem; // 96px
 
 // Border Radius
-$border-radius-sm: 0.25rem;   // 4px
-$border-radius: 0.375rem;     // 6px
-$border-radius-md: 0.5rem;    // 8px
-$border-radius-lg: 0.75rem;   // 12px
-$border-radius-xl: 1rem;      // 16px
+$border-radius-sm: 0.25rem; // 4px
+$border-radius: 0.375rem; // 6px
+$border-radius-md: 0.5rem; // 8px
+$border-radius-lg: 0.75rem; // 12px
+$border-radius-xl: 1rem; // 16px
 $border-radius-full: 9999px;
 
 // Shadows
 $shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-$shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-$shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-$shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-$shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+$shadow:
+  0 1px 3px 0 rgba(0, 0, 0, 0.1),
+  0 1px 2px 0 rgba(0, 0, 0, 0.06);
+$shadow-md:
+  0 4px 6px -1px rgba(0, 0, 0, 0.1),
+  0 2px 4px -1px rgba(0, 0, 0, 0.06);
+$shadow-lg:
+  0 10px 15px -3px rgba(0, 0, 0, 0.1),
+  0 4px 6px -2px rgba(0, 0, 0, 0.05);
+$shadow-xl:
+  0 20px 25px -5px rgba(0, 0, 0, 0.1),
+  0 10px 10px -5px rgba(0, 0, 0, 0.04);
 
 // Breakpoints
 $breakpoint-sm: 640px;

--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -7,7 +7,9 @@ html {
   box-sizing: border-box;
 }
 
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
 }
 

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -2,8 +2,8 @@
 // BASE TYPOGRAPHY
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
-@use 'sass:color';
+@use "../abstracts/variables" as *;
+@use "sass:color";
 
 body {
   font-family: $font-family-base;
@@ -19,12 +19,12 @@ body {
   font-weight: $font-weight-bold;
   line-height: $line-height-tight;
   margin: 0;
-  
+
   &--primary {
     font-size: $font-size-4xl;
     color: $text-primary;
   }
-  
+
   &--secondary {
     font-size: $font-size-2xl;
     color: $text-secondary;
@@ -37,18 +37,18 @@ body {
 
 .text {
   margin: 0;
-  
+
   &--lead {
     font-size: $font-size-xl;
     color: $text-secondary;
     font-weight: $font-weight-normal;
   }
-  
+
   &--body {
     font-size: $font-size-base;
     color: $text-secondary;
   }
-  
+
   &--small {
     font-size: $font-size-sm;
     color: $text-muted;
@@ -62,29 +62,29 @@ body {
 .link {
   text-decoration: none;
   transition: color 0.2s ease;
-  
+
   &--nav {
     color: $text-secondary;
     font-weight: $font-weight-medium;
-    
+
     &:hover {
       color: $text-primary;
     }
   }
-  
+
   &--footer {
     color: $text-muted;
     font-size: $font-size-sm;
-    
+
     &:hover {
       color: $text-secondary;
     }
   }
-  
+
   &--primary {
     color: $primary-color;
     font-weight: $font-weight-medium;
-    
+
     &:hover {
       color: color.adjust($primary-color, $lightness: -10%);
     }
@@ -99,12 +99,12 @@ body {
   list-style: none;
   margin: 0;
   padding: 0;
-  
+
   &--nav {
     display: flex;
     gap: $spacing-8;
   }
-  
+
   &--footer {
     gap: $spacing-6;
   }
@@ -116,11 +116,11 @@ body {
 
 .logo {
   display: inline-block;
-  
+
   &__image {
     height: $spacing-10;
     width: auto;
-    
+
     &--small {
       height: $spacing-8;
     }

--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -2,8 +2,8 @@
 // BUTTON COMPONENT
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
-@use 'sass:color';
+@use "../abstracts/variables" as *;
+@use "sass:color";
 
 .button {
   display: inline-flex;
@@ -17,54 +17,54 @@
   transition: all 0.2s ease;
   cursor: pointer;
   font-size: $font-size-sm;
-  
+
   // ==========================================================================
   // BUTTON VARIANTS (COLOR/STYLE)
   // ==========================================================================
-  
+
   &--primary {
     background-color: $primary-color;
     color: $white;
-    
+
     &:hover {
       background-color: color.adjust($primary-color, $lightness: -10%);
     }
   }
-  
+
   &--secondary {
     background-color: $gray-100;
     color: $text-secondary;
-    
+
     &:hover {
       background-color: $gray-200;
     }
   }
-  
+
   &--outline {
     background-color: transparent;
     border: 1px solid $gray-300;
     color: $text-secondary;
-    
+
     &:hover {
       background-color: $gray-50;
     }
   }
-  
+
   // ==========================================================================
   // BUTTON SIZES (MODIFIERS)
   // ==========================================================================
-  
+
   &--small {
     padding: $spacing-2 $spacing-4;
     font-size: $font-size-xs;
   }
-  
+
   &--large {
     padding: $spacing-4 $spacing-8;
     font-size: $font-size-base;
     width: 100%;
   }
-  
+
   &--extra-large {
     padding: $spacing-5 $spacing-10;
     font-size: $font-size-lg;

--- a/src/scss/components/_canvas-layout.scss
+++ b/src/scss/components/_canvas-layout.scss
@@ -113,7 +113,7 @@
 }
 
 .canvas-thumbnail--active::before {
-  content: '';
+  content: "";
   position: absolute;
   left: 0;
   top: 0;
@@ -143,27 +143,27 @@
 }
 
 .canvas-thumbnail__block--header {
-  background: linear-gradient(135deg, #E3F2FD, #BBDEFB);
+  background: linear-gradient(135deg, #e3f2fd, #bbdefb);
 }
 
 .canvas-thumbnail__block--program {
-  background: linear-gradient(135deg, #F3E5F5, #E1BEE7);
+  background: linear-gradient(135deg, #f3e5f5, #e1bee7);
 }
 
 .canvas-thumbnail__block--resources {
-  background: linear-gradient(135deg, #E8F5E8, #C8E6C9);
+  background: linear-gradient(135deg, #e8f5e8, #c8e6c9);
 }
 
 .canvas-thumbnail__block--content {
-  background: linear-gradient(135deg, #FFF3E0, #FFE0B2);
+  background: linear-gradient(135deg, #fff3e0, #ffe0b2);
 }
 
 .canvas-thumbnail__block--assignment {
-  background: linear-gradient(135deg, #FCE4EC, #F8BBD9);
+  background: linear-gradient(135deg, #fce4ec, #f8bbd9);
 }
 
 .canvas-thumbnail__block--footer {
-  background: linear-gradient(135deg, #F5F5F5, #EEEEEE);
+  background: linear-gradient(135deg, #f5f5f5, #eeeeee);
 }
 
 .canvas-thumbnail__label {
@@ -246,22 +246,22 @@
   .canvas-thumbnail {
     padding: 0.5rem;
   }
-  
+
   .canvas-thumbnail__preview {
     width: 32px;
     height: 45px;
     margin-right: 0.5rem;
   }
-  
+
   .canvas-thumbnail__session,
   .canvas-thumbnail__number {
     font-size: 0.7rem;
   }
-  
+
   .canvas-thumbnail__type {
     font-size: 0.8rem;
   }
-  
+
   .canvas-nav-btn {
     width: 28px;
     height: 28px;

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -2,23 +2,23 @@
 // CARD COMPONENTS
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 .card {
   background: $white;
   border-radius: $border-radius;
   box-shadow: $shadow;
   overflow: hidden;
-  
+
   &__header {
     padding: $spacing-4 $spacing-5;
     border-bottom: 1px solid $gray-200;
   }
-  
+
   &__content {
     padding: $spacing-5;
   }
-  
+
   &__footer {
     padding: $spacing-4 $spacing-5;
     border-top: 1px solid $gray-200;
@@ -38,12 +38,12 @@
   transition: all 0.2s ease;
   cursor: pointer;
   max-width: 350px;
-  
+
   &:hover {
     transform: translateY(-2px);
     box-shadow: $shadow-lg;
   }
-  
+
   &__image {
     width: 100%;
     height: 200px;
@@ -55,11 +55,15 @@
     color: $gray-500;
     font-size: 0.875rem;
   }
-  
+
   &__image-placeholder {
     width: 100%;
     height: 200px;
-    background: linear-gradient(135deg, lighten($primary-color, 20%), $primary-color);
+    background: linear-gradient(
+      135deg,
+      lighten($primary-color, 20%),
+      $primary-color
+    );
     display: flex;
     align-items: center;
     justify-content: center;
@@ -67,11 +71,11 @@
     font-size: 1.125rem;
     font-weight: $font-weight-medium;
   }
-  
+
   &__content {
     padding: $spacing-4;
   }
-  
+
   &__title {
     font-size: 1.125rem;
     font-weight: $font-weight-semibold;
@@ -79,13 +83,13 @@
     margin-bottom: $spacing-3;
     line-height: 1.4;
   }
-  
+
   &__navigation {
     display: flex;
     border-top: 1px solid $gray-200;
     background: $gray-50;
   }
-  
+
   &__nav-item {
     flex: 1;
     padding: $spacing-3 $spacing-2;
@@ -96,11 +100,11 @@
     cursor: pointer;
     transition: all 0.2s ease;
     position: relative;
-    
+
     &:not(:last-child) {
       border-right: 1px solid $gray-200;
     }
-    
+
     &:hover {
       background: $gray-100;
       color: $text-primary;
@@ -119,7 +123,7 @@
   margin-bottom: $spacing-6;
   padding-bottom: $spacing-4;
   border-bottom: 1px solid $gray-200;
-  
+
   @media (max-width: #{$breakpoint-sm - 1px}) {
     flex-direction: column;
     gap: $spacing-4;
@@ -132,7 +136,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: $spacing-6;
-  
+
   @media (max-width: #{$breakpoint-sm - 1px}) {
     grid-template-columns: 1fr;
     gap: $spacing-4;
@@ -143,7 +147,7 @@
   grid-column: 1 / -1;
   text-align: center;
   padding: $spacing-8 $spacing-4;
-  
+
   .text {
     font-size: 1.125rem;
   }

--- a/src/scss/components/_coursebuilder.scss
+++ b/src/scss/components/_coursebuilder.scss
@@ -2,8 +2,8 @@
 // COURSEBUILDER COMPONENT
 // ==========================================================================
 
-@use '../abstracts/variables' as vars;
-@use '../abstracts/mixins' as mixins;
+@use "../abstracts/variables" as vars;
+@use "../abstracts/mixins" as mixins;
 
 /* Course Builder Component */
 .coursebuilder {
@@ -15,7 +15,7 @@
   height: 100%; /* Fill the available container space */
   box-sizing: border-box;
   background-color: vars.$gray-50;
-  
+
   > * {
     border: 1px solid vars.$gray-200;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -23,7 +23,7 @@
     background-color: vars.$white;
     box-sizing: border-box;
   }
-  
+
   /* Options Bar (spans media bar and media search areas only) */
   &__options-bar {
     grid-column: 1 / 3;
@@ -33,7 +33,7 @@
     justify-content: flex-start;
     padding: 0.25rem;
   }
-  
+
   /* Canvas Toolbar (above canvas area - row 1, column 3) */
   &__canvas-toolbar {
     grid-column: 3;
@@ -42,9 +42,8 @@
     align-items: center;
     justify-content: flex-start;
     padding: 0.25rem;
-
   }
-  
+
   /* Table of Contents Options (separate top right area) */
   &__toc-options {
     grid-column: 4;
@@ -55,9 +54,8 @@
     align-items: center;
     gap: 1rem;
     padding: 0.5rem;
-
   }
-  
+
   /* Media Bar (Left Sidebar) */
   &__media-bar {
     grid-column: 1;
@@ -71,7 +69,7 @@
     overflow-y: auto; /* Allow scrolling if content overflows */
     padding: 0.5rem 0.25rem;
   }
-  
+
   /* Media Search Panel */
   &__media-search {
     grid-column: 2;
@@ -82,7 +80,7 @@
     height: 100%; /* Ensure it fills the grid area */
     overflow-y: auto; /* Allow scrolling if content overflows */
   }
-  
+
   /* Main Canvas Area - simplified with direct canvas styling */
   &__canvas {
     grid-column: 3;
@@ -97,7 +95,7 @@
     padding: 20px;
     height: 100%; /* Fill grid area */
     overflow: auto; /* Only the canvas area scrolls */
-    
+
     /* Direct canvas styling - A4 proportions */
     canvas {
       width: 794px !important;
@@ -111,7 +109,7 @@
       touch-action: none;
     }
   }
-  
+
   /* Table of Contents Sidebar */
   &__toc {
     grid-column: 4;
@@ -132,7 +130,7 @@
   overflow: hidden;
   justify-content: flex-start;
   width: 100%;
-  
+
   &__tools {
     display: flex;
     gap: 1rem;
@@ -141,7 +139,7 @@
     padding: 0;
     flex-shrink: 0; // Don't shrink the tools
   }
-  
+
   &__settings {
     flex: 1; // Take up remaining space
     overflow-x: auto; // Allow horizontal scrolling if needed
@@ -167,7 +165,7 @@
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   gap: 0.25rem;
   position: relative;
-  
+
   &__icon {
     width: 2.5rem;
     height: 2.5rem;
@@ -177,7 +175,7 @@
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(100, 149, 237, 0.1);
-    
+
     svg {
       width: 85%;
       height: 85%;
@@ -185,7 +183,7 @@
       transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     }
   }
-  
+
   &__label {
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     font-size: 0.75rem;
@@ -193,37 +191,39 @@
     text-align: center;
     color: vars.$gray-700;
   }
-  
+
   &:hover {
     transform: translateY(-1px);
-    
+
     .tool__icon {
       background: rgba(100, 149, 237, 0.15);
       border-color: rgba(100, 149, 237, 0.3);
       box-shadow: 0 4px 12px rgba(100, 149, 237, 0.2);
-      
+
       svg {
         transform: scale(1.05);
       }
     }
-    
+
     .tool__label {
       color: vars.$primary-color;
     }
   }
-  
+
   &--selected {
     .tool__icon {
       background: linear-gradient(135deg, vars.$primary-color 0%, #91b4f2 100%);
       border-color: vars.$primary-color;
-      box-shadow: 0 6px 20px rgba(100, 149, 237, 0.3), 0 0 0 2px rgba(100, 149, 237, 0.2);
-      
+      box-shadow:
+        0 6px 20px rgba(100, 149, 237, 0.3),
+        0 0 0 2px rgba(100, 149, 237, 0.2);
+
       svg {
         filter: brightness(0) invert(1);
         transform: scale(1.1);
       }
     }
-    
+
     .tool__label {
       color: vars.$primary-color;
       font-weight: 600;
@@ -237,7 +237,7 @@
   align-items: center;
   gap: 1rem;
   flex: 1;
-  
+
   &--active {
     display: flex;
   }
@@ -248,7 +248,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  
+
   &__label {
     font-size: 0.75rem;
     font-weight: 500;
@@ -277,25 +277,25 @@
   align-items: center;
   justify-content: center;
   transition: all 0.2s ease;
-  
+
   svg {
     width: 16px;
     height: 16px;
     color: vars.$gray-600;
   }
-  
+
   &:hover {
     background: vars.$white;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    
+
     svg {
       color: vars.$primary-color;
     }
   }
-  
+
   &--active {
     background: vars.$primary-color;
-    
+
     svg {
       color: white;
     }
@@ -307,7 +307,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  
+
   input[type="range"] {
     width: 80px;
     height: 4px;
@@ -316,7 +316,7 @@
     outline: none;
     appearance: none;
     -webkit-appearance: none;
-    
+
     &::-webkit-slider-thumb {
       -webkit-appearance: none;
       width: 16px;
@@ -325,7 +325,7 @@
       background: vars.$primary-color;
       cursor: pointer;
     }
-    
+
     &::-moz-range-thumb {
       width: 16px;
       height: 16px;
@@ -335,7 +335,7 @@
       border: none;
     }
   }
-  
+
   &__value {
     font-size: 0.75rem;
     color: vars.$gray-600;
@@ -349,7 +349,7 @@
   display: flex;
   gap: 0.25rem;
   flex-wrap: wrap;
-  
+
   &__color {
     width: 20px;
     height: 20px;
@@ -357,12 +357,12 @@
     cursor: pointer;
     border: 2px solid transparent;
     transition: all 0.2s ease;
-    
+
     &:hover {
       transform: scale(1.1);
       border-color: vars.$primary-color;
     }
-    
+
     &--active {
       border-color: vars.$primary-color;
       box-shadow: 0 0 0 1px rgba(100, 149, 237, 0.3);
@@ -373,7 +373,7 @@
 /* Font controls - unified version */
 .font-controls {
   margin-bottom: 1rem;
-  
+
   &__select {
     width: 100%;
     padding: 0.5rem;
@@ -381,7 +381,7 @@
     border-radius: 4px;
     font-size: 0.875rem;
     background-color: vars.$white;
-    
+
     &:focus {
       outline: none;
       border-color: vars.$primary-color;
@@ -400,7 +400,7 @@
   background: none;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  
+
   &__icon {
     width: 2.5rem;
     height: 2.5rem;
@@ -410,33 +410,33 @@
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(100, 149, 237, 0.1);
-    
+
     svg {
       width: 85%;
       height: 85%;
     }
   }
-  
+
   &__label {
     font-size: 0.75rem;
     font-weight: 500;
     text-align: center;
     color: vars.$gray-700;
   }
-  
+
   &:hover {
     transform: translateY(-1px);
-    
+
     .action-btn__icon {
       background: rgba(100, 149, 237, 0.15);
       border-color: rgba(100, 149, 237, 0.3);
       box-shadow: 0 4px 12px rgba(100, 149, 237, 0.2);
-      
+
       svg {
         transform: scale(1.05);
       }
     }
-    
+
     .action-btn__label {
       color: vars.$primary-color;
     }
@@ -453,7 +453,7 @@
   background: none;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  
+
   &__icon {
     width: 2.5rem;
     height: 2.5rem;
@@ -463,50 +463,52 @@
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(100, 149, 237, 0.1);
-    
+
     svg {
       width: 85%;
       height: 85%;
     }
   }
-  
+
   &__label {
     font-size: 0.75rem;
     font-weight: 500;
     text-align: center;
     color: vars.$gray-700;
   }
-  
+
   &:hover {
     transform: translateY(-1px);
-    
+
     .media-btn__icon {
       background: rgba(100, 149, 237, 0.15);
       border-color: rgba(100, 149, 237, 0.3);
       box-shadow: 0 4px 12px rgba(100, 149, 237, 0.2);
-      
+
       svg {
         transform: scale(1.05);
       }
     }
-    
+
     .media-btn__label {
       color: vars.$primary-color;
     }
   }
-  
+
   &--selected {
     .media-btn__icon {
       background: linear-gradient(135deg, vars.$primary-color 0%, #91b4f2 100%);
       border-color: vars.$primary-color;
-      box-shadow: 0 6px 20px rgba(100, 149, 237, 0.3), 0 0 0 2px rgba(100, 149, 237, 0.2);
-      
+      box-shadow:
+        0 6px 20px rgba(100, 149, 237, 0.3),
+        0 0 0 2px rgba(100, 149, 237, 0.2);
+
       svg {
         filter: brightness(0) invert(1);
         transform: scale(1.1);
       }
     }
-    
+
     .media-btn__label {
       color: vars.$primary-color;
       font-weight: 600;
@@ -517,14 +519,14 @@
 /* Media search panel */
 .media-search {
   padding: 1rem;
-  
+
   &__title {
     font-size: 1.125rem;
     font-weight: 600;
     margin: 0 0 1rem 0;
     color: vars.$gray-900;
   }
-  
+
   &__input {
     width: 100%;
     padding: 0.5rem;
@@ -532,14 +534,14 @@
     border-radius: 4px;
     font-size: 0.875rem;
     margin-bottom: 1rem;
-    
+
     &:focus {
       outline: none;
       border-color: vars.$primary-color;
       box-shadow: 0 0 0 3px rgba(100, 149, 237, 0.1);
     }
   }
-  
+
   &__content {
     padding: 2rem;
     text-align: center;
@@ -558,12 +560,12 @@
   gap: 10px;
   color: vars.$gray-400;
   text-align: center;
-  
+
   &__title {
     font-size: 18px;
     font-weight: 500;
   }
-  
+
   &__subtitle {
     font-size: 14px;
     opacity: 0.7;
@@ -578,35 +580,35 @@
     margin: 0 0 1rem 0;
     color: vars.$gray-900;
   }
-  
+
   &__page {
     border: 1px solid vars.$gray-300;
     border-radius: 4px;
     padding: 1rem;
     margin-bottom: 1rem;
-    
+
     &:last-child {
       margin-bottom: 0;
     }
   }
-  
+
   &__page-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     margin-bottom: 0.5rem;
   }
-  
+
   &__page-name {
     font-weight: 500;
     color: vars.$gray-900;
   }
-  
+
   &__page-format {
     font-size: 0.8rem;
     color: vars.$gray-600;
   }
-  
+
   &__page-preview {
     width: 100%;
     height: 120px;
@@ -618,7 +620,7 @@
     justify-content: center;
     align-items: center;
   }
-  
+
   &__page-preview-content {
     font-size: 12px;
     color: vars.$gray-500;
@@ -652,7 +654,7 @@
     gap: 0.5rem;
     height: 100vh;
     padding: 0.25rem;
-    
+
     &__options-bar {
       grid-column: 1;
       grid-row: 1;
@@ -660,14 +662,14 @@
       min-height: 50px;
       padding: 0.5rem;
     }
-    
+
     &__toc-options {
       grid-column: 1;
       grid-row: 2;
       height: auto;
       min-height: 40px;
     }
-    
+
     &__media-bar {
       grid-column: 1;
       grid-row: 3;
@@ -679,7 +681,7 @@
       justify-content: flex-start;
       padding: 0.5rem;
     }
-    
+
     &__canvas {
       grid-column: 1;
       grid-row: 4;
@@ -688,7 +690,7 @@
       min-height: 300px;
       padding: 10px;
     }
-    
+
     &__media-search {
       grid-column: 1;
       grid-row: 5;
@@ -696,7 +698,7 @@
       max-height: 200px;
       flex: 1;
     }
-    
+
     &__toc {
       display: none;
     }
@@ -713,19 +715,19 @@
       padding: vars.$spacing-6;
       min-height: calc(100vh - #{vars.$spacing-6} * 2 - 80px);
       align-items: start;
-      
+
       .aside {
         height: 100%;
         min-height: calc(100vh - #{vars.$spacing-6} * 2 - 80px);
         position: sticky;
         top: vars.$spacing-6;
       }
-      
+
       .article {
         min-width: 0;
         height: 100%;
         min-height: calc(100vh - #{vars.$spacing-6} * 2 - 80px);
-        
+
         .card {
           height: 100%;
           display: flex;
@@ -738,17 +740,17 @@
       @container (max-width: 768px) {
         grid-template-columns: 1fr;
         min-height: auto;
-        
+
         .aside {
           height: auto;
           min-height: auto;
           position: static;
         }
-        
+
         .article {
           height: auto;
           min-height: auto;
-          
+
           .card {
             height: auto;
           }
@@ -763,14 +765,14 @@
     padding: 0; /* Remove any padding */
     height: calc(100vh - 120px); /* Account for header and some margin */
     max-height: calc(100vh - 120px); /* Ensure it never exceeds */
-    
+
     .article {
       background-color: vars.$white;
       padding: 0;
       height: 100%;
       overflow: hidden; /* Prevent article scrolling */
       margin: 0; /* Remove any margin */
-      
+
       &--active {
         display: block;
         height: 100%;

--- a/src/scss/components/_curriculum.scss
+++ b/src/scss/components/_curriculum.scss
@@ -2,467 +2,488 @@
 
 // Curriculum Layout
 .curriculum-layout {
-    display: flex;
-    gap: 2rem;
-    height: 75vh;
-    
-    @media (max-width: 768px) {
-        flex-direction: column;
-        height: auto;
-        gap: 1.5rem;
-    }
+  display: flex;
+  gap: 2rem;
+  height: 75vh;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    height: auto;
+    gap: 1.5rem;
+  }
 }
 
 .curriculum-config {
-    flex: 0 0 380px;
-    display: flex;
-    flex-direction: column;
-    
-    @media (max-width: 768px) {
-        flex: none;
-        width: 100%;
-    }
+  flex: 0 0 380px;
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: 768px) {
+    flex: none;
+    width: 100%;
+  }
 }
 
 .curriculum-preview {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    background: var(--color-white);
-    border-radius: 12px;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    height: 80vh;;
-    overflow: hidden;
-    
-    &.hidden {
-        display: none;
-    }
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--color-white);
+  border-radius: 12px;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  height: 80vh;
+  overflow: hidden;
+
+  &.hidden {
+    display: none;
+  }
 }
 
 // Content Load Section
 .content-load-section {
-    background: var(--color-white);
-    border-radius: 12px;
-    padding: 1.5rem;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    border: 1px solid var(--color-grey-light-2);
-    
-    .heading--quaternary {
-        margin-bottom: 1rem;
-        font-size: 1.1rem;
-        color: var(--color-grey-dark-3);
-        font-weight: 600;
-        letter-spacing: -0.025em;
-    }
+  background: var(--color-white);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  border: 1px solid var(--color-grey-light-2);
+
+  .heading--quaternary {
+    margin-bottom: 1rem;
+    font-size: 1.1rem;
+    color: var(--color-grey-dark-3);
+    font-weight: 600;
+    letter-spacing: -0.025em;
+  }
 }
 
 .content-load-display {
-    padding: 1.5rem;
-    background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-    border-radius: 10px;
-    border: 1px solid var(--color-grey-light-2);
-    position: relative;
-    overflow: hidden;
-    
-    &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 3px;
-        background: linear-gradient(90deg, var(--color-primary), var(--color-primary-light));
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  border-radius: 10px;
+  border: 1px solid var(--color-grey-light-2);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(
+      90deg,
+      var(--color-primary),
+      var(--color-primary-light)
+    );
+  }
+
+  .content-load-info {
+    .content-load-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.5rem 1rem;
+      border-radius: 25px;
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 1rem;
+      border: 2px solid;
+
+      &--mini {
+        background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
+        color: #1565c0;
+        border-color: #1976d2;
+      }
+
+      &--regular {
+        background: linear-gradient(135deg, #e8f5e8 0%, #c8e6c9 100%);
+        color: #2e7d32;
+        border-color: #388e3c;
+      }
+
+      &--double {
+        background: linear-gradient(135deg, #fff3e0 0%, #ffe0b2 100%);
+        color: #ef6c00;
+        border-color: #f57c00;
+      }
+
+      &--triple {
+        background: linear-gradient(135deg, #fce4ec 0%, #f8bbd9 100%);
+        color: #ad1457;
+        border-color: #c2185b;
+      }
+
+      &--long {
+        background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
+        color: #6a1b9a;
+        border-color: #7b1fa2;
+      }
     }
-    
-    .content-load-info {
-        .content-load-badge {
-            display: inline-flex;
-            align-items: center;
-            padding: 0.5rem 1rem;
-            border-radius: 25px;
-            font-size: 0.75rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            margin-bottom: 1rem;
-            border: 2px solid;
-            
-            &--mini {
-                background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
-                color: #1565c0;
-                border-color: #1976d2;
-            }
-            
-            &--regular {
-                background: linear-gradient(135deg, #e8f5e8 0%, #c8e6c9 100%);
-                color: #2e7d32;
-                border-color: #388e3c;
-            }
-            
-            &--double {
-                background: linear-gradient(135deg, #fff3e0 0%, #ffe0b2 100%);
-                color: #ef6c00;
-                border-color: #f57c00;
-            }
-            
-            &--triple {
-                background: linear-gradient(135deg, #fce4ec 0%, #f8bbd9 100%);
-                color: #ad1457;
-                border-color: #c2185b;
-            }
-            
-            &--long {
-                background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
-                color: #6a1b9a;
-                border-color: #7b1fa2;
-            }
-        }
-        
-        .content-load-details {
-            .duration {
-                font-size: 1.1rem;
-                font-weight: 700;
-                color: var(--color-grey-dark-3);
-                margin-bottom: 0.5rem;
-                display: flex;
-                align-items: center;
-            }
-            
-            .structure {
-                font-size: 0.9rem;
-                color: var(--color-grey-dark-2);
-                line-height: 1.6;
-                padding: 0.75rem;
-                background: var(--color-white);
-                border-radius: 6px;
-                border-left: 3px solid var(--color-primary-light);
-            }
-        }
-    }
-    
-    .content-load-warning {
+
+    .content-load-details {
+      .duration {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: var(--color-grey-dark-3);
+        margin-bottom: 0.5rem;
         display: flex;
-        align-items: flex-start;
-        gap: 1rem;
-        padding: 1rem;
-        background: linear-gradient(135deg, #fef7e0 0%, #fef3c7 100%);
-        border-radius: 8px;
-        border: 1px solid #f59e0b;
-        
-        .warning-icon {
-            font-size: 1.5rem;
-            flex-shrink: 0;
-        }
-        
-        .warning-text {
-            strong {
-                color: #92400e;
-                font-size: 1rem;
-                display: block;
-                margin-bottom: 0.25rem;
-            }
-            
-            p {
-                margin: 0;
-                font-size: 0.875rem;
-                color: #78350f;
-                line-height: 1.5;
-            }
-        }
+        align-items: center;
+      }
+
+      .structure {
+        font-size: 0.9rem;
+        color: var(--color-grey-dark-2);
+        line-height: 1.6;
+        padding: 0.75rem;
+        background: var(--color-white);
+        border-radius: 6px;
+        border-left: 3px solid var(--color-primary-light);
+      }
     }
+  }
+
+  .content-load-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem;
+    background: linear-gradient(135deg, #fef7e0 0%, #fef3c7 100%);
+    border-radius: 8px;
+    border: 1px solid #f59e0b;
+
+    .warning-icon {
+      font-size: 1.5rem;
+      flex-shrink: 0;
+    }
+
+    .warning-text {
+      strong {
+        color: #92400e;
+        font-size: 1rem;
+        display: block;
+        margin-bottom: 0.25rem;
+      }
+
+      p {
+        margin: 0;
+        font-size: 0.875rem;
+        color: #78350f;
+        line-height: 1.5;
+      }
+    }
+  }
 }
 
 // Curriculum Preview Header
 .curriculum-preview-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.5rem 1.5rem 1rem 1.5rem;
-    border-bottom: 1px solid var(--color-grey-light-2);
-    background: var(--color-white);
-    flex-shrink: 0;
-    
-    @media (max-width: 768px) {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 1rem;
-    }
-    
-    .heading--tertiary {
-        margin: 0;
-        font-size: 1.25rem;
-        font-weight: 700;
-        color: var(--color-grey-dark-3);
-        letter-spacing: -0.025em;
-    }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 1.5rem 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-grey-light-2);
+  background: var(--color-white);
+  flex-shrink: 0;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .heading--tertiary {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-grey-dark-3);
+    letter-spacing: -0.025em;
+  }
 }
 
 // Preview Mode Controls
 .preview-mode-controls {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    background: var(--color-grey-light-1);
-    padding: 0.25rem;
-    border-radius: 8px;
-    border: 1px solid var(--color-grey-light-2);
-    
-    .preview-mode-label {
-        font-size: 0.875rem;
-        color: var(--color-grey-dark-2);
-        margin-right: 0.5rem;
-        font-weight: 500;
-        padding-left: 0.5rem;
-    }
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--color-grey-light-1);
+  padding: 0.25rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-grey-light-2);
+
+  .preview-mode-label {
+    font-size: 0.875rem;
+    color: var(--color-grey-dark-2);
+    margin-right: 0.5rem;
+    font-weight: 500;
+    padding-left: 0.5rem;
+  }
 }
 
 .preview-mode-btn {
-    padding: 0.5rem 1rem;
-    border: none;
-    background: transparent;
-    color: var(--color-grey-dark-2);
-    border-radius: 6px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    position: relative;
-    
+  padding: 0.5rem 1rem;
+  border: none;
+  background: transparent;
+  color: var(--color-grey-dark-2);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+
+  &:hover {
+    background: var(--color-white);
+    color: var(--color-grey-dark-3);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  &.active {
+    background: var(--color-primary) !important;
+    color: var(--color-white) !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
+
     &:hover {
-        background: var(--color-white);
-        color: var(--color-grey-dark-3);
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      background: var(--color-primary-dark) !important;
     }
-    
-    &.active {
-        background: var(--color-primary) !important;
-        color: var(--color-white) !important;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
-        
-        &:hover {
-            background: var(--color-primary-dark) !important;
-        }
-    }
+  }
 }
 
 // Curriculum Preview Content - Scrollable
 .curriculum-preview-content {
-    flex: 1;
-    overflow-y: auto;
-    background: var(--color-grey-light-1);
-    
-    &::-webkit-scrollbar {
-        width: 8px;
+  flex: 1;
+  overflow-y: auto;
+  background: var(--color-grey-light-1);
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--color-grey-light-2);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-grey-light-3);
+    border-radius: 4px;
+
+    &:hover {
+      background: var(--color-grey-dark-1);
     }
-    
-    &::-webkit-scrollbar-track {
-        background: var(--color-grey-light-2);
-    }
-    
-    &::-webkit-scrollbar-thumb {
-        background: var(--color-grey-light-3);
-        border-radius: 4px;
-        
-        &:hover {
-            background: var(--color-grey-dark-1);
-        }
-    }
-    
-    .curriculum-empty {
-        text-align: center;
-        color: var(--color-grey-dark-1);
-        font-style: italic;
-        padding: 4rem 2rem;
-        font-size: 1.1rem;
-    }
+  }
+
+  .curriculum-empty {
+    text-align: center;
+    color: var(--color-grey-dark-1);
+    font-style: italic;
+    padding: 4rem 2rem;
+    font-size: 1.1rem;
+  }
 }
 
 // Curriculum Lesson
 .curriculum-lesson {
-    margin: 1rem;
-    background: var(--color-white);
-    border-radius: 10px;
-    overflow: hidden;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    border: 1px solid var(--color-grey-light-2);
-    transition: all 0.2s ease;
-    
-    &:hover {
-        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-        transform: translateY(-1px);
+  margin: 1rem;
+  background: var(--color-white);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--color-grey-light-2);
+  transition: all 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    transform: translateY(-1px);
+  }
+
+  &:last-child {
+    margin-bottom: 1rem;
+  }
+
+  .lesson-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--color-grey-dark-3);
+    padding: 1.25rem 1.5rem;
+    margin: 0;
+    background: linear-gradient(
+      135deg,
+      var(--color-primary) 0%,
+      var(--color-primary-dark) 100%
+    );
+    color: var(--color-white);
+    position: relative;
+
+    &.editable {
+      cursor: text;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: linear-gradient(
+          135deg,
+          var(--color-primary-dark) 0%,
+          var(--color-primary) 100%
+        );
+      }
+
+      &:focus {
+        outline: 3px solid rgba(255, 255, 255, 0.3);
+        outline-offset: -3px;
+      }
     }
-    
-    &:last-child {
-        margin-bottom: 1rem;
-    }
-    
-    .lesson-title {
-        font-size: 1.1rem;
-        font-weight: 700;
-        color: var(--color-grey-dark-3);
-        padding: 1.25rem 1.5rem;
-        margin: 0;
-        background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
-        color: var(--color-white);
-        position: relative;
-        
-        &.editable {
-            cursor: text;
-            transition: all 0.2s ease;
-            
-            &:hover {
-                background: linear-gradient(135deg, var(--color-primary-dark) 0%, var(--color-primary) 100%);
-            }
-            
-            &:focus {
-                outline: 3px solid rgba(255, 255, 255, 0.3);
-                outline-offset: -3px;
-            }
-        }
-    }
+  }
 }
 
 // Lesson Topics (when in topics/objectives mode)
 .lesson-topic {
-    border-bottom: 1px solid var(--color-grey-light-2);
-    
-    &:last-child {
-        border-bottom: none;
+  border-bottom: 1px solid var(--color-grey-light-2);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .topic-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-grey-dark-3);
+    padding: 1rem 1.5rem;
+    margin: 0;
+    background: var(--color-grey-light-1);
+    border-left: 4px solid var(--color-primary-light);
+    position: relative;
+
+    &.editable {
+      cursor: text;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: var(--color-grey-light-2);
+        border-left-color: var(--color-primary);
+      }
+
+      &:focus {
+        outline: 2px solid var(--color-primary-light);
+        outline-offset: -2px;
+        background: var(--color-white);
+        border-left-color: var(--color-primary);
+      }
     }
-    
-    .topic-title {
-        font-size: 1rem;
-        font-weight: 600;
-        color: var(--color-grey-dark-3);
-        padding: 1rem 1.5rem;
-        margin: 0;
-        background: var(--color-grey-light-1);
-        border-left: 4px solid var(--color-primary-light);
-        position: relative;
-        
-        &.editable {
-            cursor: text;
-            transition: all 0.2s ease;
-            
-            &:hover {
-                background: var(--color-grey-light-2);
-                border-left-color: var(--color-primary);
-            }
-            
-            &:focus {
-                outline: 2px solid var(--color-primary-light);
-                outline-offset: -2px;
-                background: var(--color-white);
-                border-left-color: var(--color-primary);
-            }
-        }
-    }
+  }
 }
 
 // Topic Objectives (when in objectives mode)
 .topic-objective {
-    font-size: 0.9rem;
-    color: var(--color-grey-dark-2);
-    padding: 0.75rem 1.5rem 0.75rem 3rem;
-    background: var(--color-white);
-    border-bottom: 1px solid var(--color-grey-light-1);
-    position: relative;
-    
-    &::before {
-        content: '•';
-        position: absolute;
-        left: 2rem;
-        color: var(--color-primary-light);
-        font-weight: bold;
-        font-size: 1.2rem;
+  font-size: 0.9rem;
+  color: var(--color-grey-dark-2);
+  padding: 0.75rem 1.5rem 0.75rem 3rem;
+  background: var(--color-white);
+  border-bottom: 1px solid var(--color-grey-light-1);
+  position: relative;
+
+  &::before {
+    content: "•";
+    position: absolute;
+    left: 2rem;
+    color: var(--color-primary-light);
+    font-weight: bold;
+    font-size: 1.2rem;
+  }
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &.editable {
+    cursor: text;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: var(--color-grey-light-1);
+
+      &::before {
+        color: var(--color-primary);
+      }
     }
-    
-    &:last-child {
-        border-bottom: none;
+
+    &:focus {
+      outline: 2px solid var(--color-primary-light);
+      outline-offset: -2px;
+      background: var(--color-white);
+
+      &::before {
+        color: var(--color-primary);
+      }
     }
-    
-    &.editable {
-        cursor: text;
-        transition: all 0.2s ease;
-        
-        &:hover {
-            background: var(--color-grey-light-1);
-            
-            &::before {
-                color: var(--color-primary);
-            }
-        }
-        
-        &:focus {
-            outline: 2px solid var(--color-primary-light);
-            outline-offset: -2px;
-            background: var(--color-white);
-            
-            &::before {
-                color: var(--color-primary);
-            }
-        }
-    }
+  }
 }
 
 // Loading State
 .curriculum-loading {
-    text-align: center;
-    padding: 4rem 2rem;
-    color: var(--color-grey-dark-1);
-    
-    .loading-spinner {
-        width: 3rem;
-        height: 3rem;
-        border: 3px solid var(--color-grey-light-2);
-        border-top: 3px solid var(--color-primary);
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-        margin: 0 auto 1.5rem;
-    }
-    
-    &::after {
-        content: 'Generating curriculum...';
-        display: block;
-        font-weight: 500;
-        font-size: 1.1rem;
-        margin-top: 1rem;
-    }
+  text-align: center;
+  padding: 4rem 2rem;
+  color: var(--color-grey-dark-1);
+
+  .loading-spinner {
+    width: 3rem;
+    height: 3rem;
+    border: 3px solid var(--color-grey-light-2);
+    border-top: 3px solid var(--color-primary);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 1.5rem;
+  }
+
+  &::after {
+    content: "Generating curriculum...";
+    display: block;
+    font-weight: 500;
+    font-size: 1.1rem;
+    margin-top: 1rem;
+  }
 }
 
 @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 // Error State
 .curriculum-error {
-    text-align: center;
-    padding: 3rem 2rem;
-    color: var(--color-danger);
-    background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
-    border-radius: 10px;
-    margin: 1rem;
-    border: 1px solid var(--color-danger-light);
-    
-    .error-message {
-        font-weight: 600;
-        margin-bottom: 0.5rem;
-        font-size: 1.1rem;
-    }
-    
-    .error-details {
-        font-size: 0.875rem;
-        color: var(--color-danger-dark);
-        line-height: 1.5;
-    }
+  text-align: center;
+  padding: 3rem 2rem;
+  color: var(--color-danger);
+  background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+  border-radius: 10px;
+  margin: 1rem;
+  border: 1px solid var(--color-danger-light);
+
+  .error-message {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+  }
+
+  .error-details {
+    font-size: 0.875rem;
+    color: var(--color-danger-dark);
+    line-height: 1.5;
+  }
 }
 
 // Enhanced spacing and typography
 .curriculum-layout {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    line-height: 1.5;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
 }
 
 // Smooth transitions for all interactive elements
@@ -471,5 +492,5 @@
 .topic-objective,
 .preview-mode-btn,
 .content-load-display {
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -2,7 +2,7 @@
 // DROPDOWN COMPONENTS
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 // ==========================================================================
 // DROPDOWN BASE
@@ -45,7 +45,7 @@
       background-color: $gray-50;
       color: $text-muted;
       cursor: not-allowed;
-      
+
       &:hover {
         border-color: $gray-300;
       }
@@ -53,7 +53,7 @@
 
     &--success {
       border-color: $success;
-      
+
       &:focus {
         border-color: $success;
         box-shadow: 0 0 0 3px rgba($success, 0.1);
@@ -62,7 +62,7 @@
 
     &--error {
       border-color: $error;
-      
+
       &:focus {
         border-color: $error;
         box-shadow: 0 0 0 3px rgba($error, 0.1);
@@ -275,7 +275,7 @@
   &--classification {
     width: 100%;
     min-width: 180px; // Ensure consistent minimum width
-    
+
     .dropdown__trigger {
       font-size: $font-size-sm; // Smaller font to prevent resizing
       white-space: nowrap;
@@ -283,7 +283,7 @@
       text-overflow: ellipsis;
       min-height: 44px; // Fixed height
     }
-    
+
     .dropdown__label {
       white-space: nowrap;
       overflow: hidden;
@@ -291,7 +291,7 @@
       flex: 1;
       text-align: left;
     }
-    
+
     .dropdown__menu {
       max-height: 400px;
       font-size: $font-size-sm; // Consistent font size in options
@@ -338,7 +338,7 @@
       margin-bottom: 0;
     }
   }
-  
+
   &--with-arrows {
     align-items: flex-end; // Align arrows with dropdown buttons
     gap: $spacing-3;
@@ -347,7 +347,7 @@
   @media (max-width: #{$breakpoint-md - 1px}) {
     flex-direction: column;
     gap: $spacing-3;
-    
+
     &--with-arrows {
       .dropdown-arrow {
         display: none; // Hide arrows on mobile
@@ -371,7 +371,7 @@
   padding: 0 $spacing-2;
   user-select: none;
   min-width: 24px;
-  
+
   @media (max-width: #{$breakpoint-md - 1px}) {
     transform: rotate(90deg); // Turn arrows vertical on mobile
     margin-bottom: 0;
@@ -389,7 +389,7 @@
     overflow: hidden;
 
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       top: 0;
       left: -100%;

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -2,8 +2,8 @@
 // FORM COMPONENTS
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
-@use 'sass:color';
+@use "../abstracts/variables" as *;
+@use "sass:color";
 
 // ==========================================================================
 // AUTH FORM CONTAINER
@@ -16,12 +16,12 @@
   background-color: $white;
   border-radius: $border-radius-lg;
   box-shadow: $shadow-lg;
-  
+
   &__header {
     text-align: center;
     margin-bottom: $spacing-8;
   }
-  
+
   &__footer {
     text-align: center;
     margin-top: $spacing-6;
@@ -38,29 +38,29 @@
   display: flex;
   flex-direction: column;
   gap: $spacing-6;
-  
+
   &__row {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: $spacing-4;
-    
+
     @media (max-width: #{$breakpoint-sm - 1px}) {
       grid-template-columns: 1fr;
     }
   }
-  
+
   &__group {
     display: flex;
     flex-direction: column;
     gap: $spacing-2;
   }
-  
+
   &__label {
     font-size: $font-size-sm;
     font-weight: $font-weight-medium;
     color: $text-primary;
   }
-  
+
   &__input,
   &__select {
     padding: $spacing-3 $spacing-4;
@@ -70,17 +70,17 @@
     color: $text-primary;
     background-color: $white;
     transition: all 0.2s ease;
-    
+
     &::placeholder {
       color: $text-muted;
     }
-    
+
     &:focus {
       outline: none;
       border-color: $primary-color;
       box-shadow: 0 0 0 3px rgba($primary-color, 0.1);
     }
-    
+
     &:disabled {
       background-color: $gray-50;
       color: $text-muted;
@@ -89,7 +89,7 @@
 
     &--success {
       border-color: $success;
-      
+
       &:focus {
         border-color: $success;
         box-shadow: 0 0 0 3px rgba($success, 0.1);
@@ -98,28 +98,28 @@
 
     &--error {
       border-color: $error;
-      
+
       &:focus {
         border-color: $error;
         box-shadow: 0 0 0 3px rgba($error, 0.1);
       }
     }
   }
-  
+
   &__select {
     cursor: pointer;
-    
+
     option {
       padding: $spacing-2;
     }
   }
-  
+
   &__error {
     font-size: $font-size-sm;
     color: $error;
     margin-top: $spacing-1;
   }
-  
+
   &__help {
     font-size: $font-size-sm;
     color: $text-muted;
@@ -157,14 +157,14 @@
 
 .file-upload {
   position: relative;
-  
+
   &__input {
     position: absolute;
     opacity: 0;
     width: 0;
     height: 0;
   }
-  
+
   &__label {
     display: flex;
     align-items: center;
@@ -177,22 +177,22 @@
     cursor: pointer;
     transition: all 0.2s ease;
     min-height: 120px;
-    
+
     &:hover {
       border-color: $primary-color;
       background-color: color.adjust($primary-color, $lightness: 45%);
     }
   }
-  
+
   &__icon {
     font-size: 2rem;
   }
-  
+
   &__text {
     font-weight: $font-weight-medium;
     color: $text-secondary;
   }
-  
+
   &__preview {
     position: relative;
     margin-top: $spacing-3;
@@ -200,14 +200,14 @@
     overflow: hidden;
     background-color: $gray-100;
   }
-  
+
   &__preview-image {
     width: 100%;
     height: 200px;
     object-fit: cover;
     display: block;
   }
-  
+
   &__remove {
     position: absolute;
     top: $spacing-2;
@@ -224,11 +224,11 @@
     justify-content: center;
     font-size: 18px;
     font-weight: bold;
-    
+
     &:hover {
       background-color: $error;
     }
-    
+
     &--compact {
       width: 20px;
       height: 20px;
@@ -237,20 +237,20 @@
       font-size: 12px;
     }
   }
-  
+
   // Compact layout variant
   &--compact {
     .file-upload__label {
       display: none; // Hide the default large label
     }
   }
-  
+
   &__compact-layout {
     display: flex;
     align-items: center;
     gap: $spacing-4;
   }
-  
+
   &__compact-label {
     display: inline-flex;
     align-items: center;
@@ -263,18 +263,18 @@
     transition: all 0.2s ease;
     font-size: 0.875rem;
     font-weight: $font-weight-medium;
-    
+
     &:hover {
       background-color: $primary-color;
       color: $white;
     }
-    
+
     .file-upload__text {
       color: inherit;
       font-weight: inherit;
     }
   }
-  
+
   &__thumbnail {
     position: relative;
     width: 80px;
@@ -284,7 +284,7 @@
     background-color: $gray-100;
     border: 1px solid $gray-200;
   }
-  
+
   &__thumbnail-image {
     width: 100%;
     height: 100%;
@@ -304,21 +304,21 @@
   margin-top: $spacing-6;
   padding-top: $spacing-6;
   border-top: 1px solid $gray-200;
-  
+
   .form__actions-row {
     display: flex;
     align-items: center;
     gap: $spacing-4;
   }
-  
+
   .button {
     flex: 0 0 auto;
-    
+
     &--disabled {
       background-color: $gray-300;
       color: $gray-500;
       cursor: not-allowed;
-      
+
       &:hover {
         background-color: $gray-300;
         transform: none;
@@ -330,15 +330,15 @@
 .form__status {
   font-size: $font-size-sm;
   font-weight: $font-weight-medium;
-  
+
   &--success {
     color: $success;
   }
-  
+
   &--error {
     color: $error;
   }
-  
+
   &--loading {
     color: $primary-color;
   }
@@ -361,35 +361,35 @@
   font-size: $font-size-sm;
   color: $gray-600;
   transition: color 0.3s ease;
-  
+
   &__icon {
     font-size: $font-size-base;
     opacity: 0.7;
   }
-  
+
   &__text {
     font-weight: $font-weight-medium;
   }
-  
+
   &--success {
     color: $success;
-    
+
     .last-saved-indicator__icon {
       opacity: 1;
     }
   }
-  
+
   &--error {
     color: $error;
-    
+
     .last-saved-indicator__icon {
       opacity: 1;
     }
   }
-  
+
   &--loading {
     color: $primary-color;
-    
+
     .last-saved-indicator__icon {
       animation: pulse 1.5s ease-in-out infinite;
     }
@@ -397,7 +397,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 0.7;
   }
   50% {
@@ -410,7 +411,6 @@
 // ==========================================================================
 
 .course-code-display {
-  
   .course-code-container {
     display: flex;
     align-items: center;
@@ -429,7 +429,7 @@
 
   .course-code-value {
     color: $gray-800;
-    font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+    font-family: "Monaco", "Menlo", "Consolas", monospace;
     font-weight: $font-weight-semibold;
     background-color: white;
     padding: $spacing-1 $spacing-2;
@@ -490,7 +490,7 @@
   align-items: center;
   gap: $spacing-4;
   margin-bottom: $spacing-6;
-  
+
   .unit-label {
     font-size: 0.95rem;
     color: $gray-700;
@@ -505,12 +505,12 @@
   border-radius: $border-radius-md;
   padding: 2px;
   gap: 0;
-  
+
   &__input {
     position: absolute;
     opacity: 0;
     pointer-events: none;
-    
+
     &:checked + &__label {
       background-color: $white;
       color: $gray-900;
@@ -518,7 +518,7 @@
       border-color: transparent;
     }
   }
-  
+
   &__label {
     padding: $spacing-2 $spacing-4;
     background-color: transparent;
@@ -529,16 +529,16 @@
     font-weight: 500;
     color: $gray-600;
     transition: all 0.15s ease;
-    
+
     &:hover {
       color: $gray-800;
     }
-    
+
     &:first-of-type {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
     }
-    
+
     &:last-of-type {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
@@ -551,7 +551,7 @@
   grid-template-columns: 1fr 1fr;
   gap: $spacing-4 $spacing-6;
   margin-bottom: $spacing-6;
-  
+
   @media (max-width: #{$breakpoint-sm - 1px}) {
     grid-template-columns: 1fr;
     gap: $spacing-4;
@@ -578,13 +578,15 @@
   border: 1px solid $gray-300;
   border-radius: $border-radius;
   padding: 0;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-  
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+
   &:focus-within {
     border-color: $primary-color;
     box-shadow: 0 0 0 3px rgba(80, 131, 241, 0.1);
   }
-  
+
   .margin-input {
     flex: 1;
     border: none;
@@ -594,16 +596,16 @@
     font-weight: 500;
     color: $gray-900;
     min-width: 0;
-    
+
     &:focus {
       outline: none;
     }
-    
+
     &::placeholder {
       color: $gray-400;
     }
   }
-  
+
   .margin-unit-display {
     padding: 0 $spacing-3;
     font-size: 0.875rem;
@@ -622,15 +624,15 @@
       font-size: 0.8rem;
       color: $gray-500;
       font-style: italic;
-      
+
       &.saved {
         color: $success-color;
       }
-      
+
       &.saving {
         color: $warning-color;
       }
-      
+
       &.error {
         color: $danger-color;
       }
@@ -640,14 +642,14 @@
 
 .settings-section {
   margin-bottom: $spacing-8;
-  
+
   .heading--tertiary {
     margin-bottom: $spacing-6;
     color: $primary-color;
     border-bottom: 2px solid $primary-color;
     padding-bottom: $spacing-2;
   }
-  
+
   .heading--quaternary {
     margin-bottom: $spacing-4;
     color: $gray-700;
@@ -660,7 +662,7 @@
   grid-template-columns: 1fr 1fr;
   gap: $spacing-4;
   margin-bottom: $spacing-4;
-  
+
   @media (max-width: #{$breakpoint-sm - 1px}) {
     grid-template-columns: 1fr;
   }
@@ -670,15 +672,15 @@
   &__text {
     font-size: 0.875rem;
     color: $gray-600;
-    
+
     &.saved {
       color: $success-color;
     }
-    
+
     &.saving {
       color: $warning-color;
     }
-    
+
     &.error {
       color: $danger-color;
     }
@@ -712,7 +714,7 @@
   padding: $spacing-3;
   border-radius: $border-radius;
   transition: background-color 0.15s ease;
-  
+
   &:hover {
     background-color: $gray-50;
   }
@@ -727,13 +729,13 @@
   cursor: pointer;
   position: relative;
   transition: all 0.15s ease;
-  
+
   &:checked {
     background-color: $primary-color;
     border-color: $primary-color;
-    
+
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       top: 2px;
       left: 5px;
@@ -744,7 +746,7 @@
       transform: rotate(45deg);
     }
   }
-  
+
   &:focus {
     outline: none;
     box-shadow: 0 0 0 3px rgba(80, 131, 241, 0.2);
@@ -796,11 +798,11 @@
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.15s ease;
-  
+
   &:hover {
     background-color: #b91c1c;
   }
-  
+
   &:focus {
     outline: none;
     box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.2);

--- a/src/scss/components/_modals.scss
+++ b/src/scss/components/_modals.scss
@@ -2,7 +2,7 @@
 // MODAL COMPONENT
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 .modal {
   position: fixed;
@@ -17,7 +17,7 @@
   opacity: 0;
   visibility: hidden;
   transition: all 0.3s ease;
-  
+
   &--active {
     opacity: 1;
     visibility: visible;
@@ -45,7 +45,7 @@
   overflow: hidden;
   transform: scale(0.9) translateY(20px);
   transition: all 0.3s ease;
-  
+
   .modal--active & {
     transform: scale(1) translateY(0);
   }
@@ -58,7 +58,7 @@
   padding: $spacing-6;
   border-bottom: 1px solid $gray-200;
   background: $gray-50;
-  
+
   h3 {
     margin: 0;
     color: $text-primary;
@@ -78,12 +78,12 @@
   border-radius: $border-radius;
   cursor: pointer;
   transition: all 0.2s ease;
-  
+
   &:hover {
     background: $gray-100;
     color: $text-primary;
   }
-  
+
   svg {
     width: 20px;
     height: 20px;

--- a/src/scss/components/_schedule.scss
+++ b/src/scss/components/_schedule.scss
@@ -3,301 +3,301 @@
 // ================================================================
 
 .schedule-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
-    align-items: start;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: start;
 
-    @media (max-width: 768px) {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
 }
 
 // Schedule Configuration
 .schedule-config {
-    .form__row {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 1rem;
-        margin-bottom: 1.5rem; // Add space between rows
-        
-        @media (max-width: 576px) {
-            grid-template-columns: 1fr;
-        }
-    }
+  .form__row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1.5rem; // Add space between rows
 
-    .form__group {
-        margin-bottom: 1.5rem; // Add space between form groups
+    @media (max-width: 576px) {
+      grid-template-columns: 1fr;
     }
+  }
 
-    .form__actions {
-        margin-top: 3rem; // Push the buttons much further down
-        display: flex;
-        flex-direction: row; // Ensure horizontal layout
-        justify-content: center;
-        gap: 1rem; // Space between the buttons
-        align-items: center;
-        flex-wrap: wrap; // Allow wrapping on small screens
-        
-        @media (max-width: 480px) {
-            flex-direction: column; // Stack vertically on very small screens
-            gap: 0.75rem;
-        }
-    }
+  .form__group {
+    margin-bottom: 1.5rem; // Add space between form groups
+  }
 
-    &.locked {
-        opacity: 0.6;
-        pointer-events: none;
-        
-        .form__input,
-        .day-button {
-            background-color: var(--color-gray-100);
-            cursor: not-allowed;
-        }
+  .form__actions {
+    margin-top: 3rem; // Push the buttons much further down
+    display: flex;
+    flex-direction: row; // Ensure horizontal layout
+    justify-content: center;
+    gap: 1rem; // Space between the buttons
+    align-items: center;
+    flex-wrap: wrap; // Allow wrapping on small screens
+
+    @media (max-width: 480px) {
+      flex-direction: column; // Stack vertically on very small screens
+      gap: 0.75rem;
     }
+  }
+
+  &.locked {
+    opacity: 0.6;
+    pointer-events: none;
+
+    .form__input,
+    .day-button {
+      background-color: var(--color-gray-100);
+      cursor: not-allowed;
+    }
+  }
 }
 
 // Day Selection Buttons
 .day-buttons {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    margin-bottom: 2rem; // Add more space before the time inputs
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem; // Add more space before the time inputs
 }
 
 .day-button {
-    padding: 0.75rem 1.25rem;
-    border: 2px solid #000000; // Black border
-    background-color: transparent;
-    color: #000000; // Black text
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    min-width: 3.5rem;
+  padding: 0.75rem 1.25rem;
+  border: 2px solid #000000; // Black border
+  background-color: transparent;
+  color: #000000; // Black text
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 3.5rem;
+
+  &:hover {
+    border-color: #000000;
+    background-color: #f3f4f6; // Light gray on hover
+  }
+
+  &.selected {
+    background-color: #3b82f6; // Blue background when selected
+    border-color: #3b82f6; // Blue border when selected
+    color: white;
 
     &:hover {
-        border-color: #000000;
-        background-color: #f3f4f6; // Light gray on hover
+      background-color: #2563eb; // Darker blue on hover when selected
+      border-color: #2563eb;
     }
+  }
 
-    &.selected {
-        background-color: #3b82f6; // Blue background when selected
-        border-color: #3b82f6; // Blue border when selected
-        color: white;
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 
-        &:hover {
-            background-color: #2563eb; // Darker blue on hover when selected
-            border-color: #2563eb;
-        }
+    &:hover {
+      border-color: #000000;
+      background-color: transparent;
     }
-
-    &:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        
-        &:hover {
-            border-color: #000000;
-            background-color: transparent;
-        }
-    }
+  }
 }
 
 // Schedule Preview
 .schedule-preview {
-    &.hidden {
-        display: none;
-    }
+  &.hidden {
+    display: none;
+  }
 }
 
 .schedule-list-container {
-    border: 1px solid var(--color-gray-200);
-    border-radius: 0.5rem;
-    overflow: hidden;
-    background-color: white;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background-color: white;
 }
 
 .schedule-list-header {
-    display: grid;
-    grid-template-columns: 80px 1fr 100px 100px 60px;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--color-gray-50);
-    border-bottom: 1px solid var(--color-gray-200);
-    font-weight: 600;
-    font-size: 0.875rem;
-    color: var(--color-gray-700);
+  display: grid;
+  grid-template-columns: 80px 1fr 100px 100px 60px;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background-color: var(--color-gray-50);
+  border-bottom: 1px solid var(--color-gray-200);
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-gray-700);
 
-    @media (max-width: 768px) {
-        grid-template-columns: 60px 1fr 80px 80px 40px;
-        font-size: 0.75rem;
-        padding: 0.5rem;
-        gap: 0.5rem;
-    }
+  @media (max-width: 768px) {
+    grid-template-columns: 60px 1fr 80px 80px 40px;
+    font-size: 0.75rem;
+    padding: 0.5rem;
+    gap: 0.5rem;
+  }
 }
 
 .schedule-list {
-    max-height: 400px;
-    overflow-y: auto;
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .schedule-row {
-    display: grid;
-    grid-template-columns: 80px 1fr 100px 100px 60px;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--color-gray-100);
-    align-items: center;
-    transition: background-color 0.2s ease;
+  display: grid;
+  grid-template-columns: 80px 1fr 100px 100px 60px;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-gray-100);
+  align-items: center;
+  transition: background-color 0.2s ease;
 
-    &:hover {
-        background-color: var(--color-gray-25);
-    }
+  &:hover {
+    background-color: var(--color-gray-25);
+  }
 
-    &:last-child {
-        border-bottom: none;
-    }
+  &:last-child {
+    border-bottom: none;
+  }
 
-    @media (max-width: 768px) {
-        grid-template-columns: 60px 1fr 80px 80px 40px;
-        padding: 0.5rem;
-        gap: 0.5rem;
-    }
+  @media (max-width: 768px) {
+    grid-template-columns: 60px 1fr 80px 80px 40px;
+    padding: 0.5rem;
+    gap: 0.5rem;
+  }
 }
 
 .lesson-number {
-    font-weight: 600;
-    color: var(--color-gray-700);
-    text-align: center;
+  font-weight: 600;
+  color: var(--color-gray-700);
+  text-align: center;
 }
 
 .lesson-day {
-    color: var(--color-gray-700);
-    font-weight: 500;
-    text-transform: capitalize;
+  color: var(--color-gray-700);
+  font-weight: 500;
+  text-transform: capitalize;
 }
 
 .lesson-start-time,
 .lesson-end-time {
-    padding: 0.25rem 0.5rem;
-    border: 1px solid var(--color-gray-300);
-    border-radius: 0.25rem;
-    font-size: 0.875rem;
-    background-color: white;
-    
-    &:focus {
-        outline: none;
-        border-color: var(--color-primary-500);
-        box-shadow: 0 0 0 3px var(--color-primary-100);
-    }
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  background-color: white;
 
-    @media (max-width: 768px) {
-        padding: 0.125rem 0.25rem;
-        font-size: 0.75rem;
-    }
+  &:focus {
+    outline: none;
+    border-color: var(--color-primary-500);
+    box-shadow: 0 0 0 3px var(--color-primary-100);
+  }
+
+  @media (max-width: 768px) {
+    padding: 0.125rem 0.25rem;
+    font-size: 0.75rem;
+  }
 }
 
 .delete-lesson-btn {
-    width: 2rem;
-    height: 2rem;
-    border: 1px solid var(--color-red-300);
-    background-color: var(--color-red-50);
-    color: var(--color-red-600);
-    border-radius: 0.25rem;
-    font-size: 1rem;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    
-    &:hover {
-        background-color: var(--color-red-100);
-        border-color: var(--color-red-400);
-        color: var(--color-red-700);
-    }
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-red-300);
+  background-color: var(--color-red-50);
+  color: var(--color-red-600);
+  border-radius: 0.25rem;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
-    @media (max-width: 768px) {
-        width: 1.5rem;
-        height: 1.5rem;
-        font-size: 0.875rem;
-    }
+  &:hover {
+    background-color: var(--color-red-100);
+    border-color: var(--color-red-400);
+    color: var(--color-red-700);
+  }
+
+  @media (max-width: 768px) {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 0.875rem;
+  }
 }
 
 .schedule-summary {
-    padding: 1rem;
-    background-color: var(--color-gray-50);
-    border-top: 1px solid var(--color-gray-200);
+  padding: 1rem;
+  background-color: var(--color-gray-50);
+  border-top: 1px solid var(--color-gray-200);
 }
 
 .total-lessons {
-    font-weight: 600;
-    color: var(--color-gray-700);
-    text-align: center;
+  font-weight: 600;
+  color: var(--color-gray-700);
+  text-align: center;
 }
 
 // Button States
 .button--disabled,
 .button:disabled {
-    opacity: 0.5 !important;
-    cursor: not-allowed !important;
-    pointer-events: none !important;
-    background-color: #d1d5db !important; // Gray background when disabled
-    border-color: #d1d5db !important;
-    color: #6b7280 !important;
+  opacity: 0.5 !important;
+  cursor: not-allowed !important;
+  pointer-events: none !important;
+  background-color: #d1d5db !important; // Gray background when disabled
+  border-color: #d1d5db !important;
+  color: #6b7280 !important;
 }
 
 .button.active:not(:disabled):not(.button--disabled) {
-    opacity: 1 !important;
-    pointer-events: auto !important;
-    background-color: #3b82f6 !important; // Blue background when active
-    border-color: #3b82f6 !important;
-    color: white !important;
-    
-    &:hover {
-        background-color: #2563eb !important; // Darker blue on hover
-        border-color: #2563eb !important;
-    }
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  background-color: #3b82f6 !important; // Blue background when active
+  border-color: #3b82f6 !important;
+  color: white !important;
+
+  &:hover {
+    background-color: #2563eb !important; // Darker blue on hover
+    border-color: #2563eb !important;
+  }
 }
 
 #schedule-course-btn {
-    padding: 0.875rem 2rem;
-    font-size: 1rem;
-    font-weight: 600;
-    min-width: 200px;
+  padding: 0.875rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  min-width: 200px;
 }
 
 #delete-schedule-btn {
-    padding: 0.875rem 2rem;
-    font-size: 1rem;
-    font-weight: 600;
-    min-width: 180px;
-    background-color: #dc2626 !important; // Red background
-    border-color: #dc2626 !important;
-    color: white !important;
-    cursor: pointer !important;
+  padding: 0.875rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  min-width: 180px;
+  background-color: #dc2626 !important; // Red background
+  border-color: #dc2626 !important;
+  color: white !important;
+  cursor: pointer !important;
+  pointer-events: auto !important;
+
+  &:hover:not(:disabled) {
+    background-color: #b91c1c !important; // Darker red on hover
+    border-color: #b91c1c !important;
+  }
+
+  &.hidden {
+    display: none !important;
+  }
+
+  // Override any disabled styles
+  &:not(.hidden) {
+    opacity: 1 !important;
     pointer-events: auto !important;
-    
-    &:hover:not(:disabled) {
-        background-color: #b91c1c !important; // Darker red on hover
-        border-color: #b91c1c !important;
-    }
-    
-    &.hidden {
-        display: none !important;
-    }
-    
-    // Override any disabled styles
-    &:not(.hidden) {
-        opacity: 1 !important;
-        pointer-events: auto !important;
-    }
+  }
 }
 
 // Hidden utility
 .hidden {
-    display: none !important;
+  display: none !important;
 }

--- a/src/scss/components/_templates.scss
+++ b/src/scss/components/_templates.scss
@@ -1,24 +1,22 @@
-
-
 // ==========================================================================
 // TEMPLATE COMPONENT
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 // Template Builder Styles
 .template-header {
-    padding-bottom: 1rem; 
-  
+  padding-bottom: 1rem;
+
   &__actions {
     display: flex;
     gap: $spacing-4;
     justify-content: first baseline;
     align-items: center;
-    
+
     .button {
       min-width: 160px;
-      
+
       &__icon {
         margin-right: $spacing-2;
         font-size: 1.1em;
@@ -33,7 +31,7 @@
   height: calc(100vh - 250px); // Fixed height relative to viewport
   min-height: 600px;
   max-height: 800px;
-  
+
   @media (max-width: 768px) {
     flex-direction: column;
     gap: $spacing-6;
@@ -51,35 +49,33 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  
+
   // Make content area scrollable
   .template-config-placeholder,
   .template-blocks,
   .preview-container {
     flex: 1;
     overflow-y: auto;
- 
-    
+
     // Custom scrollbar styling
     &::-webkit-scrollbar {
       width: 8px;
     }
-    
+
     &::-webkit-scrollbar-track {
       background: #f1f5f9;
       border-radius: 4px;
     }
-    
+
     &::-webkit-scrollbar-thumb {
       background: #cbd5e1;
       border-radius: 4px;
-      
+
       &:hover {
         background: #94a3b8;
       }
     }
   }
-  
 }
 
 // ==========================================================================
@@ -94,7 +90,6 @@
   border-bottom: 1px solid $gray-200;
   background: $gray-50;
 }
-
 
 .template-blocks__list {
   display: flex;
@@ -111,7 +106,7 @@
   border-radius: $border-radius;
   background: $white;
   transition: all 0.2s ease;
-  
+
   &:hover {
     border-color: $primary-color;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -127,40 +122,44 @@
   align-items: center;
   justify-content: center;
   position: relative;
-  
+
   &::before {
-    content: '';
+    content: "";
     width: 20px;
     height: 20px;
     background: $gray-400;
     border-radius: 2px;
   }
-  
+
   &--header::before {
-    background: linear-gradient(135deg, $primary-color 0%, lighten($primary-color, 20%) 100%);
+    background: linear-gradient(
+      135deg,
+      $primary-color 0%,
+      lighten($primary-color, 20%) 100%
+    );
     border-radius: 4px 4px 2px 2px;
   }
-  
+
   &--program::before {
     background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);
     border-radius: 50%;
   }
-  
+
   &--resources::before {
     background: linear-gradient(135deg, #7c3aed 0%, #8b5cf6 100%);
     border-radius: 2px;
   }
-  
+
   &--content::before {
     background: linear-gradient(135deg, #059669 0%, #10b981 100%);
     border-radius: 2px;
   }
-  
+
   &--assignment::before {
     background: linear-gradient(135deg, #dc2626 0%, #ef4444 100%);
     border-radius: 2px;
   }
-  
+
   &--footer::before {
     background: linear-gradient(135deg, #6b7280 0%, #9ca3af 100%);
     border-radius: 2px 2px 4px 4px;
@@ -201,7 +200,7 @@
 .template-preview__controls {
   display: flex;
   gap: $spacing-2;
-  
+
   .button--active {
     background-color: $primary-color;
     color: $white;
@@ -229,36 +228,36 @@
   border-radius: $border-radius;
   background: $gray-50;
   transition: all 0.2s ease;
-  
+
   &:hover {
     border-color: $primary-color;
     background: lighten($primary-color, 45%);
   }
-  
+
   &:last-child {
     margin-bottom: 0;
   }
-  
+
   &--header {
     border-left: 4px solid $primary-color;
   }
-  
+
   &--program {
     border-left: 4px solid #2563eb;
   }
-  
+
   &--resources {
     border-left: 4px solid #7c3aed;
   }
-  
+
   &--content {
     border-left: 4px solid #059669;
   }
-  
+
   &--assignment {
     border-left: 4px solid #dc2626;
   }
-  
+
   &--footer {
     border-left: 4px solid #6b7280;
   }
@@ -300,7 +299,7 @@
   background: $white;
   overflow: hidden;
   transition: all 0.2s ease;
-  
+
   &:hover {
     border-color: $primary-color;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
@@ -315,13 +314,13 @@
   padding: $spacing-6;
   border-bottom: 1px solid $gray-200;
   background: $gray-50;
-  
+
   h4 {
     margin: 0;
     color: $text-primary;
     font-weight: $font-weight-medium;
   }
-  
+
   .template-type {
     background: $primary-color;
     color: $white;
@@ -347,7 +346,7 @@
   padding: $spacing-4 $spacing-6;
   border-top: 1px solid $gray-200;
   background: $gray-50;
-  
+
   .button {
     flex: 1;
   }
@@ -361,13 +360,13 @@
   text-align: center;
   color: $text-secondary;
   padding: $spacing-8;
-  
+
   h4 {
     margin-bottom: $spacing-4;
     color: $text-primary;
     font-weight: $font-weight-medium;
   }
-  
+
   p {
     margin-bottom: $spacing-6;
     line-height: 1.6;
@@ -388,16 +387,16 @@
   display: flex;
   flex-direction: column;
   gap: $spacing-6;
-  
+
   &__search {
     display: flex;
     flex-direction: column;
     gap: $spacing-4;
-    
+
     .template-filters {
       display: flex;
       gap: $spacing-3;
-      
+
       .form__input--small {
         max-width: 150px;
       }
@@ -417,7 +416,7 @@
   justify-content: center;
   gap: $spacing-4;
   padding: $spacing-8;
-  
+
   .loading-spinner {
     width: 40px;
     height: 40px;
@@ -426,7 +425,7 @@
     border-radius: 50%;
     animation: spin 1s linear infinite;
   }
-  
+
   p {
     color: $text-secondary;
     font-size: $font-size-sm;
@@ -434,8 +433,12 @@
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .template-list-grid {
@@ -452,19 +455,19 @@
   overflow: hidden;
   transition: all 0.2s ease;
   cursor: pointer;
-  
+
   &:hover {
     border-color: $primary-color;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
     transform: translateY(-2px);
   }
-  
+
   &--selected {
     border-color: $primary-color;
     box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
     background: linear-gradient(135deg, #fefbff 0%, #f0f9ff 100%);
   }
-  
+
   &__header {
     display: flex;
     justify-content: space-between;
@@ -473,7 +476,7 @@
     border-bottom: 1px solid #e5e7eb;
     background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
   }
-  
+
   &__title {
     margin: 0;
     font-size: $font-size-base;
@@ -481,7 +484,7 @@
     color: $text-primary;
     line-height: 1.4;
   }
-  
+
   &__type {
     background: $primary-color;
     color: $white;
@@ -493,7 +496,7 @@
     letter-spacing: 0.5px;
     white-space: nowrap;
   }
-  
+
   &__description {
     padding: $spacing-4;
     color: $text-secondary;
@@ -505,28 +508,28 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-  
+
   &__meta {
     padding: 0 $spacing-4 $spacing-4;
     font-size: $font-size-xs;
     color: $text-muted;
   }
-  
+
   &__date {
     font-weight: $font-weight-medium;
   }
-  
+
   &__actions {
     display: flex;
     gap: $spacing-2;
     padding: $spacing-3 $spacing-4;
     border-top: 1px solid #e5e7eb;
     background: #f9fafb;
-    
+
     .button--danger {
       color: #dc2626;
       border-color: #dc2626;
-      
+
       &:hover {
         background-color: #dc2626;
         color: $white;
@@ -543,18 +546,18 @@
   text-align: center;
   padding: $spacing-8;
   gap: $spacing-4;
-  
+
   &__icon {
     font-size: 3rem;
     margin-bottom: $spacing-2;
   }
-  
+
   h3 {
     margin: 0;
     color: $text-primary;
     font-weight: $font-weight-semibold;
   }
-  
+
   p {
     margin: 0;
     color: $text-secondary;
@@ -575,7 +578,7 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  
+
   &__content {
     background: $white;
     border-radius: $border-radius;
@@ -583,9 +586,11 @@
     width: 90vw;
     max-height: 80vh;
     overflow: hidden;
-    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    box-shadow:
+      0 20px 25px -5px rgba(0, 0, 0, 0.1),
+      0 10px 10px -5px rgba(0, 0, 0, 0.04);
   }
-  
+
   &__header {
     display: flex;
     justify-content: space-between;
@@ -593,27 +598,27 @@
     padding: $spacing-4 $spacing-6;
     border-bottom: 1px solid #e5e7eb;
     background: #f9fafb;
-    
+
     h3 {
       margin: 0;
       font-size: $font-size-lg;
       font-weight: $font-weight-semibold;
       color: $text-primary;
     }
-    
+
     button {
       background: none;
       border: none;
       font-size: 1.5rem;
       cursor: pointer;
       color: $text-muted;
-      
+
       &:hover {
         color: $text-primary;
       }
     }
   }
-  
+
   &__body {
     padding: $spacing-6;
     max-height: 60vh;
@@ -621,14 +626,12 @@
   }
 }
 
-
-
 .preview-block {
   padding: $spacing-3;
   border: 1px solid #e5e7eb;
   border-radius: $border-radius;
   background: #f9fafb;
-  
+
   &__label {
     font-weight: $font-weight-medium;
     font-size: $font-size-xs;
@@ -637,33 +640,33 @@
     color: $text-secondary;
     margin-bottom: $spacing-2;
   }
-  
+
   &__content {
     font-size: $font-size-sm;
     color: $text-primary;
     line-height: 1.4;
   }
-  
+
   &--header {
     border-left: 4px solid $primary-color;
   }
-  
+
   &--program {
     border-left: 4px solid #2563eb;
   }
-  
+
   &--resources {
     border-left: 4px solid #7c3aed;
   }
-  
+
   &--content {
     border-left: 4px solid #059669;
   }
-  
+
   &--assignment {
     border-left: 4px solid #dc2626;
   }
-  
+
   &--footer {
     border-left: 4px solid #6b7280;
   }
@@ -675,7 +678,7 @@
   border: 1px solid #e2e8f0;
   border-radius: $border-radius;
   background: #ffffff;
-  
+
   &__header {
     display: flex;
     align-items: center;
@@ -685,24 +688,24 @@
     border-bottom: 1px solid #e2e8f0;
     border-radius: $border-radius $border-radius 0 0;
   }
-  
+
   &__title {
     margin: 0;
     font-size: 1.125rem;
     font-weight: 600;
     color: var(--color-text-primary);
   }
-  
+
   &__fields {
     padding: 1rem;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 0.75rem;
-    
+
     @media (max-width: 768px) {
       grid-template-columns: repeat(2, 1fr);
     }
-    
+
     @media (max-width: 480px) {
       grid-template-columns: 1fr;
     }
@@ -711,7 +714,7 @@
 
 .template-field {
   margin-bottom: 0;
-  
+
   &__label {
     display: flex;
     align-items: center;
@@ -719,28 +722,28 @@
     cursor: pointer;
     font-size: 0.875rem;
     color: var(--color-text-secondary);
-    
+
     &:hover {
       color: var(--color-text-primary);
     }
   }
-  
+
   &__checkbox {
     width: 1rem;
     height: 1rem;
     accent-color: var(--color-primary);
-    
+
     &:disabled {
       opacity: 0.6;
       cursor: not-allowed;
     }
   }
-  
+
   &__text {
     flex: 1;
     line-height: 1.4;
   }
-  
+
   &__required {
     color: var(--color-primary);
     font-weight: 500;
@@ -755,13 +758,13 @@
   border-radius: $border-radius;
   overflow: hidden;
   background: #ffffff;
-  
+
   &__header {
     display: flex;
     background: #f8fafc;
     border-bottom: 1px solid #e2e8f0;
   }
-  
+
   &__column-header {
     flex: 1;
     padding: 0.75rem;
@@ -769,16 +772,16 @@
     font-size: 0.875rem;
     color: var(--color-text-primary);
     border-right: 1px solid #e2e8f0;
-    
+
     &:last-child {
       border-right: none;
     }
   }
-  
+
   &__row {
     display: flex;
   }
-  
+
   &__cell {
     flex: 1;
     padding: 0.75rem;
@@ -786,7 +789,7 @@
     color: var(--color-text-secondary);
     border-right: 1px solid #e2e8f0;
     background: #fafafa;
-    
+
     &:last-child {
       border-right: none;
     }
@@ -797,14 +800,14 @@
   &__header {
     margin-bottom: 0.75rem;
   }
-  
+
   &__title {
     margin: 0;
     font-size: 1rem;
     font-weight: 600;
     color: var(--color-text-primary);
   }
-  
+
   &__content {
     min-height: 3rem;
   }
@@ -864,7 +867,7 @@
 
 .template-content-field {
   margin-bottom: 0.25rem;
-  
+
   &:last-child {
     margin-bottom: 0;
   }
@@ -876,13 +879,13 @@
   border-radius: $border-radius;
   overflow: hidden;
   background: #ffffff;
-  
+
   &__header {
     display: flex;
     background: #f8fafc;
     border-bottom: 1px solid #e2e8f0;
   }
-  
+
   &__column-header {
     flex: 1;
     padding: 0.75rem;
@@ -890,16 +893,16 @@
     font-size: 0.875rem;
     color: var(--color-text-primary);
     border-right: 1px solid #e2e8f0;
-    
+
     &:last-child {
       border-right: none;
     }
   }
-  
+
   &__row {
     display: flex;
   }
-  
+
   &__cell {
     flex: 1;
     padding: 0.75rem;
@@ -907,7 +910,7 @@
     color: var(--color-text-secondary);
     border-right: 1px solid #e2e8f0;
     background: #fafafa;
-    
+
     &:last-child {
       border-right: none;
     }
@@ -918,14 +921,14 @@
   &__header {
     margin-bottom: 0.75rem;
   }
-  
+
   &__title {
     margin: 0;
     font-size: 1rem;
     font-weight: 600;
     color: var(--color-text-primary);
   }
-  
+
   &__content {
     min-height: 3rem;
   }
@@ -934,7 +937,7 @@
 // Template Preview Glossary Styles
 .template-preview-glossary {
   margin-top: 1.5rem;
-  
+
   &__title {
     margin: 0 0 0.75rem 0;
     font-size: 0.875rem;

--- a/src/scss/layout/_grid.scss
+++ b/src/scss/layout/_grid.scss
@@ -2,7 +2,7 @@
 // GRID LAYOUT - Modern Responsive Layout
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 // ==========================================================================
 // MAIN GRID CONTAINER
@@ -19,7 +19,6 @@
 
   // Ensure proper spacing and overflow handling
   overflow-x: hidden;
-
 
   &__header {
     grid-area: header;
@@ -53,7 +52,7 @@
       // Natural responsive behavior - grid will collapse when content is too narrow
       @container (max-width: 768px) {
         grid-template-columns: 1fr;
-        
+
         .aside {
           height: auto;
           min-height: auto;
@@ -77,7 +76,6 @@
     @media (min-width: $breakpoint-md) {
       padding: $spacing-8 $spacing-8;
     }
-
   }
 }
 
@@ -99,11 +97,9 @@
   }
 }
 
-
 // ==========================================================================
 // CONTENT CONTAINERS
 // ==========================================================================
-
 
 // ==========================================================================
 // RESPONSIVE UTILITIES

--- a/src/scss/layout/_navigation.scss
+++ b/src/scss/layout/_navigation.scss
@@ -2,7 +2,7 @@
 // NAVIGATION LAYOUT
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 // ==========================================================================
 // BASE NAVIGATION
@@ -14,24 +14,24 @@
   justify-content: space-between;
   width: 100%;
   padding: $spacing-4 $spacing-6;
-  
+
   // Responsive padding
   @media (min-width: $breakpoint-md) {
     padding: $spacing-4 $spacing-8;
   }
-  
+
   @media (min-width: $breakpoint-lg) {
     padding: $spacing-4 $spacing-12;
   }
-  
+
   // Navigation in footer has different styling
   &--footer {
     padding: $spacing-3 $spacing-6;
-    
+
     @media (min-width: $breakpoint-md) {
       padding: $spacing-3 $spacing-8;
     }
-    
+
     @media (min-width: $breakpoint-lg) {
       padding: $spacing-3 $spacing-12;
     }
@@ -55,7 +55,7 @@
   align-items: center;
   flex: 1;
   justify-content: center;
-  
+
   // On mobile, hide the center links to make room
   @media (max-width: #{$breakpoint-md - 1px}) {
     display: none;
@@ -78,7 +78,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  
+
   .nav__left-section,
   .nav__right-section {
     display: flex;
@@ -86,15 +86,15 @@
     flex: 0 0 auto;
     min-width: 120px; // Ensure consistent spacing
   }
-  
+
   .nav__left-section {
     justify-content: flex-start;
   }
-  
+
   .nav__right-section {
     justify-content: flex-end;
   }
-  
+
   .nav__center-section {
     display: flex;
     align-items: center;
@@ -112,11 +112,11 @@
   .nav {
     // On mobile, space out logo and button more
     padding: $spacing-3 $spacing-4;
-    
+
     // Ensure proper spacing between logo and button
     gap: $spacing-4;
   }
-  
+
   .nav--coursebuilder {
     .nav__left-section,
     .nav__right-section {

--- a/src/scss/layout/_sidebar.scss
+++ b/src/scss/layout/_sidebar.scss
@@ -2,7 +2,7 @@
 // SIDEBAR STYLING ONLY - NO LAYOUT!
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 .aside {
   background: $white;
@@ -11,23 +11,23 @@
   padding: $spacing-6;
   display: flex;
   flex-direction: column;
-  
+
   &__nav {
     width: 100%;
     flex: 1;
     display: flex;
     flex-direction: column;
   }
-  
+
   &__group {
     margin-bottom: $spacing-6;
-    
+
     &--settings {
       margin-top: auto;
       margin-bottom: 0;
     }
   }
-  
+
   &__group-title {
     font-size: $font-size-sm;
     font-weight: $font-weight-semibold;
@@ -37,17 +37,17 @@
     margin-bottom: $spacing-3;
     padding: 0 $spacing-3;
   }
-  
+
   &__menu {
     list-style: none;
     padding: 0;
     margin: 0;
   }
-  
+
   &__item {
     margin-bottom: $spacing-2;
   }
-  
+
   &__link {
     display: block;
     padding: $spacing-3 $spacing-4;
@@ -56,17 +56,17 @@
     border-radius: $border-radius-sm;
     transition: all 0.2s ease;
     font-weight: $font-weight-medium;
-    
+
     &:hover {
       background: $gray-100;
       color: $primary-color;
       transform: translateX(2px);
     }
-    
+
     &--active {
       background: $primary-color;
       color: $white;
-      
+
       &:hover {
         background: $primary-color;
         color: $white;
@@ -82,7 +82,7 @@
 
 .article {
   display: none;
-  
+
   &--active {
     display: block;
   }
@@ -91,7 +91,7 @@
 // Course builder sections
 .section {
   display: none;
-  
+
   &--active {
     display: block;
   }
@@ -103,32 +103,32 @@
     flex-direction: row;
     height: auto !important;
     min-height: auto !important;
-    
+
     &__nav {
       width: 100%;
       flex-direction: row;
     }
-    
+
     &__menu {
       display: flex;
       gap: $spacing-2;
       overflow-x: auto;
     }
-    
+
     &__item {
       margin-bottom: 0;
       flex: 0 0 auto;
     }
-    
+
     &__link {
       white-space: nowrap;
       padding: $spacing-3;
     }
-    
+
     &__group {
       margin-bottom: 0;
       margin-right: $spacing-4;
-      
+
       &--settings {
         margin-top: 0;
         margin-left: auto;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -3,43 +3,42 @@
 // ==========================================================================
 
 // 1. ABSTRACTS
-@use 'abstracts/variables';
-@use 'abstracts/functions';
-@use 'abstracts/mixins';
+@use "abstracts/variables";
+@use "abstracts/functions";
+@use "abstracts/mixins";
 
 // 2. VENDORS
-@use 'vendors/normalize';
+@use "vendors/normalize";
 
 // 3. BASE
-@use 'base/reset';
-@use 'base/typography';
-@use 'base/base';
+@use "base/reset";
+@use "base/typography";
+@use "base/base";
 
 // 4. LAYOUT
-@use 'layout/header';
-@use 'layout/navigation';
-@use 'layout/sidebar';
-@use 'layout/footer';
-@use 'layout/grid';
+@use "layout/header";
+@use "layout/navigation";
+@use "layout/sidebar";
+@use "layout/footer";
+@use "layout/grid";
 
 // 5. COMPONENTS
-@use 'components/buttons';
-@use 'components/forms';
-@use 'components/cards';
-@use 'components/modals';
-@use 'components/alerts';
-@use 'components/dropdown';
-@use 'components/templates';
-@use 'components/schedule';
-@use 'components/curriculum';
-@use 'components/coursebuilder';
-@use 'components/canvas-layout';
+@use "components/buttons";
+@use "components/forms";
+@use "components/cards";
+@use "components/modals";
+@use "components/alerts";
+@use "components/dropdown";
+@use "components/templates";
+@use "components/schedule";
+@use "components/curriculum";
+@use "components/coursebuilder";
+@use "components/canvas-layout";
 
 // 6. PAGES
-@use 'pages/home';
-@use 'pages/auth';
-@use 'pages/pricing';
-
+@use "pages/home";
+@use "pages/auth";
+@use "pages/pricing";
 
 // 7. THEMES
-@use 'themes/default';
+@use "themes/default";

--- a/src/scss/pages/_home.scss
+++ b/src/scss/pages/_home.scss
@@ -2,7 +2,7 @@
 // HOME PAGE STYLES
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 // Note: Article display logic moved to _sidebar.scss for consistency
 
@@ -94,13 +94,13 @@
     padding: $spacing-4;
     border: 1px solid $gray-200;
     border-radius: $border-radius;
-    
+
     h4 {
       margin: 0 0 $spacing-2 0;
       color: $text-primary;
       font-size: $font-size-lg;
     }
-    
+
     p {
       margin: 0 0 $spacing-3 0;
     }

--- a/src/scss/pages/_pricing.scss
+++ b/src/scss/pages/_pricing.scss
@@ -2,7 +2,7 @@
 // PRICING PAGE STYLES
 // ==========================================================================
 
-@use '../abstracts/variables' as *;
+@use "../abstracts/variables" as *;
 
 // Pricing Grid
 .pricing-grid {
@@ -10,12 +10,12 @@
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: $spacing-6;
   margin: $spacing-8 0;
-  
+
   @media (max-width: #{$breakpoint-lg - 1px}) {
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: $spacing-4;
   }
-  
+
   @media (max-width: #{$breakpoint-sm - 1px}) {
     grid-template-columns: 1fr;
     gap: $spacing-4;
@@ -28,22 +28,26 @@
   text-align: center;
   border: 2px solid $gray-200;
   transition: all 0.3s ease;
-  
+
   &:hover {
     transform: translateY(-4px);
     box-shadow: $shadow-lg;
     border-color: $primary-color;
   }
-  
+
   &--featured {
     border-color: $primary-color;
     box-shadow: $shadow-lg;
-    
+
     .card__header {
-      background: linear-gradient(135deg, $primary-color, lighten($primary-color, 10%));
+      background: linear-gradient(
+        135deg,
+        $primary-color,
+        lighten($primary-color, 10%)
+      );
       color: $white;
       position: relative;
-      
+
       .badge {
         position: absolute;
         top: -12px;
@@ -64,22 +68,22 @@
 // Price Display
 .price {
   margin: $spacing-4 0;
-  
+
   &__amount {
     font-size: 3rem;
     font-weight: $font-weight-bold;
     color: $primary-color;
-    
+
     .pricing-card--featured & {
       color: $white;
     }
   }
-  
+
   &__period {
     font-size: 1rem;
     color: $text-secondary;
     margin-left: $spacing-1;
-    
+
     .pricing-card--featured & {
       color: rgba($white, 0.8);
     }
@@ -92,11 +96,11 @@
   padding: 0;
   margin: 0;
   text-align: left;
-  
+
   .feature {
     padding: $spacing-2 0;
     border-bottom: 1px solid $gray-100;
-    
+
     &:last-child {
       border-bottom: none;
     }
@@ -119,18 +123,18 @@
 .hero {
   text-align: center;
   padding: $spacing-8 0;
-  
+
   &__content {
     max-width: 800px;
     margin: 0 auto;
   }
-  
+
   &__actions {
     margin-top: $spacing-6;
     display: flex;
     gap: $spacing-4;
     justify-content: center;
-    
+
     @media (max-width: #{$breakpoint-sm - 1px}) {
       flex-direction: column;
       align-items: center;
@@ -144,7 +148,7 @@
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: $spacing-6;
   margin: $spacing-8 0;
-  
+
   @media (max-width: #{$breakpoint-sm - 1px}) {
     grid-template-columns: 1fr;
     gap: $spacing-4;
@@ -157,14 +161,14 @@
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: $spacing-4;
   margin: $spacing-6 0;
-  
+
   .stat-number {
     font-size: 2.5rem;
     font-weight: $font-weight-bold;
     color: $primary-color;
     line-height: 1;
   }
-  
+
   .stat-label {
     font-size: 1rem;
     color: $text-secondary;
@@ -187,7 +191,7 @@
     line-height: 1.6;
     margin-bottom: $spacing-4;
   }
-  
+
   &--cite {
     font-size: 0.875rem;
     color: $text-secondary;
@@ -202,13 +206,13 @@
   background: $gray-50;
   border-radius: $border-radius;
   margin: $spacing-8 0;
-  
+
   &__actions {
     margin-top: $spacing-6;
     display: flex;
     gap: $spacing-4;
     justify-content: center;
-    
+
     @media (max-width: #{$breakpoint-sm - 1px}) {
       flex-direction: column;
       align-items: center;
@@ -247,7 +251,7 @@
   &--full {
     width: 100%;
   }
-  
+
   &--large {
     padding: $spacing-3 $spacing-5;
     font-size: 1rem;

--- a/src/types/spectorjs.d.ts
+++ b/src/types/spectorjs.d.ts
@@ -3,41 +3,41 @@
  * WebGL debugger and profiler
  */
 
-declare module 'spectorjs' {
+declare module "spectorjs" {
   export class Spector {
     constructor();
-    
+
     /**
      * Start capturing WebGL commands
      */
     startCapture(): void;
-    
+
     /**
      * Stop capturing WebGL commands
      */
     stopCapture(): void;
-    
+
     /**
      * Clear capture data
      */
     clearCapture(): void;
-    
+
     /**
      * Get capture data
      */
     getCaptureData(): any;
-    
+
     /**
      * Display capture in UI
      */
     displayUI(): void;
-    
+
     /**
      * Set capture options
      */
     setCaptureOptions(options: any): void;
   }
-  
+
   export default Spector;
 }
 
@@ -46,7 +46,7 @@ declare global {
   interface Window {
     spector?: any;
   }
-  
+
   const Spector: any;
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_SUPABASE_URL: string
-  readonly VITE_SUPABASE_ANON_KEY: string
-  readonly VITE_APP_ENV: string
-  readonly VITE_APP_NAME: string
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_APP_ENV: string;
+  readonly VITE_APP_NAME: string;
 }
 
 interface ImportMeta {
-  readonly env: ImportMetaEnv
+  readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
The coursebuilder page did not update its visible section when the URL hash was changed directly (e.g., via browser back/forward buttons), requiring a manual refresh.

This was because the `CourseBuilderNavigation` class, which manages section visibility, did not have a `hashchange` event listener. The existing listener in `navigation/index.ts` was for managing the aside menu, not the main content sections.

This commit adds a `hashchange` listener to the `CourseBuilderNavigation` class. The listener calls the existing `setInitialSection` method to synchronize the view with the URL hash. To prevent infinite loops, the `navigateToSection` method has been updated to only set the hash if it has actually changed.