### PR TITLE
refactor: central display object manager for canvas tools

### DIFF
--- a/src/scripts/coursebuilder/canvas/CanvasEventHandler.ts
+++ b/src/scripts/coursebuilder/canvas/CanvasEventHandler.ts
@@ -4,13 +4,14 @@
  * Single Responsibility: Event handling only
  */
 
-import { Application, Container, FederatedPointerEvent } from "pixi.js";
+import { Application, FederatedPointerEvent } from "pixi.js";
 import { ToolManager } from "../tools/ToolManager";
+import { DisplayObjectManager } from "./DisplayObjectManager";
 
 export class CanvasEventHandler {
   private app: Application;
   private toolManager: ToolManager;
-  private drawingContainer: Container | null = null;
+  private displayManager: DisplayObjectManager | null = null;
 
   constructor(app: Application, toolManager: ToolManager) {
     this.app = app;
@@ -18,10 +19,10 @@ export class CanvasEventHandler {
   }
 
   /**
-   * Set drawing container for tool interactions
+   * Provide display object manager for tool interactions
    */
-  public setDrawingContainer(container: Container): void {
-    this.drawingContainer = container;
+  public setDisplayManager(manager: DisplayObjectManager): void {
+    this.displayManager = manager;
   }
 
   /**
@@ -63,9 +64,10 @@ export class CanvasEventHandler {
    */
   private handlePointerDown(event: FederatedPointerEvent): void {
     const activeTool = this.toolManager.getActiveTool();
-    if (activeTool && this.drawingContainer) {
+    const container = this.displayManager?.getRoot();
+    if (activeTool && container) {
       try {
-        activeTool.onPointerDown(event, this.drawingContainer);
+        activeTool.onPointerDown(event, container);
       } catch (error) {
         console.error("❌ Error in tool pointer down:", error);
       }
@@ -77,9 +79,10 @@ export class CanvasEventHandler {
    */
   private handlePointerMove(event: FederatedPointerEvent): void {
     const activeTool = this.toolManager.getActiveTool();
-    if (activeTool && this.drawingContainer) {
+    const container = this.displayManager?.getRoot();
+    if (activeTool && container) {
       try {
-        activeTool.onPointerMove(event, this.drawingContainer);
+        activeTool.onPointerMove(event, container);
       } catch (error) {
         console.error("❌ Error in tool pointer move:", error);
       }
@@ -91,9 +94,10 @@ export class CanvasEventHandler {
    */
   private handlePointerUp(event: FederatedPointerEvent): void {
     const activeTool = this.toolManager.getActiveTool();
-    if (activeTool && this.drawingContainer) {
+    const container = this.displayManager?.getRoot();
+    if (activeTool && container) {
       try {
-        activeTool.onPointerUp(event, this.drawingContainer);
+        activeTool.onPointerUp(event, container);
       } catch (error) {
         console.error("❌ Error in tool pointer up:", error);
       }

--- a/src/scripts/coursebuilder/canvas/DisplayObjectManager.ts
+++ b/src/scripts/coursebuilder/canvas/DisplayObjectManager.ts
@@ -1,0 +1,60 @@
+import { Container, DisplayObject } from "pixi.js";
+
+/**
+ * Display Object Manager
+ * Centralizes adding and removing of display objects on the drawing layer
+ */
+export class DisplayObjectManager {
+  private root: Container;
+  private objects: Set<DisplayObject> = new Set();
+
+  constructor(root: Container) {
+    this.root = root;
+  }
+
+  /**
+   * Add a display object to the drawing layer and track it
+   */
+  public add(object: DisplayObject): void {
+    if (object.parent !== this.root) {
+      this.root.addChild(object);
+    }
+    this.objects.add(object);
+  }
+
+  /**
+   * Remove a display object from the drawing layer
+   */
+  public remove(object: DisplayObject): void {
+    if (object.parent === this.root) {
+      this.root.removeChild(object);
+    }
+    this.objects.delete(object);
+  }
+
+  /**
+   * Get the underlying root container
+   */
+  public getRoot(): Container {
+    return this.root;
+  }
+
+  /**
+   * Return all tracked display objects
+   */
+  public getObjects(): DisplayObject[] {
+    return Array.from(this.objects);
+  }
+
+  /**
+   * Remove and clear all tracked objects
+   */
+  public clear(): void {
+    this.objects.forEach((obj) => {
+      if (obj.parent === this.root) {
+        this.root.removeChild(obj);
+      }
+    });
+    this.objects.clear();
+  }
+}

--- a/src/scripts/coursebuilder/canvas/PixiCanvas.ts
+++ b/src/scripts/coursebuilder/canvas/PixiCanvas.ts
@@ -9,11 +9,13 @@ import { ToolManager } from "../tools/ToolManager";
 import { PixiApplicationManager } from "./PixiApplicationManager";
 import { CanvasLayerManager } from "./CanvasLayerManager";
 import { CanvasEventHandler } from "./CanvasEventHandler";
+import { DisplayObjectManager } from "./DisplayObjectManager";
 
 export class PixiCanvas {
   private appManager: PixiApplicationManager;
   private layerManager: CanvasLayerManager | null = null;
   private eventHandler: CanvasEventHandler | null = null;
+  private displayManager: DisplayObjectManager | null = null;
   private toolManager: ToolManager;
   private app: Application | null = null;
 
@@ -35,11 +37,17 @@ export class PixiCanvas {
       this.layerManager.initializeLayers();
       this.layerManager.addBackgroundGrid();
 
-      // Initialize event handling
-      this.eventHandler = new CanvasEventHandler(this.app, this.toolManager);
-      this.eventHandler.setDrawingContainer(
+      // Initialize display object manager
+      this.displayManager = new DisplayObjectManager(
         this.layerManager.getDrawingContainer()!,
       );
+
+      // Provide display manager to tools
+      this.toolManager.setDisplayManager(this.displayManager);
+
+      // Initialize event handling
+      this.eventHandler = new CanvasEventHandler(this.app, this.toolManager);
+      this.eventHandler.setDisplayManager(this.displayManager);
       this.eventHandler.setupEvents();
 
     } catch (error) {

--- a/src/scripts/coursebuilder/canvas/PixiCanvasRefactored.ts
+++ b/src/scripts/coursebuilder/canvas/PixiCanvasRefactored.ts
@@ -9,11 +9,13 @@ import { ToolManager } from "../tools/ToolManager.js";
 import { PixiApplicationManager } from "./PixiApplicationManager.js";
 import { CanvasLayerManager } from "./CanvasLayerManager.js";
 import { CanvasEventHandler } from "./CanvasEventHandler.js";
+import { DisplayObjectManager } from "./DisplayObjectManager.js";
 
 export class PixiCanvasRefactored {
   private appManager: PixiApplicationManager;
   private layerManager: CanvasLayerManager | null = null;
   private eventHandler: CanvasEventHandler | null = null;
+  private displayManager: DisplayObjectManager | null = null;
   private toolManager: ToolManager;
   private app: Application | null = null;
 
@@ -35,11 +37,17 @@ export class PixiCanvasRefactored {
       this.layerManager.initializeLayers();
       this.layerManager.addBackgroundGrid();
 
-      // Initialize event handling
-      this.eventHandler = new CanvasEventHandler(this.app, this.toolManager);
-      this.eventHandler.setDrawingContainer(
+      // Initialize display object manager
+      this.displayManager = new DisplayObjectManager(
         this.layerManager.getDrawingContainer()!,
       );
+
+      // Provide display manager to tools
+      this.toolManager.setDisplayManager(this.displayManager);
+
+      // Initialize event handling
+      this.eventHandler = new CanvasEventHandler(this.app, this.toolManager);
+      this.eventHandler.setDisplayManager(this.displayManager);
       this.eventHandler.setupEvents();
 
     } catch (error) {

--- a/src/scripts/coursebuilder/tools/EraserTool.ts
+++ b/src/scripts/coursebuilder/tools/EraserTool.ts
@@ -159,15 +159,21 @@ export class EraserTool extends BaseTool {
     event: FederatedPointerEvent,
     container: Container,
   ): void {
-    if (!this.erasePreview) {
+    // Ensure preview graphic exists and hasn't been destroyed
+    if (!this.erasePreview || this.erasePreview.destroyed) {
       this.erasePreview = new Graphics();
       this.erasePreview.alpha = 0.3;
       container.addChild(this.erasePreview);
     }
 
+    if (!this.erasePreview) {
+      return; // bail out if creation somehow failed
+    }
+
     const localPoint = container.toLocal(event.global);
     const radius = this.settings.size / 2;
 
+    // Clear any previous preview and draw the current one
     this.erasePreview.clear();
     this.erasePreview.circle(localPoint.x, localPoint.y, radius);
     this.erasePreview.fill({ color: 0xff4444 }); // Red preview
@@ -175,8 +181,13 @@ export class EraserTool extends BaseTool {
   }
 
   private hideErasePreview(): void {
-    if (this.erasePreview && this.erasePreview.parent) {
-      this.erasePreview.parent.removeChild(this.erasePreview);
+    if (this.erasePreview) {
+      // Remove from display list if still attached
+      if (this.erasePreview.parent) {
+        this.erasePreview.parent.removeChild(this.erasePreview);
+      }
+      // Destroy the graphics object to avoid invalid references
+      this.erasePreview.destroy();
       this.erasePreview = null;
     }
   }

--- a/src/scripts/coursebuilder/tools/ToolInterface.ts
+++ b/src/scripts/coursebuilder/tools/ToolInterface.ts
@@ -4,6 +4,7 @@
  */
 
 import { FederatedPointerEvent, Container } from "pixi.js";
+import { DisplayObjectManager } from "../canvas/DisplayObjectManager";
 
 export interface ToolSettings {
   pen: {
@@ -41,6 +42,7 @@ export interface Tool {
   onActivate(): void;
   onDeactivate(): void;
   updateSettings(settings: any): void;
+  setDisplayObjectManager(manager: DisplayObjectManager): void;
 }
 
 export abstract class BaseTool implements Tool {
@@ -48,6 +50,7 @@ export abstract class BaseTool implements Tool {
   public cursor: string;
   protected isActive: boolean = false;
   protected settings: any;
+  protected displayManager: DisplayObjectManager | null = null;
 
   constructor(name: string, cursor: string = "default") {
     this.name = name;
@@ -77,6 +80,10 @@ export abstract class BaseTool implements Tool {
 
   updateSettings(settings: any): void {
     this.settings = { ...this.settings, ...settings };
+  }
+
+  setDisplayObjectManager(manager: DisplayObjectManager): void {
+    this.displayManager = manager;
   }
 
   protected hexToNumber(hex: string): number {

--- a/src/scripts/coursebuilder/tools/ToolManager.ts
+++ b/src/scripts/coursebuilder/tools/ToolManager.ts
@@ -3,7 +3,7 @@
  * Manages all drawing tools and their interactions with the canvas
  */
 
-import { FederatedPointerEvent, Container } from "pixi.js";
+import { FederatedPointerEvent, Container, DisplayObject } from "pixi.js";
 import { Tool, ToolSettings } from "./ToolInterface";
 import { SelectionTool } from "./SelectionTool";
 import { PenTool } from "./PenTool";
@@ -11,11 +11,13 @@ import { HighlighterTool } from "./HighlighterTool";
 import { TextTool } from "./TextTool";
 import { ShapesTool } from "./ShapesTool";
 import { EraserTool } from "./EraserTool";
+import { DisplayObjectManager } from "../canvas/DisplayObjectManager";
 
 export class ToolManager {
   private tools: Map<string, Tool> = new Map();
   private activeTool: Tool | null = null;
   private settings: ToolSettings;
+  private displayManager: DisplayObjectManager | null = null;
 
   constructor() {
     this.settings = {
@@ -61,6 +63,16 @@ export class ToolManager {
     if (this.activeTool) {
       this.activeTool.onActivate();
     }
+  }
+
+  /**
+   * Provide the display object manager to all tools
+   */
+  public setDisplayManager(manager: DisplayObjectManager): void {
+    this.displayManager = manager;
+    this.tools.forEach((tool) => {
+      tool.setDisplayObjectManager(manager);
+    });
   }
 
   public setActiveTool(toolName: string): boolean {
@@ -169,6 +181,21 @@ export class ToolManager {
     tool.updateSettings(toolSettings);
   }
 
+  /**
+   * Convenience wrappers for managing display objects through the manager
+   */
+  public addDisplayObject(obj: DisplayObject): void {
+    this.displayManager?.add(obj);
+  }
+
+  public removeDisplayObject(obj: DisplayObject): void {
+    this.displayManager?.remove(obj);
+  }
+
+  public getDisplayObjects(): DisplayObject[] {
+    return this.displayManager?.getObjects() || [];
+  }
+
   public updateColorForCurrentTool(color: string): void {
     if (!this.activeTool) return;
 
@@ -207,5 +234,6 @@ export class ToolManager {
     // Clear all tools
     this.tools.clear();
     this.activeTool = null;
+    this.displayManager = null;
   }
 }


### PR DESCRIPTION
## Summary
- add `DisplayObjectManager` to centralize Pixi display object tracking
- wire `ToolManager`, `CanvasEventHandler`, and canvas setup to use shared manager
- extend tool interfaces so all tools can access display manager

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run format:check` *(fails: Code style issues found in 40 files)*

------
https://chatgpt.com/codex/tasks/task_e_689bdf5d54648327b650eda2280683a6