### PR TITLE
feat: add template-based course canvas with dnd-kit

### DIFF
--- a/src/app/(coursebuilder)/teacher/coursebuilder/template-editor/page.tsx
+++ b/src/app/(coursebuilder)/teacher/coursebuilder/template-editor/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { CoursePageEditor } from '@/components/coursebuilder/template-editor/CoursePageEditor';
+import { LESSON_TEMPLATE } from '@/templates/lesson';
+import { QUIZ_TEMPLATE } from '@/templates/quiz';
+import { useState } from 'react';
+
+export default function TemplateEditorPage() {
+  const [template, setTemplate] = useState(LESSON_TEMPLATE);
+
+  return (
+    <div className="flex flex-col h-screen">
+      <div className="h-12 border-b bg-white flex items-center px-4 justify-between shrink-0 z-10 relative">
+        <h1 className="font-semibold text-gray-700">Template Editor Prototype</h1>
+        <div className="flex gap-2">
+            <button
+                onClick={() => setTemplate(LESSON_TEMPLATE)}
+                className={`px-3 py-1 text-sm rounded ${template.id === LESSON_TEMPLATE.id ? 'bg-blue-100 text-blue-700' : 'hover:bg-gray-100'}`}
+            >
+                Lesson Template
+            </button>
+            <button
+                onClick={() => setTemplate(QUIZ_TEMPLATE)}
+                className={`px-3 py-1 text-sm rounded ${template.id === QUIZ_TEMPLATE.id ? 'bg-blue-100 text-blue-700' : 'hover:bg-gray-100'}`}
+            >
+                Quiz Template
+            </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-hidden relative">
+        {/* We use key to force re-mount when template changes to reset state */}
+        <CoursePageEditor key={template.id} template={template} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/coursebuilder/template-editor/CoursePageEditor.tsx
+++ b/src/components/coursebuilder/template-editor/CoursePageEditor.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { DndContext, DragEndEvent, DragOverlay, useSensors, useSensor, PointerSensor, DragStartEvent } from '@dnd-kit/core';
+import { useState, useCallback, useEffect } from 'react';
+import type { TemplateDefinition, ContentBlock, PageInstance, MediaType } from '@/types/template';
+import { createBlock, getDefaultData } from '@/lib/blocks';
+import { LESSON_TEMPLATE } from '@/templates/lesson';
+import { MediaPalette } from './MediaPalette';
+import { PageCanvas } from './PageCanvas';
+import { TemplateZone } from './TemplateZone';
+import { ZoomControls } from './ZoomControls';
+import { PlacedBlock } from './PlacedBlock';
+import { createPortal } from 'react-dom';
+
+export function CoursePageEditor({ template = LESSON_TEMPLATE }: {
+  template?: TemplateDefinition;
+}) {
+  const [page, setPage] = useState<PageInstance>({
+    id: crypto.randomUUID(),
+    templateId: template.id,
+    courseId: 'course-1',
+    title: 'Untitled Page',
+    status: 'draft',
+    zones: Object.fromEntries(template.zones.map(z => [z.id, []])),
+    version: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+
+  const [zoom, setZoom] = useState(0.75);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeItem, setActiveItem] = useState<ContentBlock | { type: MediaType; label: string } | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    })
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+    const data = event.active.data.current;
+    if (data?.fromPalette) {
+       setActiveItem({ type: data.mediaType, label: data.mediaType });
+    } else if (data?.block) {
+       setActiveItem(data.block);
+    }
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    setActiveItem(null);
+
+    if (!over) return;
+
+    const targetZoneId = over.id as string;
+    const sourceData = active.data.current;
+
+    // Find the zone definition to validate
+    const zoneDef = template.zones.find(z => z.id === targetZoneId);
+
+    // If we dropped on a zone (and not somewhere else)
+    if (zoneDef) {
+        const currentBlocks = page.zones[targetZoneId] || [];
+
+        // 1. Check max blocks
+        if (currentBlocks.length >= zoneDef.maxBlocks) return;
+
+        // 2. Check accepted types
+        // Note: For dnd-kit core, we manually check here.
+        // Although we used data.accepts in TemplateZone for visual feedback, we enforce it here.
+        const typeToCheck = sourceData?.mediaType || sourceData?.type;
+        if (!zoneDef.acceptedMediaTypes.includes(typeToCheck)) return;
+
+        // 3. Create or Move block
+        if (sourceData?.fromPalette) {
+            // Creating new block from palette
+            const newBlock = createBlock(
+                sourceData.mediaType,
+                getDefaultData(sourceData.mediaType),
+                targetZoneId,
+            );
+
+            setPage(prev => ({
+                ...prev,
+                zones: {
+                ...prev.zones,
+                [targetZoneId]: [
+                    ...prev.zones[targetZoneId],
+                    { ...newBlock, order: prev.zones[targetZoneId].length },
+                ],
+                },
+                updatedAt: new Date().toISOString(),
+            }));
+        } else if (sourceData?.block) {
+            // Moving existing block
+            const block = sourceData.block as ContentBlock;
+            const sourceZoneId = sourceData.fromZone;
+
+            if (sourceZoneId === targetZoneId) {
+                // Reordering within same zone (not implemented in this simplified version, requires sortable)
+                // For now, we just append to end if it's the same zone, which does nothing if we don't handle index.
+                // To properly implement reordering, we'd need @dnd-kit/sortable.
+                return;
+            }
+
+            // Moving between zones
+            setPage(prev => {
+                const sourceZoneBlocks = prev.zones[sourceZoneId].filter(b => b.id !== block.id);
+                const targetZoneBlocks = [...prev.zones[targetZoneId], { ...block, zoneId: targetZoneId }];
+
+                return {
+                    ...prev,
+                    zones: {
+                        ...prev.zones,
+                        [sourceZoneId]: sourceZoneBlocks,
+                        [targetZoneId]: targetZoneBlocks
+                    },
+                    updatedAt: new Date().toISOString(),
+                };
+            });
+        }
+    }
+  }, [page, template]);
+
+  return (
+    <DndContext
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+    >
+      <div className="flex h-screen overflow-hidden bg-gray-100">
+        <MediaPalette />
+
+        <div className="flex-1 relative overflow-hidden">
+            <PageCanvas template={template} zoom={zoom}>
+            {template.zones.map(zone => (
+                <TemplateZone
+                key={zone.id}
+                zone={zone}
+                blocks={page.zones[zone.id] || []}
+                onRemoveBlock={(blockId) => {
+                    setPage(prev => ({
+                    ...prev,
+                    zones: {
+                        ...prev.zones,
+                        [zone.id]: prev.zones[zone.id].filter(b => b.id !== blockId),
+                    },
+                    updatedAt: new Date().toISOString(),
+                    }));
+                }}
+                />
+            ))}
+            </PageCanvas>
+
+            <ZoomControls zoom={zoom} onZoomChange={setZoom} />
+        </div>
+
+        {mounted && createPortal(
+            <DragOverlay>
+                {activeId && activeItem ? (
+                     <div className="opacity-80 rotate-2 cursor-grabbing pointer-events-none">
+                        {'id' in activeItem ? (
+                            // It's a PlacedBlock (ContentBlock has id)
+                             <div className="w-64">
+                                <PlacedBlock block={activeItem as ContentBlock} onRemove={() => {}} />
+                             </div>
+                        ) : (
+                            // It's a Palette Item
+                            <div className="px-4 py-2 bg-blue-500 text-white rounded-full shadow-xl font-bold text-sm">
+                                New {(activeItem as { label: string }).label}
+                            </div>
+                        )}
+                     </div>
+                ) : null}
+            </DragOverlay>,
+            document.body
+        )}
+      </div>
+    </DndContext>
+  );
+}

