### PR TITLE
fix: guard eraser preview

### DIFF
--- a/src/scripts/coursebuilder/tools/EraserTool.ts
+++ b/src/scripts/coursebuilder/tools/EraserTool.ts
@@ -159,15 +159,21 @@ export class EraserTool extends BaseTool {
     event: FederatedPointerEvent,
     container: Container,
   ): void {
-    if (!this.erasePreview) {
+    // Ensure preview graphic exists and hasn't been destroyed
+    if (!this.erasePreview || this.erasePreview.destroyed) {
       this.erasePreview = new Graphics();
       this.erasePreview.alpha = 0.3;
       container.addChild(this.erasePreview);
     }
 
+    if (!this.erasePreview) {
+      return; // bail out if creation somehow failed
+    }
+
     const localPoint = container.toLocal(event.global);
     const radius = this.settings.size / 2;
 
+    // Clear any previous preview and draw the current one
     this.erasePreview.clear();
     this.erasePreview.circle(localPoint.x, localPoint.y, radius);
     this.erasePreview.fill({ color: 0xff4444 }); // Red preview
@@ -175,8 +181,13 @@ export class EraserTool extends BaseTool {
   }
 
   private hideErasePreview(): void {
-    if (this.erasePreview && this.erasePreview.parent) {
-      this.erasePreview.parent.removeChild(this.erasePreview);
+    if (this.erasePreview) {
+      // Remove from display list if still attached
+      if (this.erasePreview.parent) {
+        this.erasePreview.parent.removeChild(this.erasePreview);
+      }
+      // Destroy the graphics object to avoid invalid references
+      this.erasePreview.destroy();
       this.erasePreview = null;
     }
   }


### PR DESCRIPTION
## Summary
- prevent EraserTool from calling clear on a null preview graphic
- destroy preview graphics when eraser deactivates

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run format:check` (fails: Code style issues found in 40 files)


------
https://chatgpt.com/codex/tasks/task_e_689bdf5d54648327b650eda2280683a6