--- a/src/components/coursebuilder/template-editor/MediaPalette.tsx
+++ b/src/components/coursebuilder/template-editor/MediaPalette.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useDraggable } from '@dnd-kit/core';
+import { MediaType } from '@/types/template';
+import {
+  Video,
+  Image as ImageIcon,
+  Type,
+  Link as LinkIcon,
+  HelpCircle,
+  Download,
+  Award,
+  Terminal,
+  FileCheck
+} from 'lucide-react';
+
+const PALETTE_ITEMS: Array<{ type: MediaType; label: string; icon: React.ComponentType<{ className?: string }> }> = [
+  { type: 'video',        label: 'Video',         icon: Video },
+  { type: 'image',        label: 'Image',         icon: ImageIcon },
+  { type: 'richText',     label: 'Text Block',    icon: Type },
+  { type: 'embed',        label: 'Embed',         icon: LinkIcon },
+  { type: 'quizQuestion', label: 'Quiz Question', icon: HelpCircle },
+  { type: 'assessment',   label: 'Assessment',    icon: FileCheck },
+  { type: 'codePlayground', label: 'Code Playground', icon: Terminal },
+  { type: 'downloadable', label: 'File Download', icon: Download },
+  { type: 'certificateField', label: 'Cert Field', icon: Award },
+];
+
+interface PaletteItemProps {
+  type: MediaType;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+function PaletteItem({ type, label, icon: Icon }: PaletteItemProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `palette-${type}`,
+    data: {
+      mediaType: type,
+      fromPalette: true,
+      accepts: [type] // A hint for drop zones
+    },
+  });
+
+  const style = transform ? {
+    transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+  } : undefined;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className={`
+        flex items-center gap-3 px-3 py-2.5 rounded-md border
+        bg-white cursor-grab hover:border-blue-300 hover:shadow-sm hover:bg-gray-50
+        transition-all select-none w-full
+        ${isDragging ? 'opacity-50 ring-2 ring-blue-400 z-50' : 'border-gray-200'}
+      `}
+    >
+      <div className="text-gray-500">
+        <Icon className="w-4 h-4" />
+      </div>
+      <span className="text-sm font-medium text-gray-700">{label}</span>
+    </div>
+  );
+}
+
+export function MediaPalette() {
+  return (
+    <div className="w-64 p-4 bg-gray-50 border-r border-gray-200 h-full overflow-y-auto">
+      <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4 px-1">
+        Content Blocks
+      </h3>
+      <div className="space-y-2">
+        {PALETTE_ITEMS.map((item) => (
+          <PaletteItem key={item.type} {...item} />
+        ))}
+      </div>
+
+      <div className="mt-8 px-1">
+        <p className="text-xs text-gray-400">
+          Drag blocks onto the canvas zones to build your lesson structure.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/coursebuilder/template-editor/PageCanvas.tsx
+++ b/src/components/coursebuilder/template-editor/PageCanvas.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { TemplateDefinition } from '@/types/template';
+import React from 'react';
+
+// ─── Schema → CSS Grid Style converter ──────────────────────
+function templateToGridStyle(grid: TemplateDefinition['grid']): React.CSSProperties {
+  return {
+    display: 'grid',
+    gridTemplateAreas: grid.areas.map(row => `"${row}"`).join(' '),
+    gridTemplateColumns: grid.columns,
+    gridTemplateRows: grid.rows,
+    gap: grid.gap,
+    width: '100%',
+    height: '100%',
+  };
+}
+
+// ─── A4 Page Canvas with zoom ───────────────────────────────
+export function PageCanvas({
+  template,
+  zoom = 1,
+  children,
+}: {
+  template: TemplateDefinition;
+  zoom?: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-auto bg-gray-200 flex justify-center p-10 min-h-screen">
+      <div
+        className="bg-white shadow-xl transition-transform duration-200 ease-out origin-top"
+        style={{
+          width: '210mm',
+          height: '297mm',
+          padding: '15mm',
+          boxSizing: 'border-box',
+          transform: `scale(${zoom})`,
+          // transformOrigin: 'top center', // Tailwind doesn't have origin-top-center
+        }}
+      >
+        <div style={templateToGridStyle(template.grid)} className="h-full">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/coursebuilder/template-editor/PlacedBlock.tsx
+++ b/src/components/coursebuilder/template-editor/PlacedBlock.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { ContentBlock } from '@/types/template';
+import { Trash2, GripVertical } from 'lucide-react';
+import { useDraggable } from '@dnd-kit/core';
+
+interface PlacedBlockProps {
+  block: ContentBlock;
+  onRemove: (blockId: string) => void;
+}
+
+export function PlacedBlock({ block, onRemove }: PlacedBlockProps) {
+  // Blocks within a zone are also draggable (for reordering or moving between zones)
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: block.id,
+    data: {
+      block,
+      type: block.type, // Useful for validation
+      fromZone: block.zoneId,
+    },
+  });
+
+  const style = transform ? {
+    transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+  } : undefined;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`
+        relative group flex items-start gap-2 p-3 rounded-md border bg-white shadow-sm
+        transition-all select-none
+        ${isDragging ? 'opacity-50 z-50 ring-2 ring-blue-400' : 'border-gray-200 hover:border-blue-300'}
+      `}
+      {...attributes}
+      {...listeners}
+    >
+      <div className="mt-1 text-gray-400 cursor-grab active:cursor-grabbing">
+        <GripVertical size={16} />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+            {block.type}
+          </span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(block.id);
+            }}
+            className="text-gray-400 hover:text-red-500 transition-colors p-1 rounded"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+
+        <div className="text-sm text-gray-700 truncate">
+           {renderBlockSummary(block)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderBlockSummary(block: ContentBlock): string {
+  switch (block.type) {
+    case 'video':
+      return block.data.url || 'No video URL set';
+    case 'image':
+      return block.data.alt || block.data.url || 'Image block';
+    case 'richText':
+      return 'Rich Text Content';
+    case 'embed':
+      return block.data.url || 'Embed block';
+    case 'quizQuestion':
+      return block.data.question || 'New Question';
+    case 'assessment':
+      return block.data.title || 'Assessment';
+    case 'codePlayground':
+      return `${block.data.language} playground`;
+    case 'downloadable':
+      return block.data.filename || 'Downloadable file';
+    case 'certificateField':
+      return `Certificate Field: ${block.data.field}`;
+    default:
+      return 'Unknown block';
+  }
+}

--- a/src/components/coursebuilder/template-editor/TemplateZone.tsx
+++ b/src/components/coursebuilder/template-editor/TemplateZone.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useDroppable, useDndContext } from '@dnd-kit/core';
+import { ZoneDefinition, ContentBlock } from '@/types/template';
+import { Plus } from 'lucide-react';
+import { PlacedBlock } from './PlacedBlock';
+
+interface DropZoneProps {
+  zone: ZoneDefinition;
+  blocks: ContentBlock[];
+  onRemoveBlock: (blockId: string) => void;
+}
+
+export function TemplateZone({ zone, blocks, onRemoveBlock }: DropZoneProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: zone.id,
+    data: {
+      zoneId: zone.id,
+      maxBlocks: zone.maxBlocks,
+      currentCount: blocks.length,
+      accepts: zone.acceptedMediaTypes, // Pass this for validation in onDragEnd
+    },
+  });
+
+  const { active } = useDndContext();
+
+  // Check if the currently dragged item is compatible with this zone
+  const activeType = active?.data.current?.mediaType || active?.data.current?.type;
+  const isCompatible = active ? zone.acceptedMediaTypes.includes(activeType) : false;
+
+  // Only show as drop target if dragging and compatible
+  const isDropTarget = isOver && isCompatible;
+
+  const isFull = blocks.length >= zone.maxBlocks;
+  const isEmpty = blocks.length === 0;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ gridArea: zone.name }}
+      className={`
+        relative rounded-lg border-2 transition-all duration-200 p-3 min-h-[120px] flex flex-col gap-2
+        ${isEmpty
+          ? 'border-dashed border-gray-300 bg-gray-50/50'
+          : 'border-solid border-transparent bg-white/50'
+        }
+        ${isDropTarget && !isFull
+          ? 'border-blue-500 bg-blue-50 scale-[1.01] shadow-lg shadow-blue-100 ring-2 ring-blue-200'
+          : ''
+        }
+        ${isOver && !isCompatible && active
+          ? 'border-red-200 bg-red-50/30 opacity-50' // Feedback for invalid drop
+          : ''
+        }
+        ${isDropTarget && isFull
+          ? 'border-yellow-400 bg-yellow-50'
+          : ''
+        }
+      `}
+    >
+      {/* Zone label badge */}
+      <div className="absolute -top-2.5 left-3 z-20">
+        <span className="px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 text-gray-500 rounded uppercase tracking-wider border border-gray-200 shadow-sm">
+          {zone.label}
+        </span>
+        {isFull && (
+           <span className="ml-1 px-1.5 py-0.5 text-[10px] font-medium bg-yellow-100 text-yellow-700 rounded border border-yellow-200">
+             FULL
+           </span>
+        )}
+      </div>
+
+      {/* Empty state */}
+      {isEmpty && !isDropTarget && (
+        <div className="flex flex-col items-center justify-center h-full text-gray-400 select-none pointer-events-none py-8">
+          <Plus className="w-6 h-6 mb-1 opacity-40" />
+          <span className="text-xs text-center px-4">
+            Drop {zone.acceptedMediaTypes.join(', ')} here
+          </span>
+        </div>
+      )}
+
+      {/* Active drop indicator */}
+      {isDropTarget && !isFull && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-blue-500/10 pointer-events-none z-20 animate-pulse">
+          <span className="text-blue-600 text-sm font-bold bg-white/80 px-3 py-1 rounded-full shadow-sm">
+            Release to drop
+          </span>
+        </div>
+      )}
+
+      {/* Rendered blocks */}
+      <div className="relative z-10 space-y-2 flex-1">
+        {blocks.map((block) => (
+          <PlacedBlock key={block.id} block={block} onRemove={onRemoveBlock} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/coursebuilder/template-editor/ZoomControls.tsx
+++ b/src/components/coursebuilder/template-editor/ZoomControls.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { ZoomIn, ZoomOut, Search } from 'lucide-react';
+
+interface ZoomControlsProps {
+  zoom: number;
+  onZoomChange: (zoom: number) => void;
+}
+
+export function ZoomControls({ zoom, onZoomChange }: ZoomControlsProps) {
+  return (
+    <div className="fixed bottom-6 right-6 flex items-center gap-2 bg-white rounded-full shadow-lg border border-gray-200 p-1.5 z-50">
+      <button
+        onClick={() => onZoomChange(Math.max(0.25, zoom - 0.1))}
+        className="p-2 rounded-full hover:bg-gray-100 text-gray-600 transition-colors"
+        title="Zoom Out"
+      >
+        <ZoomOut size={18} />
+      </button>
+
+      <span className="text-xs font-medium w-12 text-center select-none text-gray-700">
+        {Math.round(zoom * 100)}%
+      </span>
+
+      <button
+        onClick={() => onZoomChange(Math.min(2, zoom + 0.1))}
+        className="p-2 rounded-full hover:bg-gray-100 text-gray-600 transition-colors"
+        title="Zoom In"
+      >
+        <ZoomIn size={18} />
+      </button>
+
+        <button
+        onClick={() => onZoomChange(1)}
+        className="p-2 rounded-full hover:bg-gray-100 text-gray-600 transition-colors border-l ml-1 pl-3"
+        title="Reset Zoom"
+      >
+        <Search size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -1,0 +1,115 @@
+import { MediaType, BlockConfigMap, BaseBlock, ZoneDefinition, PageInstance, TemplateDefinition } from '@/types/template';
+
+// Type-safe block creation
+export function createBlock<T extends MediaType>(
+  type: T,
+  data: BlockConfigMap[T],
+  zoneId: string,
+): BaseBlock & { type: T; data: BlockConfigMap[T] } {
+  return {
+    id: crypto.randomUUID(),
+    type,
+    data,
+    zoneId,
+    order: 0, // Order should be managed by the container
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function validateBlockForZone(
+  blockType: MediaType,
+  zone: ZoneDefinition,
+  currentBlockCount: number,
+): { valid: boolean; reason?: string } {
+  if (!zone.acceptedMediaTypes.includes(blockType)) {
+    return {
+      valid: false,
+      reason: `"${blockType}" is not allowed in "${zone.label}". Accepts: ${zone.acceptedMediaTypes.join(', ')}`,
+    };
+  }
+  if (currentBlockCount >= zone.maxBlocks) {
+    return {
+      valid: false,
+      reason: `"${zone.label}" already has ${zone.maxBlocks} block(s) (maximum reached)`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validatePage(
+  page: PageInstance,
+  template: TemplateDefinition,
+): Array<{ zoneId: string; message: string }> {
+  const errors: Array<{ zoneId: string; message: string }> = [];
+
+  for (const zone of template.zones) {
+    const blocks = page.zones[zone.id] ?? [];
+    if (blocks.length < zone.minBlocks) {
+      errors.push({ zoneId: zone.id, message: `Requires at least ${zone.minBlocks} block(s)` });
+    }
+    for (const block of blocks) {
+      if (!zone.acceptedMediaTypes.includes(block.type)) {
+        errors.push({ zoneId: zone.id, message: `Invalid block type "${block.type}" in "${zone.label}"` });
+      }
+    }
+  }
+  return errors;
+}
+
+export function getDefaultData(type: MediaType): BlockConfigMap[MediaType] {
+    switch (type) {
+        case 'video':
+            return {
+                url: '',
+                provider: 'youtube',
+                autoplay: false
+            };
+        case 'image':
+            return {
+                url: '',
+                alt: '',
+                alignment: 'center'
+            };
+        case 'richText':
+            return {
+                content: [],
+                format: 'html'
+            };
+        case 'embed':
+            return {
+                url: '',
+                embedType: 'iframe'
+            };
+        case 'quizQuestion':
+            return {
+                questionType: 'multiple-choice',
+                question: '',
+                points: 1
+            };
+        case 'assessment':
+            return {
+                title: 'New Assessment',
+                description: '',
+                questions: []
+            };
+        case 'codePlayground':
+            return {
+                language: 'javascript',
+                code: '// Write your code here'
+            };
+        case 'downloadable':
+            return {
+                url: '',
+                filename: 'file.pdf',
+                fileSize: 0
+            };
+        case 'certificateField':
+            return {
+                field: 'recipientName',
+                placeholder: 'Recipient Name'
+            };
+        default:
+             throw new Error(`Unknown media type: ${type}`);
+    }
+}

--- a/src/templates/lesson.ts
+++ b/src/templates/lesson.ts
@@ -1,0 +1,43 @@
+import { TemplateDefinition } from '@/types/template';
+
+export const LESSON_TEMPLATE: TemplateDefinition = {
+  id: 'tpl-lesson-standard',
+  name: 'Standard Lesson',
+  slug: 'lesson-standard',
+  version: '1.0.0',
+  category: 'lesson',
+  description: 'Two-column lesson with header, content, sidebar, and footer',
+  grid: {
+    areas: [
+      'header   header   header',
+      'content  content  sidebar',
+      'content  content  sidebar',
+      'footer   footer   footer',
+    ],
+    columns: '1fr 1fr 280px',
+    rows: '80px 1fr 1fr 64px',
+    gap: '12px',
+  },
+  zones: [
+    {
+      id: 'header', name: 'header', label: 'Lesson Header',
+      acceptedMediaTypes: ['image', 'video'],
+      minBlocks: 0, maxBlocks: 1,
+    },
+    {
+      id: 'content', name: 'content', label: 'Main Content',
+      acceptedMediaTypes: ['richText', 'image', 'video', 'embed', 'codePlayground'],
+      minBlocks: 1, maxBlocks: 50,
+    },
+    {
+      id: 'sidebar', name: 'sidebar', label: 'Resources',
+      acceptedMediaTypes: ['downloadable', 'embed', 'image', 'richText'],
+      minBlocks: 0, maxBlocks: 10,
+    },
+    {
+      id: 'footer', name: 'footer', label: 'Page Footer',
+      acceptedMediaTypes: ['richText'],
+      minBlocks: 0, maxBlocks: 1,
+    },
+  ],
+};

--- a/src/templates/quiz.ts
+++ b/src/templates/quiz.ts
@@ -1,0 +1,30 @@
+import { TemplateDefinition } from '@/types/template';
+
+export const QUIZ_TEMPLATE: TemplateDefinition = {
+  id: 'tpl-quiz',
+  name: 'Quiz',
+  slug: 'quiz',
+  version: '1.0.0',
+  category: 'quiz',
+  grid: {
+    areas: [
+      'instructions',
+      'questions',
+    ],
+    columns: '1fr',
+    rows: 'auto 1fr',
+    gap: '16px',
+  },
+  zones: [
+    {
+      id: 'instructions', name: 'instructions', label: 'Quiz Instructions',
+      acceptedMediaTypes: ['richText', 'image'],
+      minBlocks: 1, maxBlocks: 1,
+    },
+    {
+      id: 'questions', name: 'questions', label: 'Questions',
+      acceptedMediaTypes: ['quizQuestion'],
+      minBlocks: 1, maxBlocks: 100,
+    },
+  ],
+};

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,126 @@
+// ─── Media Types ────────────────────────────────────────────
+export type MediaType =
+  | 'video'
+  | 'image'
+  | 'richText'
+  | 'embed'
+  | 'quizQuestion'
+  | 'assessment'
+  | 'codePlayground'
+  | 'downloadable'
+  | 'certificateField';
+
+// ─── Block Config Registry (maps each type to its data shape) ───
+export interface BlockConfigMap {
+  video: {
+    url: string;
+    provider: 'youtube' | 'vimeo' | 'loom' | 'upload';
+    autoplay: boolean;
+    startTime?: number;
+    caption?: string;
+  };
+  image: {
+    url: string;
+    alt: string;
+    caption?: string;
+    alignment: 'left' | 'center' | 'right' | 'full';
+    crop?: { x: number; y: number; width: number; height: number };
+  };
+  richText: {
+    content: unknown[]; // Portable Text / Plate.js JSON
+    format: 'portable-text' | 'plate' | 'html';
+  };
+  embed: {
+    url: string;
+    embedType: 'iframe' | 'oembed' | 'codepen' | 'figma';
+    aspectRatio?: string;
+  };
+  quizQuestion: {
+    questionType: 'multiple-choice' | 'true-false' | 'short-answer';
+    question: string;
+    options?: Array<{ id: string; text: string; isCorrect: boolean }>;
+    explanation?: string;
+    points: number;
+  };
+  assessment: {
+    title: string;
+    description: string;
+    questions: string[]; // references to question blocks or embedded questions
+  };
+  codePlayground: {
+    language: 'javascript' | 'python' | 'html' | 'css';
+    code: string;
+  };
+  downloadable: {
+    url: string;
+    filename: string;
+    fileSize: number;
+  };
+  certificateField: {
+    field: 'recipientName' | 'courseName' | 'completionDate' | 'instructorName';
+    placeholder: string;
+  };
+}
+
+// ─── Content Block (discriminated union) ────────────────────
+export interface BaseBlock {
+  id: string;
+  zoneId: string;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type ContentBlock = {
+  [K in keyof BlockConfigMap]: BaseBlock & { type: K; data: BlockConfigMap[K] };
+}[keyof BlockConfigMap];
+
+// ─── Zone Definition ────────────────────────────────────────
+export interface ZoneDefinition {
+  id: string;
+  name: string;                        // Machine name, doubles as CSS grid-area
+  label: string;                       // Display label: "Main Content Area"
+  description?: string;
+  acceptedMediaTypes: MediaType[];     // Type constraint for this slot
+  minBlocks: number;
+  maxBlocks: number;                   // Use Infinity for unlimited
+  defaultContent?: ContentBlock[];
+}
+
+// ─── Template Definition ────────────────────────────────────
+export interface TemplateDefinition {
+  id: string;
+  name: string;                        // "Standard Lesson", "Quiz", "Certificate"
+  slug: string;
+  version: string;
+  category: 'lesson' | 'quiz' | 'assessment' | 'certificate' | 'custom';
+  description?: string;
+  icon?: string;
+
+  // CSS Grid layout (the "baked-in" structure)
+  grid: {
+    areas: string[];                   // ASCII-art rows for grid-template-areas
+    columns: string;                   // grid-template-columns value
+    rows: string;                      // grid-template-rows value
+    gap: string;
+  };
+
+  zones: ZoneDefinition[];             // Named content slots
+  metadata?: {
+    estimatedDuration?: number;
+    difficulty?: 'beginner' | 'intermediate' | 'advanced';
+  };
+}
+
+// ─── Page Instance (a filled-in template) ───────────────────
+export interface PageInstance {
+  id: string;
+  templateId: string;
+  courseId: string;
+  title: string;
+  status: 'draft' | 'published' | 'archived';
+  zones: Record<string, ContentBlock[]>;   // zoneId → ordered blocks
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Implemented a template-based course editor using `@dnd-kit/core`, CSS Grid named areas, and a discriminated union type system.

**Key Changes:**
*   **Schema & Types:** Defined `TemplateDefinition`, `ZoneDefinition`, `ContentBlock`, and `MediaType` in `src/types/template.ts`.
*   **Logic:** Added block creation and validation helpers in `src/lib/blocks.ts`.
*   **Templates:** Created `LESSON_TEMPLATE` and `QUIZ_TEMPLATE` definitions.
*   **Components:**
    *   `CoursePageEditor`: Main orchestrator using `DndContext`.
    *   `PageCanvas`: Generic renderer for `grid-template-areas`.
    *   `TemplateZone`: Drop zones with `acceptedMediaTypes` validation.
    *   `MediaPalette`: Draggable block source.
    *   `PlacedBlock`: Component for rendered blocks.
*   **Page:** Added route at `/teacher/coursebuilder/template-editor` to demo the editor.

**Verification:**
*   Visually verified drag-and-drop, layout rendering, and type constraints via Playwright screenshot.
*   Linted codebase.


---
*PR created automatically by Jules for task [5548366193074207874](https://jules.google.com/task/5548366193074207874) started by @ParticlesofMind*